### PR TITLE
Added configChanged flag to AndroidManifest

### DIFF
--- a/app/android/AndroidManifest.xml
+++ b/app/android/AndroidManifest.xml
@@ -69,7 +69,8 @@
         </activity>
 
         <!-- Activity Android native camera -->
-        <activity android:name="uk.co.lutraconsulting.CameraActivity" android:label="Input" android:parentActivityName="uk.co.lutraconsulting.InputActivity">
+        <activity android:name="uk.co.lutraconsulting.CameraActivity" android:label="Input" android:parentActivityName="uk.co.lutraconsulting.InputActivity"
+        android:configChanges="screenLayout|orientation|screenSize">
              <meta-data android:name="android.app.lib_name" android:value="-- %%INSERT_APP_LIB_NAME%% --"/>
         </activity>
 
@@ -94,3 +95,4 @@
     <!-- %%INSERT_FEATURES -->
 
 </manifest>
+


### PR DESCRIPTION
The problem seems to be related with loosing a state after rotation ([read more](https://developer.android.com/guide/topics/resources/runtime-changes
)). Therefore configChanges flag added to CameraActivity in AndroidManifest.

Note: There is a kind of blick affect after confirming taken image after rotation. Seems like Android tries to revoke camera once again and immediately destroys the activity.

closes #728  