### PR TITLE
Changing image of the MMFormDeleteFeatureDialog.qml

### DIFF
--- a/app/qml/dialogs/MMFormDeleteFeatureDialog.qml
+++ b/app/qml/dialogs/MMFormDeleteFeatureDialog.qml
@@ -16,7 +16,7 @@ MMDrawerDialog {
 
   signal deleteFeature()
 
-  picture: __style.positiveMMSymbolImage
+  picture: __style.negativeMMSymbolImage
   bigTitle: qsTr( "Delete feature" )
   description: qsTr( "Are you sure you want to delete this feature?" )
   primaryButton: qsTr( "Yes, I want to delete" )


### PR DESCRIPTION
ISS-101
Changing  from  ```__style.positiveMMSymbolImage``` to ```__style.negativeMMSymbolImage```
<img width="250" alt="222" src="https://github.com/MerginMaps/mobile/assets/155513369/0d45b3e8-fd33-4c75-b4df-7f650aa13b9a">
