### PR TITLE
Initialize QgsPoint with the correct WkbType to store Z and M values

### DIFF
--- a/app/inpututils.cpp
+++ b/app/inpututils.cpp
@@ -2113,11 +2113,14 @@ QList<QgsPoint> InputUtils::parsePositionUpdates( const QString &data )
       continue;
     }
 
-    QgsPoint geop;
-    geop.setX( coordinates[0].toDouble() ); // long
-    geop.setY( coordinates[1].toDouble() ); // lat
-    geop.setZ( coordinates[2].toDouble() ); // alt
-    geop.setM( coordinates[3].toDouble() ); // UTC time in secs
+    QgsPoint geop(
+      coordinates[0].toDouble(), // long
+      coordinates[1].toDouble(), // lat
+      coordinates[2].toDouble(), // alt
+      coordinates[3].toDouble(), // UTC time in secs
+      Qgis::WkbType::PointZM // explicitly mention the point type
+    );
+
     parsedUpdates << geop;
   }
 


### PR DESCRIPTION
Fixes #2910 

In the following code:
```cpp
QgsPoint point;
point.setX(1);
point.setY(2);
point.setZ(3);
point.setM(4);
```
`Z` and `M` values will be null. This happens on the version of QGIS that we use atm.
Not sure if this is a QGIS bug or feature though.
Needed to explicitly mention the WkbType.

Checked other places in the code, and they seem to be ok. Should be tested though if we record Z values atm

