### PR TITLE
Initialize QSettings in the gallery

### DIFF
--- a/gallery/main.cpp
+++ b/gallery/main.cpp
@@ -27,6 +27,12 @@ int main( int argc, char *argv[] )
 {
   QGuiApplication app( argc, argv );
 
+  // These must be set so that QSettings work properly
+  QCoreApplication::setOrganizationName( "Lutra Consulting" );
+  QCoreApplication::setOrganizationDomain( "lutraconsulting.co.uk" );
+  QCoreApplication::setApplicationName( "Mobile gallery" ); // used by QSettings
+  QCoreApplication::setApplicationVersion( "0.1" );
+
   app.setFont( QFont( Helper::installFonts() ) );
 
   QQmlApplicationEngine engine;


### PR DESCRIPTION
Must be done in order to make `QSettings` working properly in the gallery app (already there for our app)