### PR TITLE
rework center to gps

### DIFF
--- a/app/qml/gps/MMStakeoutDrawer.qml
+++ b/app/qml/gps/MMStakeoutDrawer.qml
@@ -35,7 +35,6 @@ MMDrawer {
   readonly property alias panelHeight: root.height
 
   signal panelHeightUpdated()
-  signal autoFollowClicked()
   signal stakeoutFinished()
 
   Component.onCompleted: {

--- a/app/qml/main.qml
+++ b/app/qml/main.qml
@@ -605,7 +605,6 @@ ApplicationWindow {
         stakeoutPanelLoader.active = false
       }
 
-      onAutoFollowClicked: map.autoFollowStakeoutPath()
       onPanelHeightUpdated: map.updatePosition()
     }
   }

--- a/app/qml/map/MMMapCanvas.qml
+++ b/app/qml/map/MMMapCanvas.qml
@@ -47,25 +47,30 @@ Item {
 
     // Disable animation until initial position is set
     jumpAnimator.enabled = false
+    jumpAnimator.startX = oldPosMapCRS.x
+    jumpAnimator.startY = oldPosMapCRS.y
+    jumpAnimator.endX = newPosMapCRS.x
+    jumpAnimator.endY = newPosMapCRS.y
 
-    jumpAnimator.px = oldPosMapCRS.x
-    jumpAnimator.py = oldPosMapCRS.y
-
+    jumpAnimator.percentage = 0
     jumpAnimator.enabled = true
-
-    jumpAnimator.px = newPosMapCRS.x
-    jumpAnimator.py = newPosMapCRS.y
-
+    jumpAnimator.percentage = 100
     rendererPrivate.unfreeze('jumpTo')
   }
 
   Item {
     id: jumpAnimator
 
-    property double px: 0
-    property double py: 0
+    property double startX
+    property double startY
+    property double endX
+    property double endY
+    property double percentage: 0
 
-    Behavior on py {
+    readonly property double azimuth: Math.atan2( startX - endX, startY - endY )
+    readonly property double distance: Math.sqrt( ( startX - endX ) * ( startX - endX ) + ( startY - endY ) * ( startY - endY ) )
+
+    Behavior on percentage {
       SmoothedAnimation {
         duration: 200
         reversingMode: SmoothedAnimation.Immediate
@@ -73,23 +78,11 @@ Item {
       enabled: jumpAnimator.enabled
     }
 
-    Behavior on px {
-      SmoothedAnimation {
-        duration: 200
-        reversingMode: SmoothedAnimation.Immediate
-      }
-      enabled: jumpAnimator.enabled
-    }
-
-    onPxChanged: {
+    onPercentageChanged: {
       if ( enabled ) {
-        mapRenderer.mapSettings.center = mapRenderer.mapSettings.toQgsPoint( Qt.point( px, py ) )
-      }
-    }
-
-    onPyChanged: {
-      if ( enabled ) {
-        mapRenderer.mapSettings.center = mapRenderer.mapSettings.toQgsPoint( Qt.point( px, py ) )
+        let tmpX = startX - percentage * 0.01 * distance * Math.sin( azimuth )
+        let tmpY = startY - percentage * 0.01 * distance * Math.cos( azimuth )
+        mapRenderer.mapSettings.center = mapRenderer.mapSettings.toQgsPoint( Qt.point( tmpX, tmpY ) )
       }
     }
   }

--- a/app/qml/map/MMStakeoutTools.qml
+++ b/app/qml/map/MMStakeoutTools.qml
@@ -35,36 +35,12 @@ Item {
 
     mapSettings: map.mapSettings
     positionKit: __positionKit
-    onScreenPositionChanged: updateStakeout()
-  }
-
-  Connections {
-    target: map
-    function onUserInteractedWithMap() {
-      internal.shouldAutoFollowStakoutPath = false
-    }
+    onMapPositionChanged: updateStakeout()
   }
 
   Component.onCompleted: updateStakeout()
 
-  QtObject {
-    id: internal
-
-    // Determines if canvas is auto centered to stakeout line
-    property bool shouldAutoFollowStakoutPath: true
-
-    onShouldAutoFollowStakoutPathChanged: updateStakeout()
-  }
-
   function updateStakeout() {
-    if ( internal.shouldAutoFollowStakoutPath )
-    {
-      map.mapSettings.extent = __inputUtils.stakeoutPathExtent( mapPositioning, target, map.mapSettings, mapExtentOffset )
-    }
     highlight.geometry = __inputUtils.stakeoutGeometry( mapPositioning.mapPosition, target, map.mapSettings )
-  }
-
-  function autoFollow() {
-    internal.shouldAutoFollowStakoutPath = true
   }
 }


### PR DESCRIPTION
Fixes #3257 

Also fixes:
- Stakeout line is now rendered below cursor
- Jump-to is used when in `view` state and `centerToGPS` is enabled 
- ^ Jump-to is triggered when moving outside the central 20% of the screen
- Jump-to animation is now straight and not split in two axes
- In stakeout mode the gps accuracy and center to gps buttons are visible