### PR TITLE
Fix recording toolbar and errors

### DIFF
--- a/app/qml/components/MMToolbar.qml
+++ b/app/qml/components/MMToolbar.qml
@@ -70,8 +70,11 @@ MMBaseToolbar {
     let filteredbuttons = []
 
     for ( var j = 0; j < buttonModel.count; j++ ) {
-      if ( buttonModel.get(j) && buttonModel.get(j).visibilityMode === true )
-        filteredbuttons.push( buttonModel.get(j) )
+      if ( buttonModel.get(j).visibilityMode && buttonModel.get(j).visibilityMode === false  ) {
+        continue
+      }
+
+      filteredbuttons.push( buttonModel.get(j) )
     }
 
     let buttonsCount = filteredbuttons.length

--- a/app/qml/map/components/MMCrosshair.qml
+++ b/app/qml/map/components/MMCrosshair.qml
@@ -167,7 +167,7 @@ Item {
         }
       }
 
-      opacity: snapUtils.snapped && ( snapUtils.snapType === SnapUtils.Vertex || snapUtils.snapType === SnapUtils.Other ) ? 100 : 0
+      opacity: snapUtils.snapped && ( snapUtils.snapType === MM.SnapUtils.Vertex || snapUtils.snapType === MM.SnapUtils.Other ) ? 100 : 0
 
       Behavior on opacity {
         PropertyAnimation {
@@ -218,7 +218,7 @@ Item {
         }
       }
 
-      opacity: snapUtils.snapped && snapUtils.snapType === SnapUtils.Segment ? 100 : 0
+      opacity: snapUtils.snapped && snapUtils.snapType === MM.SnapUtils.Segment ? 100 : 0
 
       Behavior on opacity {
         PropertyAnimation {


### PR DESCRIPTION
`MMLongButton` in toolbar was not visible because it was filtered out in the `MMToolbar::setupBottomBar` function 