### PR TITLE
Fix font sizes

### DIFF
--- a/app/mmstyle.h
+++ b/app/mmstyle.h
@@ -711,8 +711,13 @@ class MMStyle: public QObject
     QFont fontFactory( int pixelSize, bool bold )
     {
       QFont f;
-      f.setBold( bold );
       f.setPixelSize( pixelSize * mDp );
+
+      if ( bold )
+      {
+        f.setWeight( QFont::DemiBold );
+      }
+
       return f;
     }
 


### PR DESCRIPTION
**Font weight issue**
Fonts on Android (and most likely other systems) were rendered with font weights (700), but we are using semibold (600)

**Font size issue**
Our computation of `__dp` might not give us the best results. Time/Qt moved on and we can try to omit this constant. Let's see how this will behave on different devices, it looks fine on mine.

**Showcase**

| Before | After |
|--------|--------|
| <img src="https://github.com/MerginMaps/mobile/assets/22449698/e96c7152-66ce-4bdc-8f66-52b3b6893a7b" width=400> | <img src="https://github.com/MerginMaps/mobile/assets/22449698/8d85ac78-30f0-4456-98d6-6a895e5a81d0" width=400> |



