### PR TITLE
Enable map interaction when staking-out

### DIFF
--- a/app/qml/gps/MMStakeoutDrawer.qml
+++ b/app/qml/gps/MMStakeoutDrawer.qml
@@ -79,6 +79,10 @@ MMDrawer {
     ]
   }
 
+  modal: false
+
+  closePolicy: Popup.CloseOnEscape // prevents the drawer closing while moving canvas
+
   dropShadow: true
 
   onClosed: root.endStakeout()


### PR DESCRIPTION
Make Stake out drawer non-modal so the user may interact with the map canvas.
Fixes iss-136