### PR TITLE
Fix download button

### DIFF
--- a/app/qml/project/components/MMProjectDelegate.qml
+++ b/app/qml/project/components/MMProjectDelegate.qml
@@ -146,6 +146,8 @@ Control {
           iconSource: root.state === "OnServer" ? __style.downloadIcon : __style.moreVerticalIcon
           bgndColor: root.projectIsOpened ? __style.polarColor : __style.lightGreenColor
 
+          visible: !(root.state === "OnServer" && root.projectIsInSync)
+
           onClicked: {
             if ( internal.hasMoreMenu ) {
               moreMenuLoader.active = true


### PR DESCRIPTION
Fixes #3206

Do not show download button while download is in progress... Debug build would crash on assert anyway.
This fixes the problem (1) and it should not be possible to get problems (2) and (3) anymore

https://github.com/MerginMaps/mobile/assets/193367/cc6042ec-732e-46e4-92db-1c4a8087831e

