### PR TITLE
define QT_QML_DEBUG instead of manually instantiating debugging helper

### DIFF
--- a/app/CMakeLists.txt
+++ b/app/CMakeLists.txt
@@ -537,6 +537,10 @@ endif ()
 # QML
 # ########################################################################################
 
+target_compile_definitions(
+  Input PRIVATE $<$<OR:$<CONFIG:Debug>,$<CONFIG:RelWithDebInfo>>:QT_QML_DEBUG>
+)
+
 add_subdirectory(qml)
 
 # register Singleton TODO REMOVE!

--- a/app/main.cpp
+++ b/app/main.cpp
@@ -134,10 +134,6 @@
 
 #include <QQuickStyle>
 
-#ifdef QT_DEBUG
-#include <QQmlDebuggingEnabler>
-#endif
-
 #ifdef MOBILE_OS
 #include <QFile>
 #include <QDir>
@@ -391,9 +387,6 @@ int main( int argc, char *argv[] )
   QCoreApplication::setApplicationName( "Input" ); // used by QSettings
   QCoreApplication::setApplicationVersion( version );
 
-#ifdef QT_DEBUG
-  QQmlDebuggingEnabler enabler;
-#endif
 
 #ifdef INPUT_TEST
   InputTests tests;

--- a/gallery/CMakeLists.txt
+++ b/gallery/CMakeLists.txt
@@ -97,7 +97,9 @@ set_target_properties(
 target_link_libraries(MerginMapsGallery PRIVATE Qt6::Quick Qt6::Multimedia)
 target_include_directories(MerginMapsGallery PRIVATE ${CMAKE_SOURCE_DIR} ../app ../core)
 target_compile_definitions(
-  MerginMapsGallery PRIVATE GALLERY_SOURCE_DIR="${CMAKE_SOURCE_DIR}"
+  MerginMapsGallery
+  PRIVATE GALLERY_SOURCE_DIR="${CMAKE_SOURCE_DIR}"
+  PRIVATE $<$<OR:$<CONFIG:Debug>,$<CONFIG:RelWithDebInfo>>:QT_QML_DEBUG>
 )
 
 install(

--- a/gallery/main.cpp
+++ b/gallery/main.cpp
@@ -10,9 +10,6 @@
 #include <QGuiApplication>
 #include <QQmlApplicationEngine>
 #include <QQmlContext>
-#ifdef QT_DEBUG
-#include <QQmlDebuggingEnabler>
-#endif
 #ifdef DESKTOP_OS
 #include "hotreload.h"
 #endif
@@ -44,10 +41,6 @@ int main( int argc, char *argv[] )
   InputUtils iu;
 
   QQmlApplicationEngine engine;
-
-#ifdef QT_DEBUG
-  QQmlDebuggingEnabler enabler;
-#endif
 
   // Register C++ enums
   qmlRegisterUncreatableType<RegistrationError>( "mm", 1, 0, "RegistrationError", "RegistrationError Enum" );


### PR DESCRIPTION
Apparently you only need to define QT_QML_DEBUG for qml debugging to work.

Fixes #3303