### PR TITLE
Fixed rotation of photos in the MMFormPhotoViewer

### DIFF
--- a/app/qml/components/MMMorePhoto.qml
+++ b/app/qml/components/MMMorePhoto.qml
@@ -31,6 +31,7 @@ Row {
 
     source: control.photoUrl
     asynchronous: true
+    autoTransform: true
     layer.enabled: true
     layer {
       effect: OpacityMask {

--- a/app/qml/components/MMPhoto.qml
+++ b/app/qml/components/MMPhoto.qml
@@ -22,6 +22,7 @@ Image {
   height: width
   source: root.photoUrl
   asynchronous: true
+  autoTransform: true
   layer.enabled: true
   layer {
     effect: OpacityMask {

--- a/app/qml/components/MMPhotoPreview.qml
+++ b/app/qml/components/MMPhotoPreview.qml
@@ -38,6 +38,7 @@ Popup {
 
       height: root.height / 2
 
+      autoTransform: true;
       focus: true
       asynchronous: true
       fillMode: Image.PreserveAspectFit

--- a/app/qml/form/editors/MMFormPhotoViewer.qml
+++ b/app/qml/form/editors/MMFormPhotoViewer.qml
@@ -72,7 +72,6 @@ MMBaseInput {
       photoUrl: root.photoUrl
 
       fillMode: Image.PreserveAspectCrop
-      autoTransform: true
 
       MouseArea {
         anchors.fill: parent

--- a/app/qml/form/editors/MMFormPhotoViewer.qml
+++ b/app/qml/form/editors/MMFormPhotoViewer.qml
@@ -72,6 +72,7 @@ MMBaseInput {
       photoUrl: root.photoUrl
 
       fillMode: Image.PreserveAspectCrop
+      autoTransform: true
 
       MouseArea {
         anchors.fill: parent


### PR DESCRIPTION
Bug fix: ISS-102

Fixed: Photos attached from gallery / captured are rotated in the form
The issue was occurring on iOS only.

<img src="https://github.com/MerginMaps/mobile/assets/155513369/65c8065d-9ff4-4a04-8720-b45c58fb3618" width="200"> 

Similar bug also fixed: image rotation in MMPhotoPreview:
| Before | After |
|--------|--------|
|<img src="https://github.com/MerginMaps/mobile/assets/155513369/9980d4cc-9a9b-42fe-8fe5-7b1c0845ebdf" width="200">| <img src="https://github.com/MerginMaps/mobile/assets/155513369/ff6dd0b4-d689-437e-aeb3-1919dcc2d63b" width="200"> |
