### PR TITLE
Fix layout of dialog drawers

### DIFF
--- a/app/mmstyle.h
+++ b/app/mmstyle.h
@@ -289,6 +289,7 @@ class MMStyle: public QObject
     Q_PROPERTY( double row114 READ number114 CONSTANT )
     Q_PROPERTY( double radius6 READ number6 CONSTANT )
     Q_PROPERTY( double radius12 READ number12 CONSTANT )
+    Q_PROPERTY( double radius16 READ number16 CONSTANT )
     Q_PROPERTY( double radius20 READ number20 CONSTANT )
     Q_PROPERTY( double radius30 READ number30 CONSTANT )
     Q_PROPERTY( double radius40 READ number40 CONSTANT )

--- a/app/qml/CMakeLists.txt
+++ b/app/qml/CMakeLists.txt
@@ -76,6 +76,7 @@ set(MM_QML
     dialogs/MMDiscardGeometryChangesDialog.qml
     dialogs/MMProjectLoadErrorDialog.qml
     dialogs/MMProviderRemoveReceiverDialog.qml
+    dialogs/components/MMDialogAdditionalText.qml
     form/MMFormPage.qml
     form/MMFormStackController.qml
     form/MMFormController.qml

--- a/app/qml/components/MMCodeScanner.qml
+++ b/app/qml/components/MMCodeScanner.qml
@@ -13,7 +13,7 @@ import QtMultimedia
 
 import mm 1.0 as MM
 
-Drawer {
+Drawer { // We can keep this one as Drawer - it could actually be Popup instead
   id: root
 
   signal scanFinished( var data )

--- a/app/qml/components/MMDrawerDialog.qml
+++ b/app/qml/components/MMDrawerDialog.qml
@@ -8,171 +8,74 @@
  ***************************************************************************/
 
 import QtQuick
-import QtQuick.Controls
-import QtQuick.Controls.Basic
 
-Drawer {
-  id: control
+MMDrawer {
+  id: root
 
-  property alias picture: picture.source
-  property alias title: title.text
-  property alias bigTitle: bigTitle.text
-  property alias description: description.text
-  property alias boundedDescription: boundedDescription.text
-  property alias primaryButtonComponent: primaryButton
-  property alias primaryButton: primaryButton.text
-  property alias secondaryButton: secondaryButton.text
-  property alias specialComponent: loader.sourceComponent
+  property alias title: mmmessage.title
+  property alias description: mmmessage.description
+  property alias imageSource: mmmessage.image
+  property alias link: mmmessage.link
+  property alias linkText: mmmessage.linkText
+
+  property alias additionalContent: additionalContentGroup.children
+
+  property alias primaryButton: primaryBtn
+  property alias secondaryButton: secondaryBtn
+
+  property real spaceBeforeAdditionalContent: __style.margin20
 
   signal primaryButtonClicked
   signal secondaryButtonClicked
 
-  width: window.width // TODO maximum size
-  height: mainColumn.height
-  edge: Qt.BottomEdge
   dim: true
   interactive: false
-  dragMargin: 0
-  closePolicy: Popup.CloseOnEscape | Popup.CloseOnPressOutside
 
-  Rectangle {
-    color: roundedRect.color
-    anchors.top: parent.top
-    anchors.left: parent.left
-    anchors.right: parent.right
-    height: 2 * radius
-    anchors.topMargin: -radius
-    radius: 20 * __dp
-  }
-
-  Rectangle {
-    id: roundedRect
-
-    anchors.fill: parent
-    color: __style.polarColor
+  drawerContent: MMScrollView {
+    width: parent.width
+    height: root.maxHeightHit ? root.drawerContentAvailableHeight : contentHeight
 
     Column {
-      id: mainColumn
+      id: col
 
       width: parent.width
-      spacing: 20 * __dp
-      leftPadding: 20 * __dp
-      rightPadding: 20 * __dp
-      bottomPadding: 20 * __dp
 
-      // TODO replace with MMPageHeader?
-      Row {
+      spacing: 0
+
+      MMMessage {
+        id: mmmessage
+
         width: parent.width
-        spacing: 10 * __dp
-
-        Item {
-          id: emptyItem
-
-          width: closeButton.width
-          height: 1
-        }
-
-        Text {
-          id: title
-
-          anchors.verticalCenter: parent.verticalCenter
-          width: parent.width - emptyItem.width - closeButton.width - mainColumn.leftPadding - mainColumn.rightPadding - 2 * parent.spacing
-          horizontalAlignment: Text.AlignHCenter
-          wrapMode: Text.WordWrap
-          font: __style.t2
-          color: __style.forestColor
-        }
-
-        MMRoundButton {
-          id: closeButton
-          bgndColor: __style.lightGreenColor
-          iconSource: __style.closeIcon
-          onClicked: control.close()
-        }
       }
 
-      Image {
-        id: picture
+      MMListSpacer { height: root.spaceBeforeAdditionalContent; visible: internal.hasAdditionalContent }
 
-        anchors.horizontalCenter: parent.horizontalCenter
+      Item {
+        id: additionalContentGroup
+
+        width: parent.width
+        height: childrenRect.height
+
+        visible: children.length > 0
       }
 
-      Text {
-        id: bigTitle
-
-        anchors.horizontalCenter: parent.horizontalCenter
-        font: __style.t1
-        width: parent.width - 2*20 * __dp
-        color: __style.forestColor
-        visible: text.length > 0
-        horizontalAlignment: Text.AlignHCenter
-      }
-
-      Text {
-        id: description
-
-        anchors.horizontalCenter: parent.horizontalCenter
-        font: __style.p5
-        width: parent.width - 2*20 * __dp
-        color: __style.nightColor
-        visible: text.length > 0
-        horizontalAlignment: Text.AlignHCenter
-        wrapMode: Text.WordWrap
-        lineHeight: 1.6
-        textFormat: Text.RichText
-        onLinkActivated: function( link ) {
-          Qt.openUrlExternally( link )
-        }
-      }
-
-      Rectangle {
-        anchors.horizontalCenter: parent.horizontalCenter
-        visible: boundedDescription.text.length > 0
-        width: parent.width - 2*20 * __dp
-        height: boundedDescription.height
-        radius: 16 * __dp
-        color: __style.lightGreenColor
-
-        Text {
-          id: boundedDescription
-
-          anchors.horizontalCenter: parent.horizontalCenter
-          font: __style.p6
-          width: parent.width
-          color: __style.nightColor
-          visible: text.length > 0
-          horizontalAlignment: Text.AlignLeft
-          wrapMode: Text.WordWrap
-          lineHeight: 1.6
-          padding: 20 * __dp
-          textFormat: Text.RichText
-          onLinkActivated: function( link ) {
-            Qt.openUrlExternally( link )
-          }
-        }
-      }
-
-      Loader {
-        id: loader
-
-        anchors.horizontalCenter: parent.horizontalCenter
-      }
-
-      Item { width: 1; height: 1 }
+      MMListSpacer { height: __style.margin40; visible: primaryBtn.visible || secondaryBtn.visible }
 
       MMButton {
-        id: primaryButton
+        id: primaryBtn
 
-        width: parent.width - 2*20 * __dp
+        width: parent.width
         visible: text.length > 0
 
         onClicked: primaryButtonClicked()
       }
 
-      MMButton {
-        id: secondaryButton
+      MMListSpacer { height: __style.margin20; visible: primaryBtn.visible && secondaryBtn.visible }
 
-        width: parent.width - 2*20 * __dp
+      MMButton {
+        id: secondaryBtn
+
+        width: parent.width
         visible: text.length > 0
 
         type: MMButton.Types.Tertiary
@@ -182,5 +85,11 @@ Drawer {
         onClicked: secondaryButtonClicked()
       }
     }
+  }
+
+  QtObject {
+    id: internal
+
+    property bool hasAdditionalContent: additionalContentGroup.children.length > 0
   }
 }

--- a/app/qml/dialogs/MMDiscardGeometryChangesDialog.qml
+++ b/app/qml/dialogs/MMDiscardGeometryChangesDialog.qml
@@ -19,8 +19,8 @@ MMDrawerDialog {
 
   signal discardChanges()
 
-  picture: __style.positiveMMSymbolImage
-  bigTitle: qsTr( "Discard the changes?" )
+  imageSource: __style.positiveMMSymbolImage
+  title: qsTr( "Discard the changes?" )
   description: {
     if ( root.state === "edit" ) {
       return qsTr( "Clicking ‘Yes’ discards your changes to the geometry. If you would like " +
@@ -34,8 +34,8 @@ MMDrawerDialog {
     return ""
   }
 
-  primaryButton: qsTr ( "Yes, I want to discard" )
-  secondaryButton: qsTr ( "No, thanks" )
+  primaryButton.text: qsTr ( "Yes, I want to discard" )
+  secondaryButton.text: qsTr ( "No, thanks" )
 
   onPrimaryButtonClicked: {
     root.discardChanges()

--- a/app/qml/dialogs/MMDownloadProjectDialog.qml
+++ b/app/qml/dialogs/MMDownloadProjectDialog.qml
@@ -20,11 +20,11 @@ MMDrawerDialog {
 
   signal downloadClicked()
 
-  picture: __style.positiveMMSymbolImage
-  bigTitle: qsTr( "Download project" )
-  description: qsTr( "Would you like to download the project\n %1 ?" ).arg( relatedProjectId )
-  primaryButton: qsTr("Download")
-  secondaryButton: qsTr("Cancel")
+  imageSource: __style.positiveMMSymbolImage
+  title: qsTr( "Download project" )
+  description: qsTr( "Would you like to download project\n %1 ?" ).arg( relatedProjectId )
+  primaryButton.text: qsTr("Download")
+  secondaryButton.text: qsTr("Cancel")
 
   onPrimaryButtonClicked: {
     downloadClicked()

--- a/app/qml/dialogs/MMFormDeleteFeatureDialog.qml
+++ b/app/qml/dialogs/MMFormDeleteFeatureDialog.qml
@@ -16,11 +16,11 @@ MMDrawerDialog {
 
   signal deleteFeature()
 
-  picture: __style.negativeMMSymbolImage
-  bigTitle: qsTr( "Delete feature" )
+  imageSource: __style.negativeMMSymbolImage
+  title: qsTr( "Delete feature" )
   description: qsTr( "Are you sure you want to delete this feature?" )
-  primaryButton: qsTr( "Yes, I want to delete" )
-  secondaryButton: qsTr( "No, thanks" )
+  primaryButton.text: qsTr( "Yes, I want to delete" )
+  secondaryButton.text: qsTr( "No, thanks" )
 
   onPrimaryButtonClicked: {
     root.deleteFeature()

--- a/app/qml/dialogs/MMFormEditFailedDialog.qml
+++ b/app/qml/dialogs/MMFormEditFailedDialog.qml
@@ -14,10 +14,10 @@ import "../components"
 MMDrawerDialog {
   id: root
 
-  picture: __style.negativeMMSymbolImage
-  bigTitle: qsTr( "Saving failed" )
+  imageSource: __style.negativeMMSymbolImage
+  title: qsTr( "Saving failed" )
   description: qsTr( "Failed to save changes. This should not happen normally. Please restart the app and try again — if that does not help, please contact support." )
-  primaryButton: qsTr( "Ok, I understand" )
+  primaryButton.text: qsTr( "Ok, I understand" )
 
   onPrimaryButtonClicked: {
     close()

--- a/app/qml/dialogs/MMFormSaveChangesDialog.qml
+++ b/app/qml/dialogs/MMFormSaveChangesDialog.qml
@@ -17,11 +17,11 @@ MMDrawerDialog {
   signal saveChanges()
   signal discardChanges()
 
-  picture: __style.positiveMMSymbolImage
-  bigTitle: qsTr( "Unsaved changes" )
+  imageSource: __style.positiveMMSymbolImage
+  title: qsTr( "Unsaved changes" )
   description: qsTr( "Do you want to save the changes?" )
-  primaryButton: qsTr( "Yes, I want to save" )
-  secondaryButton: qsTr( "No, thanks" )
+  primaryButton.text: qsTr( "Yes, I want to save" )
+  secondaryButton.text: qsTr( "No, thanks" )
 
   onPrimaryButtonClicked: {
     root.saveChanges()

--- a/app/qml/dialogs/MMMigrateToMerginDialog.qml
+++ b/app/qml/dialogs/MMMigrateToMerginDialog.qml
@@ -16,11 +16,11 @@ MMDrawerDialog {
 
   signal migrationRequested()
 
-  picture: __style.positiveMMSymbolImage
-  bigTitle: qsTr( "Upload project?" )
+  imageSource: __style.positiveMMSymbolImage
+  title: qsTr( "Upload project?" )
   description: qsTr( "This project is currently not uploaded on cloud. Upload it in order to activate synchronization and collaboration." )
-  primaryButton: qsTr( "Yes, I want to upload it" )
-  secondaryButton: qsTr( "No, thanks" )
+  primaryButton.text: qsTr( "Yes, I want to upload it" )
+  secondaryButton.text: qsTr( "No, thanks" )
 
   onPrimaryButtonClicked: {
     root.migrationRequested()

--- a/app/qml/dialogs/MMMissingAuthDialog.qml
+++ b/app/qml/dialogs/MMMissingAuthDialog.qml
@@ -16,11 +16,11 @@ MMDrawerDialog {
 
   signal singInRequested()
 
-  picture: __style.signInImage
-  bigTitle: qsTr( "Sign in to your account" )
+  imageSource: __style.signInImage
+  title: qsTr( "Sign in to your account" )
   description: qsTr( "You need to be signed in to your Mergin Maps account in order to synchronize the project." )
-  primaryButton: qsTr( "Yes, I want to sign in" )
-  secondaryButton: qsTr( "No, thanks" )
+  primaryButton.text: qsTr( "Yes, I want to sign in" )
+  secondaryButton.text: qsTr( "No, thanks" )
 
   onPrimaryButtonClicked: {
     root.singInRequested()

--- a/app/qml/dialogs/MMNoPermissionsDialog.qml
+++ b/app/qml/dialogs/MMNoPermissionsDialog.qml
@@ -14,10 +14,10 @@ import "../components"
 MMDrawerDialog {
   id: root
 
-  picture: __style.noPermissionsImage
-  bigTitle: qsTr( "No rights to access the project" )
+  imageSource: __style.noPermissionsImage
+  title: qsTr( "No rights to access the project" )
   description: qsTr( "You are not allowed to synchronize your changes in this project. Contact the project owner to assign you the correct permission. If you are the project owner, log in to the dashboard." )
-  primaryButton: qsTr( "Ok, I understand" )
+  primaryButton.text: qsTr( "Ok, I understand" )
 
   onPrimaryButtonClicked: {
     close()

--- a/app/qml/dialogs/MMOutOfDateCustomServerDialog.qml
+++ b/app/qml/dialogs/MMOutOfDateCustomServerDialog.qml
@@ -19,17 +19,15 @@ MMDrawerDialog {
 
   signal ignoreClicked()
 
-  picture: __style.positiveMMSymbolImage
-  bigTitle: qsTr( "Your server will soon be out of date" )
-  description: __inputUtils.htmlLink(
-                 qsTr("Please contact your server administrator to upgrade your server to the latest version. " +
-                      "Subsequent releases of our mobile app may not be compatible with your current server version. \n" +
-                      "Learn more about %1how to migrate%2."),
-                 __style.forestColor,
-                 root.helpLink
-    )
+  imageSource: __style.positiveMMSymbolImage
+  title: qsTr( "Your server will soon be out of date" )
+  description: qsTr( "Please contact your server administrator to upgrade your server to the latest version. " +
+                     "Subsequent releases of our mobile app may not be compatible with your current server version." )
 
-  primaryButton: qsTr( "Ignore" )
+  link: helpLink
+  linkText: qsTr( "Learn more" )
+
+  primaryButton.text: qsTr( "Ignore" )
 
   onPrimaryButtonClicked: {
     root.ignoreClicked()

--- a/app/qml/dialogs/MMPositionTrackingDialog.qml
+++ b/app/qml/dialogs/MMPositionTrackingDialog.qml
@@ -8,8 +8,6 @@
  ***************************************************************************/
 
 import QtQuick
-import QtQuick.Controls
-import QtQuick.Layouts
 
 import "../components" as MMComponents
 
@@ -22,30 +20,34 @@ MMComponents.MMDrawerDialog {
 
   signal trackingBtnClicked()
 
-  picture: root.trackingActive ? __style.positionTrackingRunningImage : __style.positionTrackingStartImage
-  bigTitle: qsTr("Position tracking")
-  description: root.trackingActive ? qsTr("Mergin Maps can track your position on this project."): qsTr("Track your routes even with your screen off. Your records are stored in a separate layer. Finalised tracks are synced like any other feature.")
-  primaryButton: root.trackingActive ? qsTr("Stop tracking") : qsTr("Start tracking")
-  primaryButtonComponent.type: root.trackingActive ? MMComponents.MMButton.Types.Secondary : MMComponents.MMButton.Types.Primary
+  title: qsTr("Position tracking")
+  imageSource: root.trackingActive ? __style.positionTrackingRunningImage : __style.positionTrackingStartImage
+  description: root.trackingActive ? qsTr( "Mergin Maps can track your position on this project." ) : qsTr( "Track your routes even with your screen off. Your records are stored in a separate layer. Finalised tracks are synced like any other feature." )
+  primaryButton.text: root.trackingActive ? qsTr( "Stop tracking" ) : qsTr( "Start tracking" )
+  primaryButton.type: root.trackingActive ? MMComponents.MMButton.Secondary : MMComponents.MMButton.Primary
 
-  specialComponent: trackingInfoPanel
+  additionalContent: Item {
+    width: parent.width
+    height: childrenRect.height
 
-  Component {
-    id: trackingInfoPanel
-    Item {
-      width: root.width - 2 * __style.pageMargins
-      height: 100 * __dp // TODO needs to be adjusted
+    Row {
+      width: parent.width
+      spacing: __style.margin10
 
       Column {
-        anchors.left: parent.left
-        anchors.leftMargin: __style.pageMargins
-        height: parent.height
-        Text {
+        width: parent.width / 2 - parent.spacing / 2
+
+        MMComponents.MMText {
+          width: parent.width
+
           text: qsTr("Tracked distance")
           font: __style.p6
           color: __style.nightColor
         }
-        Text {
+
+        MMComponents.MMText {
+          width: parent.width
+
           text: root.trackingActive ? root.distanceTraveled : "-"
           font: __style.t3
           color: __style.nightColor
@@ -53,17 +55,22 @@ MMComponents.MMDrawerDialog {
       }
 
       Column {
-        anchors.right: parent.right
-        anchors.rightMargin: __style.pageMargins
-        height: parent.height
+        width: parent.width / 2 - parent.spacing / 2
 
-        Text {
+        MMComponents.MMText {
+          width: parent.width
+
           text: qsTr("Started at")
+          horizontalAlignment: Text.AlignRight
           font: __style.p6
           color: __style.nightColor
         }
-        Text {
+
+        MMComponents.MMText {
+          width: parent.width
+
           text: root.trackingActive ? root.trackingStartedAt : "-"
+          horizontalAlignment: Text.AlignRight
           font: __style.t3
           color: __style.nightColor
         }

--- a/app/qml/dialogs/MMProjErrorDialog.qml
+++ b/app/qml/dialogs/MMProjErrorDialog.qml
@@ -9,19 +9,25 @@
 
 import QtQuick
 
-import "../components"
-import "../inputs"
+import "../components" as MMComponents
+import "./components" as MMDialogComponents
 
-MMDrawerDialog {
+MMComponents.MMDrawerDialog {
   id: root
 
+  property string detailedDescription
   property string helpLink: __inputHelp.howToSetupProj
 
-  picture: __style.negativeMMSymbolImage
-  bigTitle: qsTr( "PROJ Error" )
-  description: __inputUtils.htmlLink(
-      qsTr("Learn more about %1how to setup PROJ%2"),
-      __style.forestColor,
-      root.helpLink
-    )
+  title: qsTr( "PROJ Error" )
+  imageSource: __style.negativeMMSymbolImage
+
+  description: qsTr( "There was an issue with loading your PROJ files. Please refer to our documentation to learn how to set up PROJ." )
+
+  link: helpLink
+  linkText: qsTr( "Learn more" )
+
+  additionalContent: MMDialogComponents.MMDialogAdditionalText {
+    width: parent.width
+    text: root.detailedDescription
+  }
 }

--- a/app/qml/dialogs/MMProjectLimitDialog.qml
+++ b/app/qml/dialogs/MMProjectLimitDialog.qml
@@ -8,28 +8,27 @@
  ***************************************************************************/
 
 import QtQuick
-import QtQuick.Controls
-import QtQuick.Dialogs
-import QtQuick.Layouts
 
-import "../components"
+import "../components" as MMComponents
 
-
-MMDrawerDialog {
+MMComponents.MMDrawerDialog {
   id: root
 
-  property int maxProjectNumber: -1
+  property int maxProjectNumber: 2
+
   required property string plan
   required property bool apiSupportsSubscription
 
-  picture: __style.reachedDataLimitImage
-  bigTitle: qsTr("You have reached project number limit")
-  primaryButton: apiSupportsSubscription ? qsTr("Manage account") : ""
-
   signal manageAccountClicked()
 
-  specialComponent: Column {
-    width: root.width - 2 * __style.pageMargins
+  imageSource: __style.reachedDataLimitImage
+
+  title: qsTr( "You have reached a maximum number of projects" )
+
+  primaryButton.text: apiSupportsSubscription ? qsTr( "Manage account" ) : ""
+
+  additionalContent: Column {
+    width: parent.width
     spacing: 10 * __dp
     topPadding: 20 * __dp
 
@@ -37,47 +36,55 @@ MMDrawerDialog {
       width: parent.width
       height: dataToSyncText.height
 
-      Text {
+      MMComponents.MMText {
         width: parent.width
-        text: qsTr("Maximum of projects")
+
+        text: qsTr( "Maximum number of projects" )
         font: __style.p5
-        color: __style.nightColor
+
         horizontalAlignment: Text.AlignLeft
         verticalAlignment: Text.AlignVCenter
       }
-      Text {
+
+      MMComponents.MMText {
         id: dataToSyncText
 
         width: parent.width
+
         text: root.maxProjectNumber
-        font: __style.t3
         color: __style.nightColor
+        font: __style.t3
+
         horizontalAlignment: Text.AlignRight
         verticalAlignment: Text.AlignVCenter
       }
     }
 
-    MMLine { width: parent.width }
+    MMComponents.MMLine { width: parent.width }
 
     Item {
       width: parent.width
       height: planText.height
 
-      Text {
+      MMComponents.MMText {
         width: parent.width
-        text: qsTr("Plan")
+
+        text: qsTr( "Plan" )
         font: __style.p5
-        color: __style.nightColor
+
         horizontalAlignment: Text.AlignLeft
         verticalAlignment: Text.AlignVCenter
       }
-      Text {
+
+      MMComponents.MMText {
         id: planText
 
         width: parent.width
+
         text: root.plan
-        font: __style.t3
         color: __style.nightColor
+        font: __style.t3
+
         horizontalAlignment: Text.AlignRight
         verticalAlignment: Text.AlignVCenter
       }

--- a/app/qml/dialogs/MMProjectLoadErrorDialog.qml
+++ b/app/qml/dialogs/MMProjectLoadErrorDialog.qml
@@ -17,11 +17,11 @@ MMDrawerDialog {
 
   property string helpLink: __inputHelp.projectLoadingErrorHelpLink
 
-  picture: __style.negativeMMSymbolImage
-  bigTitle: qsTr( "Failed to open the project" )
-  description: __inputUtils.htmlLink(
-                 qsTr("Learn more about %1loading errors%2."),
-                 __style.forestColor,
-                 root.helpLink
-               )
+  title: qsTr( "Failed to open the project" )
+  imageSource: __style.negativeMMSymbolImage
+
+  description: qsTr( "Unfortunately, your project could not be opened, please refer to our documentation to understand common problems." )
+
+  link: root.helpLink
+  linkText: qsTr( "Learn more" )
 }

--- a/app/qml/dialogs/MMProviderRemoveReceiverDialog.qml
+++ b/app/qml/dialogs/MMProviderRemoveReceiverDialog.qml
@@ -18,11 +18,11 @@ MMDrawerDialog {
 
   property string providerId
 
-  picture: __style.positiveMMSymbolImage
-  bigTitle: qsTr( "Remove receiver" )
+  imageSource: __style.positiveMMSymbolImage
+  title: qsTr( "Remove receiver" )
   description: qsTr( "Do you want to remove receiver from the list of recent receivers?" )
-  primaryButton: qsTr( "Yes, I want to remove" )
-  secondaryButton: qsTr( "No, thanks" )
+  primaryButton.text: qsTr( "Yes, I want to remove" )
+  secondaryButton.text: qsTr( "No, thanks" )
 
   onPrimaryButtonClicked: {
     root.removeProvider()

--- a/app/qml/dialogs/MMRemovePhotoDialog.qml
+++ b/app/qml/dialogs/MMRemovePhotoDialog.qml
@@ -19,11 +19,11 @@ MMDrawerDialog {
 
   property string imagePath
 
-  picture: __style.negativeMMSymbolImage
-  bigTitle: qsTr( "Remove photo reference" )
+  imageSource: __style.negativeMMSymbolImage
+  title: qsTr( "Remove photo reference" )
   description: qsTr( "Also permanently delete photo from device?" )
-  primaryButton: qsTr( "Yes, I want to delete" )
-  secondaryButton: qsTr( "No, thanks" )
+  primaryButton.text: qsTr( "Yes, I want to delete" )
+  secondaryButton.text: qsTr( "No, thanks" )
 
   onPrimaryButtonClicked: {
     root.deleteImage()

--- a/app/qml/dialogs/MMRemoveProjectDialog.qml
+++ b/app/qml/dialogs/MMRemoveProjectDialog.qml
@@ -20,11 +20,11 @@ MMDrawerDialog {
 
   signal removeClicked()
 
-  picture: __style.negativeMMSymbolImage
-  bigTitle: qsTr( "Remove project" )
+  imageSource: __style.negativeMMSymbolImage
+  title: qsTr( "Remove project" )
   description: qsTr( "Any unsynchronized changes will be lost in project \n %1" ).arg( relatedProjectId )
-  primaryButton: qsTr("Remove")
-  secondaryButton: qsTr("Cancel")
+  primaryButton.text: qsTr("Remove")
+  secondaryButton.text: qsTr("Cancel")
 
   onPrimaryButtonClicked: {
     removeClicked()

--- a/app/qml/dialogs/MMSplittingFailedDialog.qml
+++ b/app/qml/dialogs/MMSplittingFailedDialog.qml
@@ -14,10 +14,10 @@ import "../components"
 MMDrawerDialog {
   id: root
 
-  picture: __style.negativeMMSymbolImage
-  bigTitle: qsTr( "We could not split the feature" )
+  imageSource: __style.negativeMMSymbolImage
+  title: qsTr( "We could not split the feature" )
   description: qsTr( "Please make sure that the split line crosses your feature. The feature needs to have a valid geometry in order to split it." )
-  primaryButton: qsTr( "Ok, I understand" )
+  primaryButton.text: qsTr( "Ok, I understand" )
 
   onPrimaryButtonClicked: close()
 

--- a/app/qml/dialogs/MMStorageLimitDialog.qml
+++ b/app/qml/dialogs/MMStorageLimitDialog.qml
@@ -8,29 +8,28 @@
  ***************************************************************************/
 
 import QtQuick
-import QtQuick.Controls
-import QtQuick.Controls.Basic
 
-import "../components"
+import "../components" as MMComponents
 
 
-MMDrawerDialog {
+MMComponents.MMDrawerDialog {
   id: root
 
   property string dataToSync
   required property string dataUsing
   required property string plan
-  required property real usedData // [0 = 1]
+  required property real usedData // [0 - 1]
   required property bool apiSupportsSubscription
-
-  picture: __style.reachedDataLimitImage
-  bigTitle: qsTr("You have reached a data limit")
-  primaryButton: apiSupportsSubscription ? qsTr("Manage account") : ""
 
   signal manageAccountClicked()
 
-  specialComponent: Column {
-    width: root.width - 40 * __dp
+  title: qsTr("You have reached a data limit")
+  imageSource: __style.reachedDataLimitImage
+
+  primaryButton.text: apiSupportsSubscription ? qsTr("Manage account") : ""
+
+  additionalContent: Column {
+    width: parent.width
     spacing: 10 * __dp
     topPadding: 20 * __dp
 
@@ -38,7 +37,7 @@ MMDrawerDialog {
       width: parent.width
       height: dataToSyncText.height
 
-      Text {
+      MMComponents.MMText {
         width: parent.width
         text: qsTr("Data to sync")
         font: __style.p5
@@ -46,7 +45,8 @@ MMDrawerDialog {
         horizontalAlignment: Text.AlignLeft
         verticalAlignment: Text.AlignVCenter
       }
-      Text {
+
+      MMComponents.MMText {
         id: dataToSyncText
 
         width: parent.width
@@ -58,13 +58,13 @@ MMDrawerDialog {
       }
     }
 
-    MMLine { width: parent.width }
+    MMComponents.MMLine { width: parent.width }
 
     Item {
       width: parent.width
       height: dataUsingText.height
 
-      Text {
+      MMComponents.MMText {
         width: parent.width
         text: qsTr("Using")
         font: __style.p5
@@ -72,7 +72,8 @@ MMDrawerDialog {
         horizontalAlignment: Text.AlignLeft
         verticalAlignment: Text.AlignVCenter
       }
-      Text {
+
+      MMComponents.MMText {
         id: dataUsingText
 
         width: parent.width
@@ -84,17 +85,17 @@ MMDrawerDialog {
       }
     }
 
-    MMProgressBar {
+    MMComponents.MMProgressBar {
       position: root.usedData
     }
 
-    MMLine { width: parent.width }
+    MMComponents.MMLine { width: parent.width }
 
     Item {
       width: parent.width
       height: planText.height
 
-      Text {
+      MMComponents.MMText {
         width: parent.width
         text: qsTr("Plan")
         font: __style.p5
@@ -102,7 +103,8 @@ MMDrawerDialog {
         horizontalAlignment: Text.AlignLeft
         verticalAlignment: Text.AlignVCenter
       }
-      Text {
+
+      MMComponents.MMText {
         id: planText
 
         width: parent.width

--- a/app/qml/dialogs/MMStreamingModeDialog.qml
+++ b/app/qml/dialogs/MMStreamingModeDialog.qml
@@ -18,11 +18,11 @@ MMComponents.MMDrawerDialog {
 
   signal streamingBtnClicked()
 
-  picture: root.streamingActive ? __style.streamingBootsOrangeImage : __style.streamingBootsImage
-  bigTitle: qsTr("Streaming mode")
+  imageSource: root.streamingActive ? __style.streamingBootsOrangeImage : __style.streamingBootsImage
+  title: qsTr("Streaming mode")
   description: qsTr("Move around your designated object to record its geometry. You can stop this anytime.")
-  primaryButton: root.streamingActive ? qsTr("Stop streaming mode") : qsTr("Start streaming mode")
-  primaryButtonComponent.type: root.streamingActive ? MMComponents.MMButton.Types.Secondary : MMComponents.MMButton.Types.Primary
+  primaryButton.text: root.streamingActive ? qsTr("Stop streaming mode") : qsTr("Start streaming mode")
+  primaryButton.type: root.streamingActive ? MMComponents.MMButton.Types.Secondary : MMComponents.MMButton.Types.Primary
 
   onPrimaryButtonClicked: {
     close()

--- a/app/qml/dialogs/MMSyncFailedDialog.qml
+++ b/app/qml/dialogs/MMSyncFailedDialog.qml
@@ -9,7 +9,8 @@
 
 import QtQuick
 
-import "../components"
+import "../components" as MMComponents
+import "./components" as MMDialogComponents
 
 /**
   * Dialog bearing information about synchronization failure.
@@ -18,16 +19,21 @@ import "../components"
   * the default text (based on platform).
   */
 
-MMDrawerDialog {
+MMComponents.MMDrawerDialog {
   id: root
 
   property string detailedText
 
-  picture: __style.syncFailedImage
-  bigTitle: qsTr( "Failed to synchronize your changes" )
+  title: qsTr( "Failed to synchronize your changes" )
+  imageSource: __style.syncFailedImage
+
   description: qsTr( "Your changes could not be sent to the server, make sure you have a data connection and have permission to edit this project." )
-  primaryButton: qsTr( "Ok, I understand" )
-  boundedDescription: root.detailedText
+  primaryButton.text: qsTr( "Ok, I understand" )
+
+  additionalContent: MMDialogComponents.MMDialogAdditionalText {
+    width: parent.width
+    text: root.detailedText
+  }
 
   onPrimaryButtonClicked: {
     close()

--- a/app/qml/dialogs/components/MMDialogAdditionalText.qml
+++ b/app/qml/dialogs/components/MMDialogAdditionalText.qml
@@ -1,0 +1,40 @@
+/***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+import QtQuick
+
+import "../../components" as MMComponents
+
+//
+// MMDialogAdditionalText = use as additionalContent to MMDialogDrawer when needing advanced text
+//
+
+Rectangle {
+
+  property alias text: txt.text
+
+  height: childrenRect.height
+  // set width (parent.width)
+
+  color: __style.lightGreenColor
+
+  radius: __style.radius16
+
+  MMComponents.MMText {
+    id: txt
+
+    width: parent.width
+
+    color: __style.nightColor
+    padding: __style.margin20
+    font: __style.p5
+
+    wrapMode: Text.Wrap
+  }
+}

--- a/app/qml/main.qml
+++ b/app/qml/main.qml
@@ -95,7 +95,7 @@ ApplicationWindow {
   }
 
   function showProjError(message) {
-    projDialog.boundedDescription = message
+    projDialog.detailedDescription = message
     projDialog.open()
   }
 

--- a/app/qml/settings/components/MMSettingsInput.qml
+++ b/app/qml/settings/components/MMSettingsInput.qml
@@ -10,8 +10,8 @@
 import QtQuick
 import QtQuick.Controls
 
-import "../../inputs"
-import "../../components"
+import "../../inputs" as MMInputs
+import "../../components" as MMComponents
 
 MMSettingsItem {
   id: root
@@ -19,34 +19,63 @@ MMSettingsItem {
   property string valueDescription
 
   onClicked: {
-    inputDrawer.value = root.value
-    inputDrawer.visible = true
+    drawerLoader.active = true
   }
 
-  MMDrawerDialog {
-    id: inputDrawer
+  Loader {
+    id: drawerLoader
 
-    property string value
+    active: false
+    asynchronous: true
 
-    signal clicked ( string newValue )
+    sourceComponent: MMComponents.MMDrawer {
+      id: drawer
 
-    width: ApplicationWindow.window.width
-    title: root.title
-    primaryButton: qsTr("Confirm")
-    visible: false
-    specialComponent: MMTextInput {
-      width: inputDrawer.width - 40 * __dp
-      title: root.valueDescription
-      bgColor: __style.lightGreenColor
-      text: inputDrawer.value
-      focus: true
+      drawerHeader.title: root.title
 
-      onTextChanged: inputDrawer.value = text
-    }
+      onClosed: drawerLoader.active = false
 
-    onPrimaryButtonClicked: {
-      visible = false
-      root.valueWasChanged(inputDrawer.value)
+      drawerContent: MMComponents.MMScrollView {
+
+        width: parent.width
+        height: drawer.maxHeightHit ? drawer.drawerContentAvailableHeight : contentHeight
+
+        Column {
+          width: parent.width
+          spacing: 0
+
+          MMComponents.MMListSpacer { height: __style.spacing20 }
+
+          MMInputs.MMTextInput {
+            id: textInput
+
+            title: root.title
+
+            bgColor: __style.lightGreenColor
+
+            text: root.value
+            textFieldComponent.inputMethodHints: Qt.ImhNoPredictiveText | Qt.ImhNoAutoUppercase
+          }
+
+          MMComponents.MMListSpacer { height: __style.spacing40 }
+
+          MMComponents.MMButton {
+            width: parent.width
+
+            text: qsTr( "Confirm" )
+
+            onClicked: {
+              root.valueWasChanged( textInput.text )
+              drawer.close()
+            }
+          }
+        }
+
+        Component.onCompleted: open()
+      }
     }
   }
 }
+
+
+

--- a/gallery/qml.qrc
+++ b/gallery/qml.qrc
@@ -152,5 +152,6 @@
         <file>../app/qml/dialogs/MMProjectLoadErrorDialog.qml</file>
         <file>../app/qml/dialogs/MMDiscardGeometryChangesDialog.qml</file>
         <file>../app/qml/dialogs/MMProviderRemoveReceiverDialog.qml</file>
+        <file>../app/qml/dialogs/components/MMDialogAdditionalText.qml</file>
     </qresource>
 </RCC>

--- a/gallery/qml/pages/DrawerPage.qml
+++ b/gallery/qml/pages/DrawerPage.qml
@@ -116,14 +116,6 @@ Page {
       }
 
       Button {
-        text: "codeScanner"
-
-        onClicked: {
-          codeScanner.open()
-        }
-      }
-
-      Button {
         text: "removePhotoDialog"
 
         onClicked: {
@@ -311,10 +303,6 @@ Page {
     id: migrateToMerginDialog
   }
 
-  MMCodeScanner {
-    id: codeScanner
-  }
-
   MMRemovePhotoDialog {
     id: removePhotoDialog
   }
@@ -334,19 +322,19 @@ Page {
   MMProjErrorDialog {
     id: projErrorDialog
 
-    helpLink: "www.merginmaps.com"
+    helpLink: "https://merginmaps.com"
   }
 
   MMOutOfDateCustomServerDialog {
     id: outOfDateServerDialog
 
-    helpLink: "www.merginmaps.com"
+    helpLink: "https://merginmaps.com"
   }
 
   MMProjectLoadErrorDialog {
     id: projectLoadErrorDialog
 
-    helpLink: "www.merginmaps.com"
+    helpLink: "https://merginmaps.com"
   }
 
   MMDiscardGeometryChangesDialog {


### PR DESCRIPTION
`MMDrawerDialog` now inherits `MMDrawer`, it is scrollable and adjusts its height based on the content height.

I replaced `specialComponent` done via `Loader` with approach that we use in other places (`property alias xyz: xyzm.children`), the new property is called `additionalContent`. This way I extracted the "boundedMessage" to a standalone component that can be used when needed.

<img width="400" alt="Screenshot 2024-03-27 at 22 07 32" src="https://github.com/MerginMaps/mobile/assets/22449698/3387c8ef-ed22-4a5f-805d-902a0eb754b8">
<img width="380" alt="Screenshot 2024-03-27 at 22 07 37" src="https://github.com/MerginMaps/mobile/assets/22449698/17f81508-2034-40ea-b0b4-45452dfd96bd">


With the `additionalContent` it can look like this:

<img width="400" alt="Screenshot 2024-03-27 at 22 47 02" src="https://github.com/MerginMaps/mobile/assets/22449698/5153e32f-eab5-45a3-a1f5-370bdc962fc1">

but you can inject any other item to it to get something custom, like:

<img width="400" alt="Screenshot 2024-03-27 at 21 55 01 2" src="https://github.com/MerginMaps/mobile/assets/22449698/7f548bf0-a606-464e-b3ec-d50435e0fb70">

