### PR TITLE
Add check for empty points before transformation

### DIFF
--- a/app/positionkit.h
+++ b/app/positionkit.h
@@ -248,6 +248,8 @@ class PositionKit : public QObject
     void updateScreenPosition();
     void updateScreenAccuracy();
 
+    void setProjectedPosition( const QgsPoint &projectedPosition );
+
     QGeoPositionInfoSource *gpsSource();
     QGeoPositionInfoSource *simulatedSource( double longitude, double latitude, double radius );
 


### PR DESCRIPTION
During startup, GPS position might not be available, so positions stored in PositionKit had empty geometries. However, we still tried to apply transformation on these points which led to explosion.

Resolves #1688 
Resolves #1693 
And resolves one out of three in https://github.com/lutraconsulting/input/issues/1719