### PR TITLE
Fix freeze on start

### DIFF
--- a/app/scalebarkit.cpp
+++ b/app/scalebarkit.cpp
@@ -82,6 +82,9 @@ void ScaleBarKit::updateScaleBar()
     return;
 
   double distInMeters = InputUtils().screenUnitsToMeters( mMapSettings, mPreferredWidth ); // meters
+  if ( std::isnan( distInMeters ) )
+    return;
+
   double dist;
   Qgis::DistanceUnit distUnits;
   InputUtils().humanReadableDistance( distInMeters, Qgis::DistanceUnit::Meters,


### PR DESCRIPTION
I was getting black screen upon app start on linux. It was quite horrible to debug, but in the end this is how it goes:
- at some point during init, when ScaleBarKit::updateScaleBar() tries to figure out good scale bar width, the InputUtils::screenUnitsToMeters() function returns NaN because we're trying to do ellipsoid calculations with bad coordinates
- NaN gets propagated and the scale bar gets width = -2147483600
- ShaderEffectSource used for the blur box gets sourceRect set to -2147483600 and that gets the code stuck somewhere in Quick Scene Graph code forever

Before:
![mm-black-before](https://github.com/MerginMaps/mobile/assets/193367/fad825e0-78c7-49f6-b0e4-f7a97a2c9aec)

After:
![mm-black-after](https://github.com/MerginMaps/mobile/assets/193367/b03f3e35-f272-450a-90d7-c79c6d5b3c16)
