### PR TITLE
Handle Android versions 10 and below

### DIFF
--- a/app/android/src/uk/co/lutraconsulting/InputActivity.java
+++ b/app/android/src/uk/co/lutraconsulting/InputActivity.java
@@ -59,7 +59,7 @@ public class InputActivity extends QtActivity
   void setCustomStatusAndNavBar() 
   {
     if (Build.VERSION.SDK_INT < Build.VERSION_CODES.R) {
-      Log.d( TAG, "Too old for that" );
+      Log.d( TAG, "Older android version." );
       return;
     }
     else {
@@ -91,7 +91,7 @@ public class InputActivity extends QtActivity
   public String getSafeArea() {
 
     if (Build.VERSION.SDK_INT < Build.VERSION_CODES.R) {
-      Log.d( TAG, "Too old for that" );
+      Log.d( TAG, "Older android version." );
       return ( "0,0,0,0" );
     }
     else {

--- a/app/android/src/uk/co/lutraconsulting/InputActivity.java
+++ b/app/android/src/uk/co/lutraconsulting/InputActivity.java
@@ -59,7 +59,7 @@ public class InputActivity extends QtActivity
   void setCustomStatusAndNavBar() 
   {
     if (Build.VERSION.SDK_INT < Build.VERSION_CODES.R) {
-      Log.d( TAG, "Older android version." );
+      Log.d( TAG, "Unsupported Android version for painting behind system bars." );
       return;
     }
     else {
@@ -91,7 +91,7 @@ public class InputActivity extends QtActivity
   public String getSafeArea() {
 
     if (Build.VERSION.SDK_INT < Build.VERSION_CODES.R) {
-      Log.d( TAG, "Older android version." );
+      Log.d( TAG, "Unsupported Android version for painting behind system bars." );
       return ( "0,0,0,0" );
     }
     else {

--- a/app/android/src/uk/co/lutraconsulting/InputActivity.java
+++ b/app/android/src/uk/co/lutraconsulting/InputActivity.java
@@ -58,23 +58,26 @@ public class InputActivity extends QtActivity
 
   void setCustomStatusAndNavBar() 
   {
-    WindowCompat.setDecorFitsSystemWindows(getWindow(), false);
+    if (Build.VERSION.SDK_INT < Build.VERSION_CODES.R) {
+      Log.d( TAG, "Too old for that" );
+      return;
+    }
+    else {
+      WindowCompat.setDecorFitsSystemWindows(getWindow(), false);
 
-    Window window = getWindow();
+      Window window = getWindow();
 
-    // draw app edge-to-edge
-    window.addFlags(WindowManager.LayoutParams.FLAG_DRAWS_SYSTEM_BAR_BACKGROUNDS);
-    
-    // make the status bar background color transparent
-    window.setStatusBarColor(Color.TRANSPARENT);
-    
-    // make the navigation button background color transparent
-    window.setNavigationBarColor(Color.TRANSPARENT);
+      // draw app edge-to-edge
+      window.addFlags(WindowManager.LayoutParams.FLAG_DRAWS_SYSTEM_BAR_BACKGROUNDS);
+      
+      // make the status bar background color transparent
+      window.setStatusBarColor(Color.TRANSPARENT);
+      
+      // make the navigation button background color transparent
+      window.setNavigationBarColor(Color.TRANSPARENT);
 
-    // do not show background dim for the navigation buttons
-    window.setNavigationBarContrastEnforced(false); 
-
-    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+      // do not show background dim for the navigation buttons
+      window.setNavigationBarContrastEnforced(false); 
 
       // change the status bar text color to black
       WindowInsetsController insetsController = window.getDecorView().getWindowInsetsController();
@@ -87,18 +90,24 @@ public class InputActivity extends QtActivity
 
   public String getSafeArea() {
 
-    WindowInsets windowInsets = getWindow().getDecorView().getRootWindowInsets();
-
-    if ( windowInsets == null ) {
-      Log.d( TAG, "Try to ask for insets later" );
-      return null;
+    if (Build.VERSION.SDK_INT < Build.VERSION_CODES.R) {
+      Log.d( TAG, "Too old for that" );
+      return ( "0,0,0,0" );
     }
+    else {
+      WindowInsets windowInsets = getWindow().getDecorView().getRootWindowInsets();
 
-    Insets safeArea = windowInsets.getInsets( android.view.WindowInsets.Type.statusBars() | 
-                                              android.view.WindowInsets.Type.navigationBars() | 
-                                              android.view.WindowInsets.Type.displayCutout() );
-                                              
-    return ( "" + safeArea.top + "," + safeArea.right + "," + safeArea.bottom + "," + safeArea.left );
+      if ( windowInsets == null ) {
+        Log.d( TAG, "Try to ask for insets later" );
+        return null;
+      }
+
+      Insets safeArea = windowInsets.getInsets( android.view.WindowInsets.Type.statusBars() | 
+                                                android.view.WindowInsets.Type.navigationBars() | 
+                                                android.view.WindowInsets.Type.displayCutout() );
+                                                
+      return ( "" + safeArea.top + "," + safeArea.right + "," + safeArea.bottom + "," + safeArea.left );
+    }
   }
 
   public void hideSplashScreen()


### PR DESCRIPTION
Adjusting the ```getSafeArea``` and ```setCustomStatusAndNavBar``` methods in ```InputActivity.java``` to accommodate Android versions 10 and earlier.

- <img src="https://github.com/MerginMaps/mobile/assets/155513369/9a261b09-2853-4c4b-9f0f-90baf7f14536" width="300">
- <img src="https://github.com/MerginMaps/mobile/assets/155513369/9c36467d-5611-4a6d-aa90-e308fe3b862a" width="300">
