### PR TITLE
add support for pg_service.conf file

### DIFF
--- a/app/inputhelp.cpp
+++ b/app/inputhelp.cpp
@@ -218,6 +218,7 @@ QVector<QString> InputHelp::logHeader( bool isHtml )
 {
   QVector<QString> retLines;
   retLines.push_back( QStringLiteral( "Input App: %1 - %2 (%3)" ).arg( CoreUtils::appVersion() ).arg( InputUtils::appPlatform() ).arg( CoreUtils::appVersionCode() ) );
+  retLines.push_back( QStringLiteral( "Data Dir: %1" ).arg( InputUtils::appDataDir() ) );
   retLines.push_back( QStringLiteral( "System: %1" ).arg( QSysInfo::prettyProductName() ) );
   retLines.push_back( QStringLiteral( "Mergin URL: %1" ).arg( mMerginApi->apiRoot() ) );
   retLines.push_back( QStringLiteral( "Mergin User: %1" ).arg( mMerginApi->userAuth()->username() ) );

--- a/app/inpututils.cpp
+++ b/app/inpututils.cpp
@@ -600,6 +600,12 @@ bool InputUtils::isMobilePlatform()
   return platform == QStringLiteral( "android" ) || platform == QStringLiteral( "ios" );
 }
 
+QString InputUtils::appDataDir()
+{
+  QString dataDir = QString::fromLocal8Bit( qgetenv( "QGIS_QUICK_DATA_PATH" ) ) ;
+  return dataDir;
+}
+
 void InputUtils::onQgsLogMessageReceived( const QString &message, const QString &tag, Qgis::MessageLevel level )
 {
   QString levelStr;

--- a/app/inpututils.h
+++ b/app/inpututils.h
@@ -169,6 +169,8 @@ class InputUtils: public QObject
     static QString appPlatform();
     static bool isMobilePlatform();
 
+    static QString appDataDir();
+
     /**
      * Converts string in rational number format to double.
      * @param rationalValue String - expecting value in format "numerator/denominator" (e.g "123/100").

--- a/app/main.cpp
+++ b/app/main.cpp
@@ -250,6 +250,16 @@ static void init_qgis( const QString &pkgPath )
   qDebug( "qgis providers:\n%s", QgsProviderRegistry::instance()->pluginList().toLatin1().data() );
 }
 
+static void init_pg( const QString &dataDir )
+{
+  QFileInfo pgFile( QStringLiteral( "%1/pg_service.conf" ).arg( dataDir ) );
+  if ( pgFile.exists() && pgFile.isReadable() )
+  {
+    setenv( "PGSYSCONFDIR", dataDir.toUtf8(), true );
+    CoreUtils::log( QStringLiteral( "PostgreSQL" ), QStringLiteral( "found pg_service.conf, setting PGSYSCONFDIR" ) );
+  }
+}
+
 void initDeclarative()
 {
   qmlRegisterUncreatableType<MerginUserAuth>( "lc", 1, 0, "MerginUserAuth", "" );
@@ -451,6 +461,9 @@ int main( int argc, char *argv[] )
 #endif
   InputProjUtils inputProjUtils;
   inputProjUtils.initProjLib( appBundleDir, dataDir, projectDir );
+
+  init_pg( dataDir );
+
   init_qgis( appBundleDir );
 
   // AppSettings has to be initialized after QGIS app init (because of correct reading/writing QSettings).

--- a/app/main.cpp
+++ b/app/main.cpp
@@ -255,7 +255,7 @@ static void init_pg( const QString &dataDir )
   QFileInfo pgFile( QStringLiteral( "%1/pg_service.conf" ).arg( dataDir ) );
   if ( pgFile.exists() && pgFile.isReadable() )
   {
-    setenv( "PGSYSCONFDIR", dataDir.toUtf8(), true );
+    qputenv( "PGSYSCONFDIR", dataDir.toUtf8() );
     CoreUtils::log( QStringLiteral( "PostgreSQL" ), QStringLiteral( "found pg_service.conf, setting PGSYSCONFDIR" ) );
   }
 }


### PR DESCRIPTION
fix https://github.com/MerginMaps/mobile/issues/2258
docs: https://github.com/MerginMaps/docs/pull/387
qgis: https://docs.qgis.org/3.4/en/docs/user_manual/managing_data_source/opening_data.html#postgresql-service-connection-file

Tested on desktop: peter.petrik/[Pgtest](https://app.merginmaps.com/projects/peter.petrik/Pgtest)
(note that pg_service.conf is part of the project, but in production it should not be)

```
// Start container
docker run --name some-postgis -p 5432:5432 -e POSTGRES_DB=gisdb -e POSTGRES_USER=myuser -e POSTGRES_PASSWORD=mysecretpassword -d postgis/postgis

// Test in QGIS
export PGSERVICEFILE=/Users/peter/Projects/mergin/data/Pgtest/pg_service.conf
open /Applications/QGIS.app/

// Test in app (desktop)
cp /Users/peter/Projects/mergin/data/Pgtest/pg_service.conf /Users/peter/Projects/quick/input/android/assets/qgis-data/
open Input.app
load peter.peter/Pgtest project
layer country should be there

// on mobile you need to copy via USB the file to input data folder (android-only)

// CLEAN ALL
docker ps 
docker stop <container id>
docker rm <container id>
```

pg_service.conf file
```
[pgtest_service]
host=localhost
port=5432
dbname=gisdb
user=myuser
password=mysecretpassword
```