### PR TITLE
Set communication mode for BT permission

### DIFF
--- a/app/position/providers/bluetoothpositionprovider.cpp
+++ b/app/position/providers/bluetoothpositionprovider.cpp
@@ -142,6 +142,7 @@ void BluetoothPositionProvider::handleLostConnection()
 
 #ifdef ANDROID
   QBluetoothPermission btPermission;
+  btPermission.setCommunicationModes( QBluetoothPermission::Access );
 
   if ( qApp && ( permissionStatus = qApp->checkPermission( btPermission ) ) != Qt::PermissionStatus::Granted )
   {


### PR DESCRIPTION
Communication mode must be explicitly mentioned when asking whether permission was granted. 
We do not request a permission from Android to make the device discoverable, only to initiate connection to a different device. Unless we do not mention the communication mode, Qt thinks we want to do both and returns false (not granted permission). 

This is a fix for situation when we lose connection to a BT device.

Related to #2943