### PR TITLE
Fix header back button top margin

### DIFF
--- a/app/mmstyle.h
+++ b/app/mmstyle.h
@@ -262,6 +262,7 @@ class MMStyle: public QObject
     Q_PROPERTY( double row36 READ row36 CONSTANT )
     Q_PROPERTY( double row40 READ row40 CONSTANT )
     Q_PROPERTY( double row49 READ row49 CONSTANT )
+    Q_PROPERTY( double row60 READ row60 CONSTANT )
     Q_PROPERTY( double row63 READ row63 CONSTANT )
     Q_PROPERTY( double row67 READ row67 CONSTANT )
     Q_PROPERTY( double row80 READ row80 CONSTANT )
@@ -485,6 +486,7 @@ class MMStyle: public QObject
     double row36() {return 36 * mDp;}
     double row40() {return 40 * mDp;}
     double row49() {return 49 * mDp;}
+    double row60() {return 60 * mDp;}
     double row63() {return 63 * mDp;}
     double row67() {return 67 * mDp;}
     double row80() {return 80 * mDp;}

--- a/app/qml/components/MMPageHeader.qml
+++ b/app/qml/components/MMPageHeader.qml
@@ -24,12 +24,9 @@ Rectangle {
   property bool backVisible: true
   property alias backButton: backBtn
 
-  color: __style.transparentColor
+  property alias rightItemContent: rightButtonGroup.children
 
-  //! When adding items on the right side of MMPageHeader (account icon, save button, slider, ...),
-  //! make sure to set the width of the item via this property to keep the title centred to
-  //! the page and elide properly
-  property real rightMarginShift: 0
+  color: __style.transparentColor
 
   signal backClicked
 
@@ -40,11 +37,11 @@ Rectangle {
     // If there is a right or a left icon, we need to shift the margin
     // of the opposite side to keep the text centred to the center of the screen
     property real leftMarginShift: {
-      return Math.max( internal.backBtnRealWidth, root.rightMarginShift ) + internal.headerSpacing + __style.pageMargins
+      return Math.max( internal.backBtnRealWidth, rightButtonGroup.width ) + internal.headerSpacing + __style.pageMargins
     }
 
     property real rightMarginShift: {
-      return Math.max( internal.backBtnRealWidth, root.rightMarginShift ) + internal.headerSpacing + __style.pageMargins
+      return Math.max( internal.backBtnRealWidth, rightButtonGroup.width ) + internal.headerSpacing + __style.pageMargins
     }
 
     anchors {
@@ -67,11 +64,21 @@ Rectangle {
   MMRoundButton {
     id: backBtn
 
-    x: __style.pageMargins
+    x: __style.pageMargins + __style.safeAreaLeft
     y: ( internal.baseHeaderHeight / 2 - height / 2 ) + __style.safeAreaTop
 
     visible: root.backVisible
     onClicked: root.backClicked()
+  }
+
+  Item {
+    id: rightButtonGroup
+
+    x: parent.width - __style.pageMargins - __style.safeAreaRight - width
+    y: ( internal.baseHeaderHeight / 2 - height / 2 ) + __style.safeAreaTop
+
+    width: childrenRect.width
+    height: parent.height
   }
 
   QtObject {

--- a/app/qml/components/MMPageHeader.qml
+++ b/app/qml/components/MMPageHeader.qml
@@ -33,7 +33,7 @@ Rectangle {
 
   signal backClicked
 
-  implicitHeight: 60 * __dp + __style.safeAreaTop
+  implicitHeight: internal.baseHeaderHeight + __style.safeAreaTop
   implicitWidth: ApplicationWindow.window?.width ?? 0
 
   Text {
@@ -67,12 +67,8 @@ Rectangle {
   MMRoundButton {
     id: backBtn
 
-    anchors {
-      left: parent.left
-      topMargin: __style.safeAreaTop
-      leftMargin: __style.pageMargins
-      verticalCenter: parent.verticalCenter
-    }
+    x: __style.pageMargins
+    y: ( internal.baseHeaderHeight / 2 - height / 2 ) + __style.safeAreaTop
 
     visible: root.backVisible
     onClicked: root.backClicked()
@@ -82,6 +78,7 @@ Rectangle {
     id: internal
 
     property real headerSpacing: 10 * __dp
+    property real baseHeaderHeight: __style.row60
     property real backBtnRealWidth: backBtn.visible ? backBtn.width : 0
   }
 }


### PR DESCRIPTION
Fixed the back button on page header that was not aligned properly with safeArea

<img src="https://github.com/MerginMaps/mobile/assets/22449698/f695a111-3c85-41a4-8f19-26747334cc10" width=400>

**PR also fixes the same thing for the right item in the page header.** The usage of the `MMPageHeader` changes a little bit, instead of setting `rightMarginShift`, define your items via `rightItemContent` property, like this:

```qml
MMPageHeader {
  ...
  rightItemContent: MMProgressBar {

      width: 60 * __dp
      height: 4 * __dp

      anchors.verticalCenter: parent.verticalCenter

      color: __style.grassColor
      progressColor: __style.forestColor
      position: 2/3
    }
}
```

Header will take the `width` of the rightItemContent automatically, so you do not need to set it up manually anymore (via `rightMarginShift`)