### PR TITLE
fixes incorrect long lat for geotagged photos in ios

### DIFF
--- a/app/ios/iosinterface.mm
+++ b/app/ios/iosinterface.mm
@@ -130,8 +130,8 @@ static NSMutableDictionary *getGPSData( PositionKit *positionKit, Compass *compa
       @try
       {
         const QgsPoint position = positionKit->position();
-        [gpsDict setValue:[NSNumber numberWithFloat:position.x()] forKey:( NSString * )kCGImagePropertyGPSLatitude];
-        [gpsDict setValue:[NSNumber numberWithFloat:position.y()] forKey:( NSString * )kCGImagePropertyGPSLongitude];
+        [gpsDict setValue:[NSNumber numberWithFloat:position.x()] forKey:( NSString * )kCGImagePropertyGPSLongitude];
+        [gpsDict setValue:[NSNumber numberWithFloat:position.y()] forKey:( NSString * )kCGImagePropertyGPSLatitude];
         [gpsDict setValue:position.x() < 0.0 ? @"S" : @"N" forKey : ( NSString * )kCGImagePropertyGPSLatitudeRef];
         [gpsDict setValue:position.y() < 0.0 ? @"W" : @"E" forKey : ( NSString * )kCGImagePropertyGPSLongitudeRef];
         [gpsDict setValue:[NSNumber numberWithFloat:positionKit->position().z()] forKey:( NSString * )kCGImagePropertyGPSAltitude];


### PR DESCRIPTION
This should fix #1698 

I have tested the PR and the result looks correct - red dot is the way geottaged are stored and green do is with this PR based on https://github.com/lutraconsulting/input/issues/1698#issuecomment-938980851:
![image](https://user-images.githubusercontent.com/2649047/136618677-657ced0e-91c6-4a73-bcea-2713ceedb4b7.png)
