### PR TITLE
Drawers page column in scroll view

### DIFF
--- a/gallery/qml/pages/DrawerPage.qml
+++ b/gallery/qml/pages/DrawerPage.qml
@@ -22,85 +22,81 @@ import lc 1.0
 Page {
   id: pane
 
-  Column {
-    width: parent.width
-    spacing: 10
-    padding: 10
+  ScrollView {
+    anchors.fill: parent
 
-    Label {
-      text: "Drawers"
-    }
+    Column {
+      width: parent.width
+      spacing: 10
+      padding: 10
 
-    MMButton {
-      text: "Position Tracking"
-      onClicked: drawerPositionTracking.open()
-    }
-
-    MMButton {
-      text: "Upload"
-      onClicked: drawer1.open()
-    }
-
-    MMButton {
-      text: "MMStorageLimitDialog"
-      onClicked: storageLimitDialog.open()
-    }
-
-    MMButton {
-      text: "MMCloseAccountDialog"
-      onClicked: closeAccountDialog.open()
-    }
-
-    MMButton {
-      text: "MMRemoveProjectDialog"
-      onClicked: removeProjectDialog.open()
-    }
-
-    MMButton {
-      text: "MMDownloadProjectDialog"
-      onClicked: downloadProjectDialog.open()
-    }
-
-    MMButton {
-      text: "Synchronization Failed"
-      onClicked: drawer3.open()
-    }
-
-    MMButton {
-      text: "MMStreamingModeDialog"
-      onClicked: streamingModeDialog.open()
-    }
-
-    MMButton {
-      text: "MMBluetoothConnectionDrawer"
-      onClicked: {
-        bluetoothConnectionDrawer.positionProvider.state = PositionProvider.Connecting
-        bluetoothConnectionTimer.start()
-        bluetoothConnectionDrawer.open()
+      Label {
+        text: "Drawers"
       }
-    }
 
-    MMButton {
-      text: "MMSyncFailedDialog"
-
-      onClicked: {
-        syncFailedDialog.open()
+      MMButton {
+        text: "Position Tracking"
+        onClicked: drawerPositionTracking.open()
       }
-    }
 
-    MMButton {
-      text: "MMNoPermissionsDialog"
-
-      onClicked: {
-        noPermissionsDialog.open()
+      MMButton {
+        text: "Upload"
+        onClicked: drawer1.open()
       }
-    }
 
-    MMButton {
-      text: "MMNoPermissionsDialog"
+      MMButton {
+        text: "MMStorageLimitDialog"
+        onClicked: storageLimitDialog.open()
+      }
 
-      onClicked: {
-        drawer5.open()
+      MMButton {
+        text: "MMCloseAccountDialog"
+        onClicked: closeAccountDialog.open()
+      }
+
+      MMButton {
+        text: "MMRemoveProjectDialog"
+        onClicked: removeProjectDialog.open()
+      }
+
+      MMButton {
+        text: "MMDownloadProjectDialog"
+        onClicked: downloadProjectDialog.open()
+      }
+
+      MMButton {
+        text: "Synchronization Failed"
+        onClicked: drawer3.open()
+      }
+
+      MMButton {
+        text: "MMStreamingModeDialog"
+        onClicked: streamingModeDialog.open()
+      }
+
+      MMButton {
+        text: "MMBluetoothConnectionDrawer"
+        onClicked: {
+          bluetoothConnectionDrawer.positionProvider.state = PositionProvider.Connecting
+          bluetoothConnectionTimer.start()
+          bluetoothConnectionDrawer.open()
+        }
+      }
+
+      MMButton {
+        text: "MMSyncFailedDialog"
+
+        onClicked: {
+          syncFailedDialog.open()
+        }
+      }
+
+      MMButton {
+        text: "MMNoPermissionsDialog"
+
+        onClicked: {
+          noPermissionsDialog.open()
+        }
       }
     }
   }
@@ -220,9 +216,5 @@ Page {
 
   MMNoPermissionsDialog {
     id: noPermissionsDialog
-  }
-
-  MMNoPermissionsDialog {
-    id: drawer5
   }
 }

--- a/gallery/qml/pages/DrawerPage.qml
+++ b/gallery/qml/pages/DrawerPage.qml
@@ -95,6 +95,14 @@ Page {
         noPermissionsDialog.open()
       }
     }
+
+    MMButton {
+      text: "MMNoPermissionsDialog"
+
+      onClicked: {
+        drawer5.open()
+      }
+    }
   }
 
   MMBluetoothConnectionDrawer {
@@ -212,5 +220,9 @@ Page {
 
   MMNoPermissionsDialog {
     id: noPermissionsDialog
+  }
+
+  MMNoPermissionsDialog {
+    id: drawer5
   }
 }

--- a/gallery/qml/pages/ImagesPage.qml
+++ b/gallery/qml/pages/ImagesPage.qml
@@ -48,6 +48,8 @@ ScrollView {
         Column { Image { source: __style.streamingBootsImage } Text { text: "streamingBootsImage" } }
         Column { Image { source: __style.streamingBootsOrangeImage } Text { text: "streamingBootsOrangeImage" } }
         Column { Image { source: __style.noWifiImage } Text { text: "noWifiImage" } }
+        Column { Image { source: __style.syncFailedImage  } Text { text: "syncFailedImage " } }
+        Column { Image { source: __style.noPermissionsImage } Text { text: "noPermissionsImage" } }
       }
     }
 


### PR DESCRIPTION
- To fit more buttons in the gallery, it was necessary to place the main column of Drawers Page inside a Scroll View.
- Sync Failed and No Permissions dialogs images added to gallery.

![drawer](https://github.com/MerginMaps/mobile/assets/155513369/405e42f1-3cd5-4a1f-9954-baed74b27ce2)
