### PR TITLE
Fix hot reload paths

### DIFF
--- a/gallery/CMakeLists.txt
+++ b/gallery/CMakeLists.txt
@@ -88,6 +88,9 @@ set_target_properties(
 
 target_link_libraries(MerginMapsGallery PRIVATE Qt6::Quick Qt6::Multimedia)
 target_include_directories(MerginMapsGallery PRIVATE ../app ../core)
+target_compile_definitions(
+  MerginMapsGallery PRIVATE GALLERY_SOURCE_DIR="${CMAKE_SOURCE_DIR}"
+)
 
 install(
   TARGETS MerginMapsGallery

--- a/gallery/hotreload.cpp
+++ b/gallery/hotreload.cpp
@@ -20,8 +20,8 @@ QString HotReload::syncScript() const
   return "#!/bin/sh \n\
 echo running hot reload sync directories ... \n\
 while true; do \n\
-  rsync -ra ../../../../gallery/qml/ HotReload/qml/ \n\
-  rsync -ra ../../../../app/qml/ HotReload/app/qml/ \n\
+  rsync -ra " GALLERY_SOURCE_DIR "/qml/ HotReload/qml/ \n\
+  rsync -ra " GALLERY_SOURCE_DIR "/../app/qml/ HotReload/app/qml/ \n\
   sleep 1 \n\
 done";
 }
@@ -38,7 +38,6 @@ HotReload::HotReload( QQmlApplicationEngine &engine, QObject *parent ):
   // create runnable sync script (near the app)
   QString scriptFilename = QGuiApplication::applicationDirPath() + "/syncGallery.sh";
   qInfo() << "Sync script location: " << scriptFilename;
-  if ( !QFileInfo::exists( scriptFilename ) )
   {
     QFile file( QFileInfo( scriptFilename ).absoluteFilePath() );
     const QString script = syncScript();


### PR DESCRIPTION
Should work everywhere now.
Also make sure to always overwrite the sync script on start (because why not) to make sure we're using up-to-date paths.