### PR TITLE
Send post-registration data when onboarding is completed

### DIFF
--- a/app/qml/onboarding/MMHowYouFoundUs.qml
+++ b/app/qml/onboarding/MMHowYouFoundUs.qml
@@ -41,6 +41,7 @@ Page {
     id: header
 
     title: listView.contentY > -30 * __dp ? root.headerTitle : ""
+    backVisible: false
 
     onBackClicked: root.backClicked()
 

--- a/app/qml/onboarding/MMOnboardingController.qml
+++ b/app/qml/onboarding/MMOnboardingController.qml
@@ -249,7 +249,19 @@ Item {
 
       onIndustrySelected: function (selectedText) {
         postRegisterData.whichIndustry = selectedText
-        controller.end()
+        __merginApi.postRegisterUser( postRegisterData.howYouFoundUs, postRegisterData.whichIndustry, postRegisterData.wantNewsletter )
+      }
+
+      Connections {
+        target: __merginApi
+
+        function onPostRegistrationSucceeded() {
+          controller.end()
+        }
+
+        function onPostRegistrationFailed() {
+          controller.end()
+        }
       }
     }
   }

--- a/app/qml/onboarding/MMOnboardingController.qml
+++ b/app/qml/onboarding/MMOnboardingController.qml
@@ -224,9 +224,6 @@ Item {
       id: howYouFoundUsPanel
 
       objectName: "howYouFoundUsPanel"
-      onBackClicked: {
-        stackView.popOnePageOrClose()
-      }
 
       onHowYouFoundUsSelected: function (selectedText) {
         postRegisterData.howYouFoundUs = selectedText

--- a/core/merginapi.cpp
+++ b/core/merginapi.cpp
@@ -1338,8 +1338,6 @@ void MerginApi::postRegistrationFinished()
   if ( r->error() == QNetworkReply::NoError )
   {
     CoreUtils::log( "post-register", QStringLiteral( "Success" ) );
-    QString msg = tr( "Workspace created" );
-    emit notify( msg );
     emit postRegistrationSucceeded();
   }
   else
@@ -1349,10 +1347,9 @@ void MerginApi::postRegistrationFinished()
     QVariant statusCode = r->attribute( QNetworkRequest::HttpStatusCodeAttribute );
     int status = statusCode.toInt();
     emit postRegistrationFailed( QStringLiteral( "Post-registation failed %1" ).arg( serverMsg ) );
-
-    QString msg = tr( "Unable to send post registration information" );
-    emit notify( msg );
   }
+  QString msg = tr( "Workspace created" );
+  emit notify( msg );
   r->deleteLater();
 }
 


### PR DESCRIPTION
Send post-registration data when onboarding is completed (endpoint `/v1/post-register` is not yet available in test.dev server)

Success/failure is only logged and not shown to the user. He only cares that his workspace was created, so always show this.

The back button was also removed from `MMHowYouFoundUs` so that users can't skip _how you found us_ and _which industry_ questions.