### PR TITLE
Core utils nameAbbr method changes

### DIFF
--- a/app/test/testcoreutils.cpp
+++ b/app/test/testcoreutils.cpp
@@ -253,11 +253,13 @@ void TestCoreUtils::testNameAbbr()
 {
   QVector< QPair< QString, QString > > testcases =
     {
-      { QStringLiteral( "" ), QStringLiteral( "CH" ) },
+      { QStringLiteral( "" ), QStringLiteral( "" ) },
       { QStringLiteral( "Chuck Brave|chuck@example.com" ), QStringLiteral( "CB" ) },
       { QStringLiteral( "Chuck Norris|chuck@example.com" ), QStringLiteral( "CN" ) },
-      { QStringLiteral( "chuck@example.com" ), QStringLiteral( "CH" ) },
-      { QStringLiteral( "Chuck|" ), QStringLiteral( "C" ) },
+      { QStringLiteral( "Chuck Norris Carlos|chuck@example.com" ), QStringLiteral( "CC" ) },
+      { QStringLiteral( "Chuck|chuck@example.com" ), QStringLiteral( "CH" ) },
+      { QStringLiteral( "|chuck@example.com" ), QStringLiteral( "CH" ) },
+      { QStringLiteral( "Chuck|" ), QStringLiteral( "CH" ) },
       { QStringLiteral( "C|" ), QStringLiteral( "C" ) },
     };
 

--- a/app/test/testcoreutils.cpp
+++ b/app/test/testcoreutils.cpp
@@ -252,23 +252,23 @@ void TestCoreUtils::testNameValidation()
 void TestCoreUtils::testNameAbbr()
 {
   QVector< QPair< QString, QString > > testcases =
-    {
-      { QStringLiteral( "" ), QStringLiteral( "" ) },
-      { QStringLiteral( "Chuck Brave|chuck@example.com" ), QStringLiteral( "CB" ) },
-      { QStringLiteral( "Chuck Norris|chuck@example.com" ), QStringLiteral( "CN" ) },
-      { QStringLiteral( "Chuck Norris Carlos|chuck@example.com" ), QStringLiteral( "CC" ) },
-      { QStringLiteral( "Chuck|chuck@example.com" ), QStringLiteral( "CH" ) },
-      { QStringLiteral( "|chuck@example.com" ), QStringLiteral( "CH" ) },
-      { QStringLiteral( "Chuck|" ), QStringLiteral( "CH" ) },
-      { QStringLiteral( "C|" ), QStringLiteral( "C" ) },
-    };
+  {
+    { QStringLiteral( "" ), QStringLiteral( "" ) },
+    { QStringLiteral( "Chuck Brave|chuck@example.com" ), QStringLiteral( "CB" ) },
+    { QStringLiteral( "Chuck Norris|chuck@example.com" ), QStringLiteral( "CN" ) },
+    { QStringLiteral( "Chuck Norris Carlos|chuck@example.com" ), QStringLiteral( "CC" ) },
+    { QStringLiteral( "Chuck|chuck@example.com" ), QStringLiteral( "CH" ) },
+    { QStringLiteral( "|chuck@example.com" ), QStringLiteral( "CH" ) },
+    { QStringLiteral( "Chuck|" ), QStringLiteral( "CH" ) },
+    { QStringLiteral( "C|" ), QStringLiteral( "C" ) },
+  };
 
   for ( const auto &test : testcases )
   {
-    QStringList nameAndEmail = test.first.split('|');
-    QString name = nameAndEmail.size() > 0 ? nameAndEmail.at(0) : "";
-    QString email = nameAndEmail.size() > 1 ? nameAndEmail.at(1) : "";
+    QStringList nameAndEmail = test.first.split( '|' );
+    QString name = nameAndEmail.size() > 0 ? nameAndEmail.at( 0 ) : "";
+    QString email = nameAndEmail.size() > 1 ? nameAndEmail.at( 1 ) : "";
 
-    QCOMPARE(CoreUtils::nameAbbr(name, email), test.second);
+    QCOMPARE( CoreUtils::nameAbbr( name, email ), test.second );
   }
 }

--- a/app/test/testcoreutils.cpp
+++ b/app/test/testcoreutils.cpp
@@ -252,14 +252,14 @@ void TestCoreUtils::testNameValidation()
 void TestCoreUtils::testNameAbbr()
 {
   QVector< QPair< QString, QString > > testcases =
-  {
-    { QStringLiteral( "" ), QStringLiteral( "" ) },
-    { QStringLiteral( "Chuck Brave Norris" ), QStringLiteral( "CN" ) },
-    { QStringLiteral( "Chuck Norris" ), QStringLiteral( "CN" ) },
-    { QStringLiteral( "chuck@example.com" ), QStringLiteral( "CH" ) },
-    { QStringLiteral( "Chuck" ), QStringLiteral( "C" ) },
-    { QStringLiteral( "C" ), QStringLiteral( "C" ) },
-  };
+    {
+      { QStringLiteral( "" ), QStringLiteral( "CH" ) },
+      { QStringLiteral( "Chuck Brave|chuck@example.com" ), QStringLiteral( "CB" ) },
+      { QStringLiteral( "Chuck Norris|chuck@example.com" ), QStringLiteral( "CN" ) },
+      { QStringLiteral( "chuck@example.com" ), QStringLiteral( "CH" ) },
+      { QStringLiteral( "Chuck|" ), QStringLiteral( "C" ) },
+      { QStringLiteral( "C|" ), QStringLiteral( "C" ) },
+    };
 
   for ( const auto &test : testcases )
   {

--- a/app/test/testcoreutils.cpp
+++ b/app/test/testcoreutils.cpp
@@ -256,12 +256,17 @@ void TestCoreUtils::testNameAbbr()
     { QStringLiteral( "" ), QStringLiteral( "" ) },
     { QStringLiteral( "Chuck Brave Norris" ), QStringLiteral( "CN" ) },
     { QStringLiteral( "Chuck Norris" ), QStringLiteral( "CN" ) },
+    { QStringLiteral( "chuck@example.com" ), QStringLiteral( "CH" ) },
     { QStringLiteral( "Chuck" ), QStringLiteral( "C" ) },
     { QStringLiteral( "C" ), QStringLiteral( "C" ) },
   };
 
   for ( const auto &test : testcases )
   {
-    QCOMPARE( CoreUtils::nameAbbr( test.first ), test.second );
+    QStringList nameAndEmail = test.first.split('|');
+    QString name = nameAndEmail.size() > 0 ? nameAndEmail.at(0) : "";
+    QString email = nameAndEmail.size() > 1 ? nameAndEmail.at(1) : "";
+
+    QCOMPARE(CoreUtils::nameAbbr(name, email), test.second);
   }
 }

--- a/core/coreutils.cpp
+++ b/core/coreutils.cpp
@@ -253,7 +253,7 @@ QString CoreUtils::nameAbbr( const QString &name, const QString &email )
     return QString( "%1%2" ).arg( list.first()[0], list.last()[0] ).toUpper();
 
   if ( email.isEmpty() )
-    return name.left(2).toUpper();
+    return name.left( 2 ).toUpper();
 
-  return email.left(2).toUpper();
+  return email.left( 2 ).toUpper();
 }

--- a/core/coreutils.cpp
+++ b/core/coreutils.cpp
@@ -243,17 +243,17 @@ bool CoreUtils::isValidName( const QString &name )
 
 QString CoreUtils::nameAbbr(const QString &name, const QString &email)
 {
-    if ( name.isEmpty() )
-        return email.left( 2 ).toUpper();
+  if ( name.isEmpty() )
+    return email.left( 2 ).toUpper();
 
-    static QRegularExpression re( R"([\r\n\t ]+)" );
-    QStringList list = name.split( re, Qt::SplitBehaviorFlags::SkipEmptyParts );
+  static QRegularExpression re( R"([\r\n\t ]+)" );
+  QStringList list = name.split( re, Qt::SplitBehaviorFlags::SkipEmptyParts );
 
-    if ( list.size() > 1 )
-      return QString( "%1%2" ).arg( list.first()[0], list.last()[0] ).toUpper();
+  if ( list.size() > 1 )
+    return QString( "%1%2" ).arg( list.first()[0], list.last()[0] ).toUpper();
 
-    if ( email.isEmpty() )
-        return name.left(2).toUpper();
+  if ( email.isEmpty() )
+    return name.left(2).toUpper();
 
-    return email.left(2).toUpper();
+  return email.left(2).toUpper();
 }

--- a/core/coreutils.cpp
+++ b/core/coreutils.cpp
@@ -241,7 +241,7 @@ bool CoreUtils::isValidName( const QString &name )
   return !matchForbiddenNames.hasMatch();
 }
 
-QString CoreUtils::nameAbbr(const QString &name, const QString &email)
+QString CoreUtils::nameAbbr( const QString &name, const QString &email )
 {
   if ( name.isEmpty() )
     return email.left( 2 ).toUpper();

--- a/core/coreutils.cpp
+++ b/core/coreutils.cpp
@@ -241,24 +241,16 @@ bool CoreUtils::isValidName( const QString &name )
   return !matchForbiddenNames.hasMatch();
 }
 
-QString CoreUtils::nameAbbr( const QString &name )
+QString CoreUtils::nameAbbr(const QString &name, const QString &email)
 {
-  QString ret;
+    if ( name.isEmpty() )
+        return email.left( 2 ).toUpper();
 
-  if ( name.isEmpty() )
-    return ret;
+    static QRegularExpression re( R"([\r\n\t ]+)" );
+    QStringList list = name.split( re, Qt::SplitBehaviorFlags::SkipEmptyParts );
 
-  static QRegularExpression re( R"([\r\n\t ]+)" );
-  QStringList list = name.split( re, Qt::SplitBehaviorFlags::SkipEmptyParts );
-  if ( !list.empty() )
-  {
-    ret += list.at( 0 )[0];
-  }
+    if ( list.size() > 1 )
+      return QString( "%1%2" ).arg( list.first()[0], list.last()[0] ).toUpper();
 
-  if ( list.size() > 1 )
-  {
-    ret += list.at( list.size() - 1 )[0];
-  }
-
-  return ret;
+    return email.left( 2 ).toUpper();
 }

--- a/core/coreutils.cpp
+++ b/core/coreutils.cpp
@@ -252,5 +252,8 @@ QString CoreUtils::nameAbbr(const QString &name, const QString &email)
     if ( list.size() > 1 )
       return QString( "%1%2" ).arg( list.first()[0], list.last()[0] ).toUpper();
 
-    return email.left( 2 ).toUpper();
+    if ( email.isEmpty() )
+        return name.left(2).toUpper();
+
+    return email.left(2).toUpper();
 }

--- a/core/coreutils.h
+++ b/core/coreutils.h
@@ -100,7 +100,7 @@ class CoreUtils
      *   Pat -> P
      *   from <empty> -> <empty>
      */
-    static QString nameAbbr( const QString &name , const QString &email);
+    static QString nameAbbr( const QString &name, const QString &email );
 
   private:
     static QString sLogFile;

--- a/core/coreutils.h
+++ b/core/coreutils.h
@@ -100,7 +100,7 @@ class CoreUtils
      *   Pat -> P
      *   from <empty> -> <empty>
      */
-    static QString nameAbbr( const QString &name );
+    static QString nameAbbr( const QString &name , const QString &email);
 
   private:
     static QString sLogFile;

--- a/core/merginuserinfo.cpp
+++ b/core/merginuserinfo.cpp
@@ -38,7 +38,7 @@ void MerginUserInfo::setFromJson( QJsonObject docObj )
   // parse profile data
   mEmail = docObj.value( QStringLiteral( "email" ) ).toString();
   mName = docObj.value( QStringLiteral( "name" ) ).toString();
-  mNameAbbr = CoreUtils::nameAbbr( mName );
+  mNameAbbr = CoreUtils::nameAbbr( mName, mEmail );
 
   int preferredWorkspace = -1;
   if ( docObj.contains( QStringLiteral( "preferred_workspace" ) ) )


### PR DESCRIPTION
Changes to the nameAbbr method in ```coreutils.cpp```:

"Barry Allen Joe", "[bjallen@gmail.com]"

<img src="https://github.com/MerginMaps/mobile/assets/155513369/7964b076-0354-4ee1-9257-740a98e74259" width="300">

"Barry Allen", "[bjallen@gmail.com]

<img src="https://github.com/MerginMaps/mobile/assets/155513369/d2ac13c8-7d3b-40b4-877a-44b56336e840" width="300">

"Barry", "[bjallen@gmail.com]
<img src="https://github.com/MerginMaps/mobile/assets/155513369/da15f2fc-32d3-4424-bbe3-a0ad97edb286" width="300">

Other cases:
"", [] -> ""
"Barry", [] -> BA
"B", [] -> B
"", [bjallen@gmail.com] -> BJ




