### PR TITLE
Position tracking button visibility adjustment

### DIFF
--- a/app/qml/components/MMToolbar.qml
+++ b/app/qml/components/MMToolbar.qml
@@ -65,16 +65,18 @@ MMBaseToolbar {
 
   function setupBottomBar() {
     var m = root.model
-    var c = m.count
     var w = buttonView.width
     var button
 
-    for (var j = 0; j < c; j++)
+    for ( var j = m.count - 1 ; j >= 0 ; j-- )
     {
-      if (m.get(j).visible === false) {
-          m.remove(j);
+      if ( m.get(j).visibilityMode === false )
+      {
+          m.remove( j );
       }
     }
+
+    var c = m.count
 
     // add all buttons (max maxButtonsInToolbar) into toolbar
     visibleButtonModel.clear()

--- a/app/qml/components/MMToolbar.qml
+++ b/app/qml/components/MMToolbar.qml
@@ -69,6 +69,13 @@ MMBaseToolbar {
     var w = buttonView.width
     var button
 
+    for (var j = 0; j < c; j++)
+    {
+      if (m.get(j).visible === false) {
+          m.remove(j);
+      }
+    }
+
     // add all buttons (max maxButtonsInToolbar) into toolbar
     visibleButtonModel.clear()
     if(c <= maxButtonsInToolbar || w >= c*root.minimumToolbarButtonWidth) {

--- a/app/qml/components/MMToolbar.qml
+++ b/app/qml/components/MMToolbar.qml
@@ -64,9 +64,8 @@ MMBaseToolbar {
   Loader { id: buttonMore; sourceComponent: componentMore; visible: false }
 
   function setupBottomBar() {
-    var buttonModel = root.model
-    var buttonWidth = buttonView.width
-    var button
+    let buttonModel = root.model
+    let buttonWidth = buttonView.width
 
     let filteredbuttons = []
 
@@ -75,13 +74,13 @@ MMBaseToolbar {
         filteredbuttons.push( buttonModel.get(j) )
     }
 
-    var buttonsCount = filteredbuttons.length
+    let buttonsCount = filteredbuttons.length
 
     // add all buttons (max maxButtonsInToolbar) into toolbar
     visibleButtonModel.clear()
     if(buttonsCount <= maxButtonsInToolbar || buttonWidth >= buttonsCount*root.minimumToolbarButtonWidth) {
       for( var i = 0; i < buttonsCount; i++ ) {
-        button = filteredbuttons[i]
+        let button = filteredbuttons[i]
         if(button.isMenuButton !== undefined)
           button.isMenuButton = false
         button.width = Math.floor(buttonWidth / buttonsCount)
@@ -97,14 +96,14 @@ MMBaseToolbar {
         maxVisible = maxButtonsInToolbar
       for( i = 0; i < maxVisible-1; i++ ) {
         if(maxVisible===maxButtonsInToolbar || buttonWidth >= i*root.minimumToolbarButtonWidth) {
-          button = filteredbuttons[i]
+          let button = filteredbuttons[i]
           button.isMenuButton = false
           button.width = Math.floor(buttonWidth / maxVisible)
           visibleButtonModel.append(button)
         }
       }
       // add More '...' button
-      button = buttonMore
+      let button = buttonMore
       button.visible = true
       button.width = maxVisible ? buttonWidth / maxVisible : buttonWidth
       visibleButtonModel.append( button )
@@ -115,7 +114,7 @@ MMBaseToolbar {
       for( i = maxVisible-1; i < buttonsCount; i++ ) {
         if(i<0)
           continue
-        button = filteredbuttons[i]
+        let button = filteredbuttons[i]
         button.isMenuButton = true
         button.width = Math.floor(buttonWidth)
         button.parentMenu = menu

--- a/app/qml/components/MMToolbar.qml
+++ b/app/qml/components/MMToolbar.qml
@@ -70,12 +70,9 @@ MMBaseToolbar {
 
     let filteredbuttons = []
 
-    for ( var j = 0; j < buttonModel.count; j++ )
-    {
+    for ( var j = 0; j < buttonModel.count; j++ ) {
       if ( buttonModel.get(j) && buttonModel.get(j).visibilityMode === true )
-      {
-          filteredbuttons.push( buttonModel.get(j) )
-      }
+        filteredbuttons.push( buttonModel.get(j) )
     }
 
     var buttonsCount = filteredbuttons.length

--- a/app/qml/components/MMToolbar.qml
+++ b/app/qml/components/MMToolbar.qml
@@ -64,61 +64,63 @@ MMBaseToolbar {
   Loader { id: buttonMore; sourceComponent: componentMore; visible: false }
 
   function setupBottomBar() {
-    var m = root.model
-    var w = buttonView.width
+    var buttonModel = root.model
+    var buttonWidth = buttonView.width
     var button
 
-    for ( var j = m.count - 1 ; j >= 0 ; j-- )
+    let filteredbuttons = []
+
+    for ( var j = 0; j < buttonModel.count; j++ )
     {
-      if ( m.get(j).visibilityMode === false )
+      if ( buttonModel.get(j) && buttonModel.get(j).visibilityMode === true )
       {
-          m.remove( j );
+          filteredbuttons.push( buttonModel.get(j) )
       }
     }
 
-    var c = m.count
+    var buttonsCount = filteredbuttons.length
 
     // add all buttons (max maxButtonsInToolbar) into toolbar
     visibleButtonModel.clear()
-    if(c <= maxButtonsInToolbar || w >= c*root.minimumToolbarButtonWidth) {
-      for( var i = 0; i < c; i++ ) {
-        button = m.get(i)
+    if(buttonsCount <= maxButtonsInToolbar || buttonWidth >= buttonsCount*root.minimumToolbarButtonWidth) {
+      for( var i = 0; i < buttonsCount; i++ ) {
+        button = filteredbuttons[i]
         if(button.isMenuButton !== undefined)
           button.isMenuButton = false
-        button.width = Math.floor(w / c)
+        button.width = Math.floor(buttonWidth / buttonsCount)
         visibleButtonModel.append(button)
       }
-      buttonView.cellWidth = Math.floor(w / c)
+      buttonView.cellWidth = Math.floor(buttonWidth / buttonsCount)
     }
     else {
       // not all buttons are visible in toolbar due to width
       // the past of them will apper in the menu inside '...' button
-      var maxVisible = Math.floor(w/root.minimumToolbarButtonWidth)
+      var maxVisible = Math.floor(buttonWidth/root.minimumToolbarButtonWidth)
       if(maxVisible<maxButtonsInToolbar)
         maxVisible = maxButtonsInToolbar
       for( i = 0; i < maxVisible-1; i++ ) {
-        if(maxVisible===maxButtonsInToolbar || w >= i*root.minimumToolbarButtonWidth) {
-          button = m.get(i)
+        if(maxVisible===maxButtonsInToolbar || buttonWidth >= i*root.minimumToolbarButtonWidth) {
+          button = filteredbuttons[i]
           button.isMenuButton = false
-          button.width = Math.floor(w / maxVisible)
+          button.width = Math.floor(buttonWidth / maxVisible)
           visibleButtonModel.append(button)
         }
       }
       // add More '...' button
       button = buttonMore
       button.visible = true
-      button.width = maxVisible ? w / maxVisible : w
+      button.width = maxVisible ? buttonWidth / maxVisible : buttonWidth
       visibleButtonModel.append( button )
-      buttonView.cellWidth = Math.floor(maxVisible ? w / maxVisible : w)
+      buttonView.cellWidth = Math.floor(maxVisible ? buttonWidth / maxVisible : buttonWidth)
 
       // add all other buttons inside the '...' button
       invisibleButtonModel.clear()
-      for( i = maxVisible-1; i < c; i++ ) {
+      for( i = maxVisible-1; i < buttonsCount; i++ ) {
         if(i<0)
           continue
-        button = m.get(i)
+        button = filteredbuttons[i]
         button.isMenuButton = true
-        button.width = Math.floor(w)
+        button.width = Math.floor(buttonWidth)
         button.parentMenu = menu
         invisibleButtonModel.append(button)
       }

--- a/app/qml/components/MMToolbarButton.qml
+++ b/app/qml/components/MMToolbarButton.qml
@@ -27,6 +27,8 @@ Item {
   property bool isMenuButton: false
   property int buttonSpacing: 5 * __dp
 
+  visible: true
+
   height: isMenuButton ? __style.menuDrawerHeight/2 : __style.toolbarHeight
 
   // Toolbar button

--- a/app/qml/components/MMToolbarButton.qml
+++ b/app/qml/components/MMToolbarButton.qml
@@ -27,7 +27,7 @@ Item {
   property bool isMenuButton: false
   property int buttonSpacing: 5 * __dp
 
-  visible: true
+  property bool visibilityMode: true
 
   height: isMenuButton ? __style.menuDrawerHeight/2 : __style.toolbarHeight
 

--- a/app/qml/main.qml
+++ b/app/qml/main.qml
@@ -993,7 +993,7 @@ ApplicationWindow {
       projectErrorDialog.open()
     }
 
-    function onPositionTrackingSupportedChanged(){
+    function onPositionTrackingSupportedChanged() {
       positionTrackingButton.visibilityMode = __activeProject.positionTrackingSupported
       mapToolbar.setupBottomBar()
     }

--- a/app/qml/main.qml
+++ b/app/qml/main.qml
@@ -995,6 +995,7 @@ ApplicationWindow {
 
     function onPositionTrackingSupportedChanged(){
       positionTrackingButton.visibilityMode = __activeProject.positionTrackingSupported
+      mapToolbar.setupBottomBar()
     }
   }
 

--- a/app/qml/main.qml
+++ b/app/qml/main.qml
@@ -348,6 +348,8 @@ ApplicationWindow {
       }
 
       MMToolbarButton {
+        id: positionTrackingButton
+
         text: qsTr("Position tracking")
         iconSource: __style.positionTrackingIcon
         menuButtonRightText: map.isTrackingPosition ? "Active" : ""
@@ -357,7 +359,6 @@ ApplicationWindow {
         onClicked: {
           trackingPanelLoader.active = true
         }
-
       }
 
       MMToolbarButton {
@@ -990,6 +991,10 @@ ApplicationWindow {
     function onProjectReadingFailed( message ) {
       projectErrorDialog.informativeText = qsTr( "Could not read the project file:" ) + "\n" + message
       projectErrorDialog.open()
+    }
+
+    function onPositionTrackingSupportedChanged(){
+      positionTrackingButton.visibilityMode = __activeProject.positionTrackingSupported
     }
   }
 

--- a/app/qml/main.qml
+++ b/app/qml/main.qml
@@ -352,6 +352,8 @@ ApplicationWindow {
         iconSource: __style.positionTrackingIcon
         menuButtonRightText: map.isTrackingPosition ? "Active" : ""
 
+        visible: true
+
         onClicked: {
           trackingPanelLoader.active = true
         }

--- a/app/qml/main.qml
+++ b/app/qml/main.qml
@@ -352,7 +352,7 @@ ApplicationWindow {
         iconSource: __style.positionTrackingIcon
         menuButtonRightText: map.isTrackingPosition ? "Active" : ""
 
-        visible: true
+        visibilityMode: __activeProject.positionTrackingSupported
 
         onClicked: {
           trackingPanelLoader.active = true


### PR DESCRIPTION
Position tracking button in ```MMToolbar.qml``` visibility adjustment with new property in ```MMToolbarButton.qml```:
- ```visibilityMode```, which manages the overall visibility of a toolbar button. If set to ```false```, the button will not be displayed on the toolbar under any circumstances. The default value is ```true```, ensuring standard behavior for the button.

```visibilityMode true``` for Position Tracking button

<img src="https://github.com/MerginMaps/mobile/assets/155513369/1ee28971-cca1-48d6-bc8b-7289a201a475" width="300">

```visibilityMode false```  for Position Tracking button
<img src="https://github.com/MerginMaps/mobile/assets/155513369/5c63453f-571a-44b6-9177-af452fb52db1" width="300">

