### PR TITLE
Fix testMerginApi

### DIFF
--- a/app/test/testmerginapi.cpp
+++ b/app/test/testmerginapi.cpp
@@ -1106,8 +1106,8 @@ void TestMerginApi::testDiffUpload()
   QVERIFY( !MerginApi::hasLocalProjectChanges( projectDir ) );
 
   // replace gpkg with a new version with a modified geometry
-  QFile::remove( projectDir + "/base.gpkg" );
-  QFile::copy( mTestDataPath + "/modified_1_geom.gpkg", projectDir + "/base.gpkg" );
+  QVERIFY( QFile::remove( projectDir + "/base.gpkg" ) );
+  QVERIFY( QFile::copy( mTestDataPath + "/modified_1_geom.gpkg", projectDir + "/base.gpkg" ) );
 
   ProjectDiff diff = MerginApi::localProjectChanges( projectDir );
   ProjectDiff expectedDiff;
@@ -1143,8 +1143,8 @@ void TestMerginApi::testDiffSubdirsUpload()
   QVERIFY( !MerginApi::hasLocalProjectChanges( projectDir ) );
 
   // replace gpkg with a new version with a modified geometry
-  QFile::remove( projectDir + "/" + base );
-  QFile::copy( mTestDataPath + "/modified_1_geom.gpkg", projectDir + "/" + base );
+  QVERIFY( QFile::remove( projectDir + "/" + base ) );
+  QVERIFY( QFile::copy( mTestDataPath + "/modified_1_geom.gpkg", projectDir + "/" + base ) );
 
   ProjectDiff diff = MerginApi::localProjectChanges( projectDir );
   ProjectDiff expectedDiff;

--- a/app/test/testmerginapi.cpp
+++ b/app/test/testmerginapi.cpp
@@ -1106,6 +1106,8 @@ void TestMerginApi::testDiffUpload()
   QVERIFY( !MerginApi::hasLocalProjectChanges( projectDir ) );
 
   // replace gpkg with a new version with a modified geometry
+  // but make sure time it gets a different timestamp or its checksum will be read from the cache
+  QTest::qSleep( 1000 );
   QVERIFY( QFile::remove( projectDir + "/base.gpkg" ) );
   QVERIFY( QFile::copy( mTestDataPath + "/modified_1_geom.gpkg", projectDir + "/base.gpkg" ) );
 
@@ -1143,6 +1145,8 @@ void TestMerginApi::testDiffSubdirsUpload()
   QVERIFY( !MerginApi::hasLocalProjectChanges( projectDir ) );
 
   // replace gpkg with a new version with a modified geometry
+  // but make sure time it gets a different timestamp or its checksum will be read from the cache
+  QTest::qSleep( 1000 );
   QVERIFY( QFile::remove( projectDir + "/" + base ) );
   QVERIFY( QFile::copy( mTestDataPath + "/modified_1_geom.gpkg", projectDir + "/" + base ) );
 


### PR DESCRIPTION
Sleep for a second to allow `::lastModified()` datetime of copied file to change, otherwise its checksum is fetched from the cache instead of getting calculated.

Care should be taken whenever we read the checksum cache too shortly after writing to it (probably only applies to tests).