### PR TITLE
fix centering when preview panel is opened

### DIFF
--- a/app/inpututils.cpp
+++ b/app/inpututils.cpp
@@ -281,7 +281,7 @@ QPointF InputUtils::geometryCenterToScreenCoordinates( const QgsGeometry &geom, 
 {
   QPointF screenPoint;
 
-  if ( geom.isNull() || !geom.constGet() )
+  if ( !mapSettings || geom.isNull() || !geom.constGet() )
     return screenPoint;
 
   QgsRectangle bbox = geom.boundingBox();

--- a/app/inpututils.cpp
+++ b/app/inpututils.cpp
@@ -277,6 +277,19 @@ void InputUtils::setExtentToFeature( const FeatureLayerPair &pair, InputMapSetti
   mapSettings->setExtent( currentExtent );
 }
 
+QPointF InputUtils::geometryCenterToScreenCoordinates( const QgsGeometry &geom, InputMapSettings *mapSettings )
+{
+  QPointF screenPoint;
+
+  if ( geom.isNull() || !geom.constGet() )
+    return screenPoint;
+
+  QgsRectangle bbox = geom.boundingBox();
+  screenPoint = mapSettings->coordinateToScreen( QgsPoint( bbox.center() ) );
+
+  return screenPoint;
+}
+
 double InputUtils::convertCoordinateString( const QString &rationalValue )
 {
   QStringList values = rationalValue.split( "," );

--- a/app/inpututils.cpp
+++ b/app/inpututils.cpp
@@ -246,7 +246,7 @@ QString InputUtils::formatDateTimeDiff( const QDateTime &tMin, const QDateTime &
   return INVALID_DATETIME_STR;
 }
 
-void InputUtils::setExtentToFeature( const FeatureLayerPair &pair, InputMapSettings *mapSettings, double panelOffsetRatio )
+void InputUtils::setExtentToFeature( const FeatureLayerPair &pair, InputMapSettings *mapSettings )
 {
 
   if ( !mapSettings )
@@ -267,13 +267,12 @@ void InputUtils::setExtentToFeature( const FeatureLayerPair &pair, InputMapSetti
   QgsPointXY currentExtentCenter = currentExtent.center();
   QgsPointXY featureCenter = bbox.center();
 
-  double panelOffset = ( currentExtent.yMaximum() - currentExtent.yMinimum() ) * panelOffsetRatio / 2;
   double offsetX = currentExtentCenter.x() - featureCenter.x();
   double offsetY = currentExtentCenter.y() - featureCenter.y();
   currentExtent.setXMinimum( currentExtent.xMinimum() - offsetX );
   currentExtent.setXMaximum( currentExtent.xMaximum() - offsetX );
-  currentExtent.setYMinimum( currentExtent.yMinimum() - offsetY - panelOffset );
-  currentExtent.setYMaximum( currentExtent.yMaximum() - offsetY - panelOffset );
+  currentExtent.setYMinimum( currentExtent.yMinimum() - offsetY );
+  currentExtent.setYMaximum( currentExtent.yMaximum() - offsetY );
   mapSettings->setExtent( currentExtent );
 }
 

--- a/app/inpututils.h
+++ b/app/inpututils.h
@@ -78,6 +78,12 @@ class InputUtils: public QObject
     Q_INVOKABLE QString formatDistanceInProjectUnit( const double distanceInMeters, int precision = 1, Qgis::DistanceUnit destUnit = Qgis::DistanceUnit::Unknown );
     Q_INVOKABLE void setExtentToFeature( const FeatureLayerPair &pair, InputMapSettings *mapSettings, double panelOffsetRatio );
 
+    /**
+     * Returns the screen coordinates for a geometry's bounding box centroid
+     * Geometry must be in canvas CRS
+     */
+    Q_INVOKABLE QPointF geometryCenterToScreenCoordinates( const QgsGeometry &geom, InputMapSettings *mapSettings );
+
     // utility functions to extract information from map settings
     // (in theory this data should be directly available from .MapTransform
     // but they are not currently, so this is a workaround we need for display of markers)

--- a/app/inpututils.h
+++ b/app/inpututils.h
@@ -76,7 +76,7 @@ class InputUtils: public QObject
     Q_INVOKABLE QString formatProjectName( const QString &fullProjectName );
     Q_INVOKABLE QString formatNumber( const double number, int precision = 1 );
     Q_INVOKABLE QString formatDistanceInProjectUnit( const double distanceInMeters, int precision = 1, Qgis::DistanceUnit destUnit = Qgis::DistanceUnit::Unknown );
-    Q_INVOKABLE void setExtentToFeature( const FeatureLayerPair &pair, InputMapSettings *mapSettings, double panelOffsetRatio );
+    Q_INVOKABLE void setExtentToFeature( const FeatureLayerPair &pair, InputMapSettings *mapSettings );
 
     /**
      * Returns the screen coordinates for a geometry's bounding box centroid

--- a/app/qml/form/MMFormController.qml
+++ b/app/qml/form/MMFormController.qml
@@ -43,6 +43,7 @@ Item {
   signal openLinkedFeature( var linkedFeature )
   signal createLinkedFeature( var targetLayer, var parentPair )
   signal stakeoutFeature( var feature )
+  signal previewPanelChanged( var panelHeight )
 
   function openDrawer() {
     root.panelState = "form"
@@ -102,6 +103,7 @@ Item {
       }
     }
 
+    // this animation handles the transition from preview to form and different preview sizes
     Behavior on height {
       PropertyAnimation { properties: "height"; easing.type: Easing.InOutQuad }
     }
@@ -129,6 +131,11 @@ Item {
     edge: Qt.BottomEdge
     closePolicy: Popup.CloseOnEscape // prevents the drawer closing while moving canvas
 
+    onOpened: {
+      if ( panelState === "preview" )
+        previewPanelChanged( previewPanel.implicitHeight )
+    }
+
     onClosed: {
       if ( statesManager.state !== "hidden" )
         statesManager.state = "closed"
@@ -154,6 +161,10 @@ Item {
       }
 
       onCloseClicked: drawer.close()
+
+      onImplicitHeightChanged: {
+        previewPanelChanged( previewPanel.implicitHeight )
+      }
     }
 
     MMFormPage {
@@ -210,5 +221,10 @@ Item {
         }
       }
     }
+  }
+
+  onFeatureLayerPairChanged: {
+    if ( panelState === "preview" )
+      previewPanelChanged( previewPanel.implicitHeight )
   }
 }

--- a/app/qml/form/MMFormStackController.qml
+++ b/app/qml/form/MMFormStackController.qml
@@ -51,7 +51,8 @@ Item {
   signal closed()
   signal editGeometryRequested( var pair )
   signal createLinkedFeatureRequested( var targetLayer, var parentPair )
-  signal stakeoutFeature( var feature );
+  signal stakeoutFeature( var feature )
+  signal previewPanelChanged( var panelHeight )
 
   function openForm( pair, formState, panelState ) {
     if ( formsStack.depth === 0 )
@@ -282,6 +283,11 @@ Item {
           formsStack.popOneOrClose()
         }
       }
+
+      onPreviewPanelChanged: function( panelHeight ) {
+        root.previewPanelChanged( panelHeight )
+      }
+
       onEditGeometry: function( pair ) {
         root.editGeometryRequested( pair )
       }

--- a/app/qml/main.qml
+++ b/app/qml/main.qml
@@ -106,7 +106,7 @@ ApplicationWindow {
       formsStackManager.openForm( pair, "readOnly", "form" )
     }
     else if ( pair.valid ) {
-      map.select( pair )
+      map.highlightPair( pair )
       formsStackManager.openForm( pair, "readOnly", "preview")
     }
   }
@@ -663,6 +663,10 @@ ApplicationWindow {
 
       map.stakeout( feature )
       closeDrawer()
+    }
+
+    onPreviewPanelChanged: function( panelHeight ) {
+      map.jumpToHighlighted( panelHeight - mapToolbar.height )
     }
   }
 

--- a/app/qml/map/MMMapCanvas.qml
+++ b/app/qml/map/MMMapCanvas.qml
@@ -71,9 +71,9 @@ Item {
     readonly property double distance: Math.sqrt( ( startX - endX ) * ( startX - endX ) + ( startY - endY ) * ( startY - endY ) )
 
     Behavior on percentage {
-      SmoothedAnimation {
-        duration: 200
-        reversingMode: SmoothedAnimation.Immediate
+      NumberAnimation {
+        easing.type: Easing.OutQuart
+        duration: 500
       }
       enabled: jumpAnimator.enabled
     }

--- a/app/qml/map/MMMapController.qml
+++ b/app/qml/map/MMMapController.qml
@@ -1188,6 +1188,8 @@ Item {
       }
 
       case "view": {
+        // While a feature is highlighted we want to keep it visible in the map extent
+        // so in that case we skip centering to position
         if ( identifyHighlight.geometry !== null )
         {
           break

--- a/app/qml/map/MMMapController.qml
+++ b/app/qml/map/MMMapController.qml
@@ -202,7 +202,7 @@ Item {
 
         if ( pair.valid )
         {
-          root.select( pair )
+          root.highlightPair( pair )
           root.featureIdentified( pair )
         }
         else
@@ -1048,11 +1048,6 @@ Item {
     }
   }
 
-  function select( featurepair ) {
-    root.centerToPair( featurepair, true )
-    root.highlightPair( featurepair )
-  }
-
   function record() {
     state = "record"
   }
@@ -1134,6 +1129,15 @@ Item {
     __inputUtils.setExtentToFeature( pair, mapCanvas.mapSettings, mapExtentOffsetRatio )
   }
 
+  function jumpToHighlighted( mapOffset ) {
+    if ( identifyHighlight.geometry === null )
+      return
+
+    let screenPt = __inputUtils.geometryCenterToScreenCoordinates( identifyHighlight.geometry, mapCanvas.mapSettings )
+    screenPt.y += mapOffset / 2
+    mapCanvas.jumpTo( screenPt )
+  }
+
   function highlightPair( pair ) {
     let geometry = __inputUtils.extractGeometry( pair )
     identifyHighlight.geometry = __inputUtils.transformGeometryToMapWithLayer( geometry, pair.layer, mapCanvas.mapSettings )
@@ -1141,6 +1145,7 @@ Item {
 
   function hideHighlight() {
     identifyHighlight.geometry = null
+    updatePosition()
   }
 
   function centerToPosition( animate = false ) {
@@ -1183,6 +1188,11 @@ Item {
       }
 
       case "view": {
+        if ( identifyHighlight.geometry !== null )
+        {
+          break
+        }
+
         if ( root.isPositionOutOfExtent() )
         {
           root.centerToPosition( true )

--- a/app/qml/map/MMMapController.qml
+++ b/app/qml/map/MMMapController.qml
@@ -1120,13 +1120,8 @@ Item {
     root.centeredToGPS = internal.centeredToGPSBeforeStakeout
   }
 
-  function centerToPair( pair, considerMapExtentOffset = false ) {
-    if ( considerMapExtentOffset )
-      var mapExtentOffsetRatio = mapExtentOffset / mapCanvas.height
-    else
-      mapExtentOffsetRatio = 0
-
-    __inputUtils.setExtentToFeature( pair, mapCanvas.mapSettings, mapExtentOffsetRatio )
+  function centerToPair( pair ) {
+    __inputUtils.setExtentToFeature( pair, mapCanvas.mapSettings )
   }
 
   function jumpToHighlighted( mapOffset ) {


### PR DESCRIPTION
Fixes #3260

- Preview panel height is taken into account when centering to the identified feature
- Animation is used while centering
- If _follow gps_ was enabled, map pans back to gps position after closing the preview panel