### PR TITLE
Add layer name and layer geometry icon to multi-identify results

### DIFF
--- a/app/featuresmodel.cpp
+++ b/app/featuresmodel.cpp
@@ -10,6 +10,7 @@
 #include "featuresmodel.h"
 #include "coreutils.h"
 
+#include "inpututils.h"
 #include "qgsproject.h"
 #include "qgsexpressioncontextutils.h"
 #include "qgsvectorlayerfeatureiterator.h"
@@ -137,6 +138,8 @@ QVariant FeaturesModel::data( const QModelIndex &index, int role ) const
     case FeaturePair: return QVariant::fromValue<FeatureLayerPair>( pair );
     case Description: return QVariant( QString( "Feature ID %1" ).arg( pair.feature().id() ) );
     case SearchResult: return searchResultPair( pair );
+    case LayerName: return pair.layer() ? pair.layer()->name() : QString();
+    case LayerIcon: return pair.layer() ? InputUtils::loadIconFromLayer( pair.layer() ) : QString();
     case Qt::DisplayRole: return featureTitle( pair );
   }
 
@@ -269,6 +272,8 @@ QHash<int, QByteArray> FeaturesModel::roleNames() const
   roleNames[FeaturePair] = QStringLiteral( "FeaturePair" ).toLatin1();
   roleNames[Description] = QStringLiteral( "Description" ).toLatin1();
   roleNames[SearchResult] = QStringLiteral( "SearchResult" ).toLatin1();
+  roleNames[LayerName] = QStringLiteral( "LayerName" ).toLatin1();
+  roleNames[LayerIcon] = QStringLiteral( "LayerIcon" ).toLatin1();
   return roleNames;
 }
 

--- a/app/featuresmodel.h
+++ b/app/featuresmodel.h
@@ -61,7 +61,9 @@ class FeaturesModel : public QAbstractListModel
       Feature,
       FeaturePair,
       Description, // secondary text in list view
-      SearchResult // pair of attribute and its value by which the feature was found, empty if search expression is empty
+      SearchResult, // pair of attribute and its value by which the feature was found, empty if search expression is empty
+      LayerName,
+      LayerIcon,
     };
     Q_ENUM( ModelRoles );
 

--- a/app/qml/components/MMListDrawer.qml
+++ b/app/qml/components/MMListDrawer.qml
@@ -52,7 +52,7 @@ MMDrawer {
       width: parent.width
       interactive: root.maxHeightHit ? true : false
 
-      height: root.listModel ? root.listModel.count * __style.menuDrawerHeight : 0
+      height: Math.min( root.drawerContentAvailableHeight, root.listModel ? root.listModel.count * __style.menuDrawerHeight : 0 )
       maximumFlickVelocity: __androidUtils.isAndroid ? __style.scrollVelocityAndroid : maximumFlickVelocity
 
       delegate: MMListDrawerItem {

--- a/app/qml/components/MMListDrawer.qml
+++ b/app/qml/components/MMListDrawer.qml
@@ -24,7 +24,7 @@ MMDrawer {
 
   property string valueRole: "type"
   property string textRole: "name"
-  property string descriptionRole: "description"
+  property string descriptionRole: "" //! optional description role
   property string imageRole: "iconSource"
 
   property var activeValue /* which value defined by valueRole should be highlighted */
@@ -62,7 +62,7 @@ MMDrawer {
 
         type: model[root.valueRole]
         text: model[root.textRole]
-        description: model[root.descriptionRole] ?? ""
+        description: descriptionRole !== "" ? model[root.descriptionRole] : ""
         iconSource: model[root.imageRole]
         isActive: root.activeValue ? root.activeValue === model[root.valueRole] : false
 

--- a/app/qml/components/MMListDrawer.qml
+++ b/app/qml/components/MMListDrawer.qml
@@ -12,7 +12,7 @@ import QtQuick.Controls
 import QtQuick.Controls.Basic
 
 /**
- * This is a white drawer with close button that shows items from model with icon + title
+ * This is a white drawer with close button that shows items from model with icon + title + optional description
  * You can specify element to show where there are no items (use MMMessage component)
  */
 MMDrawer {
@@ -24,13 +24,14 @@ MMDrawer {
 
   property string valueRole: "type"
   property string textRole: "name"
+  property string descriptionRole: "description"
   property string imageRole: "iconSource"
 
   property var activeValue /* which value defined by valueRole should be highlighted */
 
   property bool modelIsEmpty: root.listModel ? root.listModel.count === 0 : true
 
-  signal clicked( string type )
+  signal clicked( var type )
 
   drawerContent: Item {
     width: parent.width
@@ -61,6 +62,7 @@ MMDrawer {
 
         type: model[root.valueRole]
         text: model[root.textRole]
+        description: model[root.descriptionRole] ?? ""
         iconSource: model[root.imageRole]
         isActive: root.activeValue ? root.activeValue === model[root.valueRole] : false
 

--- a/app/qml/components/MMListDrawerItem.qml
+++ b/app/qml/components/MMListDrawerItem.qml
@@ -50,14 +50,14 @@ Item {
       height: parent.height
       width: parent.width
 
-      Text {
+      MMText {
         width: parent.width
         text: control.text
         color: __style.nightColor
         font: __style.t3
       }
 
-      Text {
+      MMText {
         width: parent.width
         text: control.description
         color: __style.nightColor

--- a/app/qml/components/MMListDrawerItem.qml
+++ b/app/qml/components/MMListDrawerItem.qml
@@ -15,10 +15,11 @@ import QtQuick.Layouts
 Item {
   id: control
 
-  signal clicked(type: string)
+  signal clicked(var type)
 
-  property string type
+  property var type
   property string text
+  property string description
   property var iconSource
 
   property bool isActive
@@ -45,14 +46,24 @@ Item {
       source: control.iconSource ?? ""
     }
 
-    Text {
-      Layout.fillWidth: true
+    Column {
       height: parent.height
-      Layout.alignment: Qt.AlignVCenter
+      width: parent.width
 
-      text: control.text
-      color: __style.nightColor
-      font: __style.t3
+      Text {
+        width: parent.width
+        text: control.text
+        color: __style.nightColor
+        font: __style.t3
+      }
+
+      Text {
+        width: parent.width
+        text: control.description
+        color: __style.nightColor
+        font: __style.p6
+        visible: control.description
+      }
     }
 
     MMIcon {

--- a/app/qml/main.qml
+++ b/app/qml/main.qml
@@ -774,17 +774,18 @@ ApplicationWindow {
   // Should be the top-most visual item
   MMNotificationView {}
 
-  MMDropdownDrawer {
+  MMListDrawer {
     id: featurePairSelection
 
-    title: qsTr( "Select feature" )
-    withSearchbar: false
-    model: MM.FeaturesModel {}
+    drawerHeader.title: qsTr( "Select feature" )
+    maxHeight: ApplicationWindow.window?.height * 2 / 3 ?? 0
+    listModel: MM.FeaturesModel {}
     valueRole: "FeaturePair"
     textRole: "FeatureTitle"
+    imageRole: "LayerIcon"
+    descriptionRole: "LayerName"
 
-    onSelectionFinished: function( pairs ) {
-      var pair = pairs[0]
+    onClicked: function( pair ) {
       featurePairSelection.close()
       map.highlightPair( pair )
       formsStackManager.openForm( pair, "readOnly", "preview" );
@@ -793,7 +794,7 @@ ApplicationWindow {
     function showPairs( pairs ) {
       if ( pairs.length > 0 )
       {
-        model.populateStaticModel( pairs )
+        listModel.populateStaticModel( pairs )
         open()
       }
     }

--- a/app/qml/main.qml
+++ b/app/qml/main.qml
@@ -778,7 +778,6 @@ ApplicationWindow {
     id: featurePairSelection
 
     drawerHeader.title: qsTr( "Select feature" )
-    maxHeight: ApplicationWindow.window?.height * 2 / 3 ?? 0
     listModel: MM.FeaturesModel {}
     valueRole: "FeaturePair"
     textRole: "FeatureTitle"


### PR DESCRIPTION
Add an icon according to layer's geometry type, add layer name as a secondary _description_ text.

![image](https://github.com/MerginMaps/mobile/assets/11358178/76629581-6590-48d5-88bd-a1c1b60604c8)

Also fixes scrolling in MMListDrawer, it would always snap-return to top of list.

issues:
Spacing between primary and secondary text probably needs some adjusting to match the design docs.
List items overlap the Header when scrolled, as seen on the screenshot above (was the case before this pr too)