### PR TITLE
Adjustment of the text displayed during synchronization

### DIFF
--- a/app/qml/project/components/MMProjectDelegate.qml
+++ b/app/qml/project/components/MMProjectDelegate.qml
@@ -134,7 +134,7 @@ Control {
             MMText {
               width: parent.width - projectStatusIcon.width - parent.spacing
 
-              text: root.projectDescription
+              text: projectIsInSync ? qsTr( "Synchronising project changes" ) : root.projectDescription
 
               font: __style.p6
               color: root.projectIsOpened ? __style.polarColor : __style.nightColor

--- a/app/qml/project/components/MMProjectDelegate.qml
+++ b/app/qml/project/components/MMProjectDelegate.qml
@@ -180,7 +180,7 @@ Control {
 
           MMText {
             width: parent.width - parent.spacing - stopSyncGroup.width
-            text: qsTr( "Synchronising" ) + "..."
+            text: qsTr( "Please don't close the app." )
             font: __style.p6
             color: root.projectIsOpened ? __style.polarColor : __style.nightColor
           }


### PR DESCRIPTION
From "Synchronising..." to "Please don't close the app." 

<img src="https://github.com/MerginMaps/mobile/assets/155513369/d8d10242-7847-4e96-8923-3e26e2e7f962" width="300">
