### PR TITLE
Redesign highlight.qml

### DIFF
--- a/app/qml/InputStyle.qml
+++ b/app/qml/InputStyle.qml
@@ -45,8 +45,6 @@ QtObject {
     property color darkOrange: "#FD9626"
     property color softGreen: "#32AA3A"
     property color darkGreen: "#006146"
-    property color mapObjectsColor: "#EF4444"
-    property color mapObjectsColorTransparent: "#80EF4444"
 
     property int fontPixelSizeSmall: scaleFont(15)
     property int fontPixelSizeNormal: scaleFont(18)
@@ -205,36 +203,10 @@ QtObject {
 
     property real scrollVelocityAndroid: 10000 // [px/s] scrolling on Android devices is too slow by default
 
-    property color guidelineColor: mapObjectsColor
-    property real guidelineWidth: 4 * __dp
-
     property real changelogLineWidth: 2 * __dp
     property color changelogLineWColor: "lightGray"
 
-    property color mapMarkerColor: mapObjectsColor
-    property color mapMarkerBorderColor: "white"
-
     property real mapLoadingIndicatorHeight: 7 * __dp
-
-    property real mapMarkerWidth: 60 * __dp
-    property real mapMarkerBorderWidth: 2 * __dp
-    property real mapMarkerHeight: 70 * __dp
-    property real mapMarkerAnchorY: 48 * __dp
-    property real mapMarkerSize: 18 * __dp
-    property real mapMarkerSizeBig: 21 * __dp
-
-    property color mapLineColor: mapObjectsColor
-    property color mapLineBorderColor: "white"
-
-    property real mapLineWidth: 8 * __dp
-    property real mapLineBorderWidth: 4 * __dp
-
-    property color mapPolygonRingColor: mapObjectsColor
-    property color mapPolygonRingBorderColor: "white"
-    property color mapPolygonFillColor: mapObjectsColorTransparent
-
-    property real mapPolygonRingWidth: 8 * __dp
-    property real mapPolygonRingBorderWidth: 0 * __dp
 
     function scale(size)
     {

--- a/app/qml/map/MapWrapper.qml
+++ b/app/qml/map/MapWrapper.qml
@@ -342,9 +342,9 @@ Item {
               height: mapCanvas.height
               width: mapCanvas.width
 
-              markerColor: InputStyle.highlightColor
-              lineColor: InputStyle.highlightColor
-              lineWidth: InputStyle.mapLineWidth / 2
+              markerColor: __style.sunsetColor
+              lineColor: __style.sunsetColor
+              lineWidth: Highlight.LineWidths.Narrow
 
               mapSettings: mapCanvas.mapSettings
               geometry: trackingHighlight.highlightGeometry

--- a/app/qml/map/RecordingTools.qml
+++ b/app/qml/map/RecordingTools.qml
@@ -108,7 +108,7 @@ Item {
     geometry: __inputUtils.transformGeometryToMapWithLayer( mapTool.handles, __activeLayer.vectorLayer, root.map.mapSettings )
 
     lineStrokeStyle: ShapePath.DashLine
-    lineWidth: InputStyle.guidelineWidth
+    lineWidth: Highlight.LineWidths.Narrow
   }
 
   Highlight {
@@ -117,7 +117,7 @@ Item {
     height: root.map.height
     width: root.map.width
 
-    lineWidth: InputStyle.guidelineWidth
+    lineWidth: Highlight.LineWidths.Narrow
     lineStrokeStyle: ShapePath.DashLine
 
     mapSettings: root.map.mapSettings
@@ -133,9 +133,8 @@ Item {
     mapSettings: root.map.mapSettings
     geometry: __inputUtils.transformGeometryToMapWithLayer( mapTool.midPoints, __activeLayer.vectorLayer, root.map.mapSettings )
 
-    markerType: "circle"
-    markerSize: InputStyle.mapMarkerSize
-    markerBorderColor: InputStyle.mapMarkerColor
+    markerType: Highlight.MarkerTypes.Circle
+    markerBorderColor: __style.grapeColor
   }
 
   Highlight {
@@ -147,13 +146,8 @@ Item {
     mapSettings: root.map.mapSettings
     geometry: __inputUtils.transformGeometryToMapWithLayer( mapTool.existingVertices, __activeLayer.vectorLayer, root.map.mapSettings )
 
-    markerType: "circle"
-    markerSize: InputStyle.mapMarkerSizeBig
-  }
-
-  PositionMarker {
-    mapPosition: mapPositioning
-    compass: root.compass
+    markerType: Highlight.MarkerTypes.Circle
+    markerSize: Highlight.MarkerSizes.Bigger
   }
 
   Crosshair {

--- a/app/qml/map/StakeoutTools.qml
+++ b/app/qml/map/StakeoutTools.qml
@@ -29,7 +29,6 @@ Item {
     lineColor: __style.forestColor
 
     mapSettings: root.map.mapSettings
-    lineWidth: InputStyle.mapLineWidth
   }
 
   MapPosition {


### PR DESCRIPTION
 - Updated `Highlight.qml` component with the new graphics
 - Replaced use of `InputStyle` in the highlight

| Header | Header | Header |
|--------|--------|--------|
|<img width="300" alt="Screenshot 2024-01-22 at 15 20 09" src="https://github.com/MerginMaps/mobile/assets/22449698/31f66c78-3324-4bea-8e48-0c300acb1571"> | <img width="300" alt="Screenshot 2024-01-22 at 15 19 50" src="https://github.com/MerginMaps/mobile/assets/22449698/1a39f952-d09d-412a-b184-4bdf38ead110"> |<img width="300" alt="Screenshot 2024-01-22 at 15 19 48" src="https://github.com/MerginMaps/mobile/assets/22449698/058a2cdc-352c-4a74-9751-8be95c6516cf"> | 

