### PR TITLE
Multi-feature selection initial implementation

### DIFF
--- a/app/featuresmodel.cpp
+++ b/app/featuresmodel.cpp
@@ -28,6 +28,15 @@ FeaturesModel::FeaturesModel( QObject *parent )
 
 FeaturesModel::~FeaturesModel() = default;
 
+void FeaturesModel::populateStaticModel( FeatureLayerPairs pairs )
+{
+  beginResetModel();
+  mFeatures.clear();
+  mFeatures.append( pairs );
+  endResetModel();
+  emit countChanged( rowCount() );
+}
+
 void FeaturesModel::populate()
 {
   if ( mLayer )

--- a/app/featuresmodel.h
+++ b/app/featuresmodel.h
@@ -73,6 +73,14 @@ class FeaturesModel : public QAbstractListModel
     QHash<int, QByteArray> roleNames() const override;
 
     /**
+     * \brief populateStatic populates a static model using the supplied \a pairs
+     * \param pairs to populate the model with
+     * This method allows to use a model that is not tied to a specific layer and
+     * has a fixed set of FeatureLayerPairs
+     */
+    Q_INVOKABLE void populateStaticModel( FeatureLayerPairs pairs );
+
+    /**
      * \brief reloadFeatures reloads features from current layer
      */
     Q_INVOKABLE void reloadFeatures();

--- a/app/qml/main.qml
+++ b/app/qml/main.qml
@@ -169,6 +169,11 @@ ApplicationWindow {
         formsStackManager.openForm( pair, "readOnly", "preview" );
       }
 
+      onFeaturesIdentified: function( pairs ) {
+        formsStackManager.closeDrawer()
+        featurePairSelection.showPairs( pairs );
+      }
+
       onNothingIdentified: {
         formsStackManager.closeDrawer()
       }
@@ -814,6 +819,31 @@ ApplicationWindow {
         left: parent.left
         right: parent.right
         topMargin: 20 * __dp
+      }
+    }
+
+    MMDropdownDrawer {
+      id: featurePairSelection
+
+      title: qsTr( "Select feature" )
+      withSearchbar: false
+      model: InputClass.FeaturesModel {}
+      valueRole: "FeaturePair"
+      textRole: "FeatureTitle"
+
+      onSelectionFinished: function( pairs ) {
+        var pair = pairs[0]
+        featurePairSelection.close()
+        map.highlightPair( pair )
+        formsStackManager.openForm( pair, "readOnly", "preview" );
+      }
+
+      function showPairs( pairs ) {
+        if ( pairs.length > 0 )
+        {
+          model.populateStaticModel( pairs )
+          open()
+        }
       }
     }
 

--- a/app/qml/map/MMMapCanvas.qml
+++ b/app/qml/map/MMMapCanvas.qml
@@ -194,13 +194,19 @@ Item {
 
           clickDifferentiatorTimer.restart()
         }
-        else if ( !isDragging )
+        else if ( !isDragging && !clickDifferentiatorTimer.ignoreNextTrigger )
         {
           // this is a simple click
 
           clickDifferentiatorTimer.clickedPoint = clickPosition
           clickDifferentiatorTimer.ignoreNextTrigger = false // just in case
           clickDifferentiatorTimer.start()
+        }
+        else
+        {
+          // this was a pressAndHold or a drag release
+
+          clickDifferentiatorTimer.ignoreNextTrigger = false
         }
 
         previousPosition = null
@@ -213,7 +219,10 @@ Item {
       }
 
       onPressAndHold: function ( mouse ) {
-        mapRoot.longPressed( Qt.point( mouse.x, mouse.y ) )
+        if ( !isDragging ) {
+          mapRoot.longPressed( Qt.point( mouse.x, mouse.y ) )
+        }
+
         clickDifferentiatorTimer.ignoreNextTrigger = true
       }
 

--- a/app/qml/map/MapWrapper.qml
+++ b/app/qml/map/MapWrapper.qml
@@ -38,6 +38,7 @@ Item {
   property PositionTrackingManager trackingManager: tracking.item?.manager ?? null
 
   signal featureIdentified( var pair )
+  signal featuresIdentified( var pairs )
   signal nothingIdentified()
 
   signal recordingStarted()
@@ -227,6 +228,22 @@ Item {
           if ( __positionKit.positionProvider && __positionKit.positionProvider.id() === "simulated" )
           {
             __positionKit.positionProvider.setPosition( __inputUtils.mapPointToGps( Qt.point( point.x, point.y ), mapCanvas.mapSettings ) )
+          }
+
+          if ( root.state === "view" )
+          {
+            let screenPoint = Qt.point( point.x, point.y )
+            let pairs = identifyKit.identify( screenPoint )
+
+            if ( !pairs.isEmpty )
+            {
+              root.featuresIdentified( pairs )
+            }
+            else
+            {
+              root.hideHighlight()
+              root.nothingIdentified()
+            }
           }
         }
       }


### PR DESCRIPTION
Initial implementation of selection of overlapping features.

Use _tap and hold_ to bring up a list of features if at least one is under the tap point.
![image](https://github.com/MerginMaps/mobile/assets/11358178/05de0abf-6a06-40f8-bd6a-91bcfc38f857)

Pick from the list to open the feature preview drawer.
![image](https://github.com/MerginMaps/mobile/assets/11358178/45287fe4-1789-4a2e-9b81-dc152b2d92d4)

The current item delegate is too simple for this use case, we should use an item delegate that displays more info about the features (layer, fid?, icon)