### PR TITLE
Fix endless login loop

### DIFF
--- a/core/merginapi.cpp
+++ b/core/merginapi.cpp
@@ -87,7 +87,7 @@ MerginApi::MerginApi( LocalProjectsManager &localProjects, QObject *parent )
   QObject::connect( mUserAuth, &MerginUserAuth::authChanged, this, &MerginApi::authChanged );
   QObject::connect( mUserAuth, &MerginUserAuth::authChanged, this, [this]()
   {
-    if ( mUserAuth->hasAuthData() )
+    if ( !mUserAuth->authToken().isEmpty() && mUserAuth->tokenExpiration() >= QDateTime().currentDateTime().toUTC() )
     {
       // do not call /user/profile when user just logged out
       getUserInfo();

--- a/core/merginapi.cpp
+++ b/core/merginapi.cpp
@@ -87,7 +87,7 @@ MerginApi::MerginApi( LocalProjectsManager &localProjects, QObject *parent )
   QObject::connect( mUserAuth, &MerginUserAuth::authChanged, this, &MerginApi::authChanged );
   QObject::connect( mUserAuth, &MerginUserAuth::authChanged, this, [this]()
   {
-    if ( !mUserAuth->authToken().isEmpty() && mUserAuth->tokenExpiration() >= QDateTime().currentDateTime().toUTC() )
+    if ( mUserAuth->hasValidToken() )
     {
       // do not call /user/profile when user just logged out
       getUserInfo();

--- a/core/merginuserauth.cpp
+++ b/core/merginuserauth.cpp
@@ -129,3 +129,8 @@ void MerginUserAuth::setTokenExpiration( const QDateTime &tokenExpiration )
   mTokenExpiration = tokenExpiration;
   emit authChanged();
 }
+
+bool MerginUserAuth::hasValidToken() const
+{
+  return !mAuthToken.isEmpty() && mTokenExpiration >= QDateTime().currentDateTimeUtc();
+}

--- a/core/merginuserauth.h
+++ b/core/merginuserauth.h
@@ -30,7 +30,13 @@ class MerginUserAuth: public QObject
     void authChanged();
 
   public:
+    //! Returns true if username/password is set, but that does not
+    //! necessarily mean that we have managed to log in and get a token.
     Q_INVOKABLE bool hasAuthData();
+
+    //! Returns true if we have a token and it is not expired,
+    //! i.e. we should be good to do authenticated requests.
+    bool hasValidToken() const;
 
     void clear();
 


### PR DESCRIPTION
Fixes #3194 / ISS-142

This was caused by the fact we were trying to get user info even when login failed, which in turn triggered another login request, getting into an endless loop. Could be triggered by not having network, or by using a wrong server URL.