### PR TITLE
Fix download of files >= 2GB

### DIFF
--- a/core/merginapi.cpp
+++ b/core/merginapi.cpp
@@ -2421,10 +2421,10 @@ void MerginApi::requestServerConfig( const QString &projectFullName )
 QList<DownloadQueueItem> MerginApi::itemsForFileChunks( const MerginFile &file, int version )
 {
   QList<DownloadQueueItem> lst;
-  int from = 0;
+  qint64 from = 0;
   while ( from < file.size )
   {
-    int size = qMin( MerginApi::UPLOAD_CHUNK_SIZE, static_cast<int>( file.size ) - from );
+    qint64 size = qMin( MerginApi::UPLOAD_CHUNK_SIZE, file.size - from );
     lst << DownloadQueueItem( file.path, size, version, from, from + size - 1 );
     from += size;
   }
@@ -3742,7 +3742,7 @@ bool MerginApi::apiSupportsWorkspaces()
   }
 }
 
-DownloadQueueItem::DownloadQueueItem( const QString &fp, int s, int v, int rf, int rt, bool diff )
+DownloadQueueItem::DownloadQueueItem( const QString &fp, qint64 s, int v, qint64 rf, qint64 rt, bool diff )
   : filePath( fp ), size( s ), version( v ), rangeFrom( rf ), rangeTo( rt ), downloadDiff( diff )
 {
   tempFileName = CoreUtils::uuidWithoutBraces( QUuid::createUuid() );

--- a/core/merginapi.h
+++ b/core/merginapi.h
@@ -117,13 +117,13 @@ struct ProjectDiff
  */
 struct DownloadQueueItem
 {
-  DownloadQueueItem( const QString &fp, int s, int v, int rf = -1, int rt = -1, bool diff = false );
+  DownloadQueueItem( const QString &fp, qint64 s, int v, qint64 rf = -1, qint64 rt = -1, bool diff = false );
 
   QString filePath;          //!< path within the project
-  int size;                  //!< size of the item in bytes
+  qint64 size;               //!< size of the item in bytes
   int version = -1;          //!< what version to download  (for ordinary files it will be the target version, for diffs it can be different version)
-  int rangeFrom = -1;        //!< what range of bytes to download (-1 if downloading the whole file)
-  int rangeTo = -1;          //!< what range of bytes to download (-1 if downloading the whole file)
+  qint64 rangeFrom = -1;     //!< what range of bytes to download (-1 if downloading the whole file)
+  qint64 rangeTo = -1;       //!< what range of bytes to download (-1 if downloading the whole file)
   bool downloadDiff = false; //!< whether to download just the diff between the previous version and the current one
   QString tempFileName;      //!< relative filename of the temporary file where the downloaded content will be stored
 };
@@ -160,7 +160,7 @@ struct TransactionStatus
   };
 
   qreal totalSize = 0;     //!< total size (in bytes) of files to be pushed or pulled
-  int transferedSize = 0;  //!< size (in bytes) of amount of data transferred so far
+  qint64 transferedSize = 0;  //!< size (in bytes) of amount of data transferred so far
   QString transactionUUID; //!< only for push. Initially dummy non-empty string, after server confirms a valid UUID, on finish/cancel it is empty
 
   // pull replies

--- a/core/merginprojectmetadata.cpp
+++ b/core/merginprojectmetadata.cpp
@@ -22,7 +22,7 @@ MerginFile MerginFile::fromJsonObject( const QJsonObject &merginFileInfo )
   MerginFile merginFile;
   merginFile.checksum = merginFileInfo.value( QStringLiteral( "checksum" ) ).toString();
   merginFile.path = merginFileInfo.value( QStringLiteral( "path" ) ).toString();
-  merginFile.size = merginFileInfo.value( QStringLiteral( "size" ) ).toInt();
+  merginFile.size = merginFileInfo.value( QStringLiteral( "size" ) ).toInteger();
   merginFile.mtime =  QDateTime::fromString( merginFileInfo.value( QStringLiteral( "mtime" ) ).toString(), Qt::ISODateWithMs ).toUTC();
   merginFile.diffSize = 0;
 
@@ -53,7 +53,7 @@ MerginFile MerginFile::fromJsonObject( const QJsonObject &merginFileInfo )
         if ( obj.contains( "diff" ) )
         {
           QJsonObject diffObj = obj["diff"].toObject();
-          int fileSize = diffObj["size"].toInt();
+          qint64 fileSize = diffObj["size"].toInteger();
           merginFile.pullDiffFiles << qMakePair( key, fileSize );
         }
         else

--- a/core/merginprojectmetadata.h
+++ b/core/merginprojectmetadata.h
@@ -37,7 +37,7 @@ struct MerginFile
   //
 
   bool pullCanUseDiff = false;  //!< whether or not we can update the local file by downloading and applying diffs
-  QList< QPair<int, int> > pullDiffFiles;   //!< list of diffs that will need to be fetched: the version and their sizes
+  QList< QPair<int, qint64> > pullDiffFiles;   //!< list of diffs that will need to be fetched: the version and their sizes
 
   static MerginFile fromJsonObject( const QJsonObject &merginFileInfo );
 };


### PR DESCRIPTION
Fixes #2808

- JSON parsing: use toInteger() instead of toInt() for big numbers (returns qint64 instead of int)
- store sizes and file offsets as qint64 instead of int