### PR TITLE
Fix photo editor

### DIFF
--- a/app/qml/components/MMPhotoPreview.qml
+++ b/app/qml/components/MMPhotoPreview.qml
@@ -38,7 +38,7 @@ Popup {
 
       height: root.height / 2
 
-      autoTransform: true;
+      autoTransform: true
       focus: true
       asynchronous: true
       fillMode: Image.PreserveAspectFit

--- a/app/qml/dialogs/MMRemovePhotoDialog.qml
+++ b/app/qml/dialogs/MMRemovePhotoDialog.qml
@@ -15,23 +15,30 @@ MMDrawerDialog {
   id: root
 
   signal deleteImage()
-  signal keepImage()
+  signal unlinkImage()
 
   property string imagePath
 
   imageSource: __style.negativeMMSymbolImage
-  title: qsTr( "Remove photo reference" )
-  description: qsTr( "Also permanently delete photo from device?" )
-  primaryButton.text: qsTr( "Yes, I want to delete" )
-  secondaryButton.text: qsTr( "No, thanks" )
+  title: qsTr( "Delete photo?" )
+  description: qsTr( "Would you like to delete or unlink the photo? Deleting removes the photo from your project entirely, while unlinking keeps the photo in your project but removes it from this specific feature." )
 
-  onPrimaryButtonClicked: {
-    root.deleteImage()
-    close()
+  primaryButton {
+    text: qsTr( "Delete photo" )
+
+    fontColor: __style.grapeColor
+    bgndColor: __style.negativeColor
+    fontColorHover: __style.negativeColor
+    bgndColorHover: __style.grapeColor
   }
 
-  onSecondaryButtonClicked: {
-    root.keepImage()
-    close()
+  secondaryButton {
+    text: qsTr( "Unlink photo" )
+
+    fontColor: __style.grapeColor
+    fontColorHover: __style.negativeColor
   }
+
+  onPrimaryButtonClicked: root.deleteImage()
+  onSecondaryButtonClicked: root.unlinkImage()
 }

--- a/app/qml/form/editors/MMFormPhotoEditor.qml
+++ b/app/qml/form/editors/MMFormPhotoEditor.qml
@@ -203,7 +203,7 @@ MMFormPhotoViewer {
     function calculateAbsoluteImagePath() {
       let absolutePath = __inputUtils.getAbsolutePath( root._fieldValue, internal.prefixToRelativePath )
 
-      if ( root.photoComponent.status === Image.Error ) { // <--- this looks dodgy to calculate it from the image.status
+      if ( root.photoComponent.status === Image.Error ) {
         root.state = "notAvailable"
         absoluteImagePath = ""
         return
@@ -279,7 +279,7 @@ MMFormPhotoViewer {
         imageDeleteDialog.open()
       }
       else {
-        root.editorValueChanged( "", false )
+        root.editorValueChanged( "", true )
       }
     }
 

--- a/app/qml/form/editors/MMFormPhotoEditor.qml
+++ b/app/qml/form/editors/MMFormPhotoEditor.qml
@@ -118,11 +118,18 @@ MMFormPhotoViewer {
     property string imagePath
 
     onDeleteImage: {
+      // schedule the image for deletion
       internal.imageSourceToDelete = imageDeleteDialog.imagePath
-      root.editorValueChanged( "", false ) // Shouldn't this be true?
+      resetValueAndClose()
     }
-    onKeepImage: {
-      root.editorValueChanged( "", false ) // Shouldn't this be true?
+
+    onUnlinkImage: resetValueAndClose()
+
+    function resetValueAndClose() {
+      root.editorValueChanged( "", true )
+
+      imagePath = ""
+      close()
     }
   }
 

--- a/app/qml/form/editors/MMFormPhotoEditor.qml
+++ b/app/qml/form/editors/MMFormPhotoEditor.qml
@@ -148,6 +148,17 @@ MMFormPhotoViewer {
     }
   }
 
+  function callbackOnFormSaved() {
+    if ( internal.imageSourceToDelete ) {
+      __inputUtils.removeFile( internal.imageSourceToDelete )
+      internal.imageSourceToDelete = ""
+    }
+  }
+
+  function callbackOnFormCanceled() {
+    internal.imageSourceToDelete = ""
+  }
+
   QtObject {
     id: internal
     //! This object is a combination of previous "ExternalResourceBundle" and some functions from "inputexternalresource" editor
@@ -181,15 +192,6 @@ MMFormPhotoViewer {
     property string absoluteImagePath
 
     property string imageSourceToDelete // used to postpone image deletion to when the form is saved
-
-    function callbackOnFormSaved() {
-      __inputUtils.removeFile( imageSourceToDelete )
-      imageSourceToDelete = ""
-    }
-
-    function callbackOnFormCanceled() {
-      imageSourceToDelete = ""
-    }
 
     function calculateAbsoluteImagePath() {
       let absolutePath = __inputUtils.getAbsolutePath( root._fieldValue, internal.prefixToRelativePath )

--- a/app/qml/form/editors/MMFormPhotoViewer.qml
+++ b/app/qml/form/editors/MMFormPhotoViewer.qml
@@ -23,11 +23,6 @@ import "../../inputs"
 MMBaseInput {
   id: root
 
-  // TODO:
-  // - handle "photo notAvailable" state
-  // - handle empty state - add "capture photo" and "choose from gallery" signals
-  // - scale images well - based on the root.size
-
   property url photoUrl: ""
   property bool hasCameraCapability: true
 
@@ -92,7 +87,7 @@ MMBaseInput {
         bgndColor: __style.negativeColor
         iconSource: __style.deleteIcon
         iconColor: __style.grapeColor
-        visible: root.allowEditing && photo.status === Image.Ready
+        visible: root.allowEditing && root.state !== "notSet"
         onClicked: root.trashClicked()
       }
     }


### PR DESCRIPTION
Fixes multiple issues with the photo editor:
 - show trash icon even when the image is not available (previously it showed the icon only when the Image was loaded successfully)
 - update the text of the `MMRemovePhotoDialog` to better represent what it does
 - photos were not removed from the project even if the `Delete photo` was selected. The issue was that the callback function `onFormSaved` was placed in the private `QtObject` and thus could not be called from the form
 - we used to call `root.editorValueChanged( "", false )` where the boolean value represents if the new value is null. We were passing `false` even when removing the photo. Changed it to `true`.

<img width="400" alt="Screenshot 2024-04-12 at 13 12 41" src="https://github.com/MerginMaps/mobile/assets/22449698/368462c6-665d-4b28-a601-491ef59c0a25">
