### PR TITLE
Fix logic of how the "N more" is calculated in relation editor

### DIFF
--- a/app/qml/form/editors/MMFormRelationEditor.qml
+++ b/app/qml/form/editors/MMFormRelationEditor.qml
@@ -40,8 +40,8 @@ MMInputs.MMBaseInput {
 
   contentItemHeight: privates.itemHeight * privates.rows + 2 * flow.spacing + 20 * __dp
 
-  Component.onCompleted: root.recalculate()
-  onWidthChanged: root.recalculate()
+  Component.onCompleted: root.recalculateVisibleItems()
+  onWidthChanged: root.recalculateVisibleItems()
 
   title: _fieldShouldShowTitle ? _fieldTitle : ""
 
@@ -93,7 +93,10 @@ MMInputs.MMBaseInput {
             // Repeater does not necesarry clear delegates immediately if they are invisible,
             // we need to do hard reload in this case so that recalculateVisibleItems() is triggered
 
-            root.recalculate()
+            repeater.model = null
+            repeater.model = rmodel
+
+            root.recalculateVisibleItems()
           }
         }
 
@@ -120,11 +123,7 @@ MMInputs.MMBaseInput {
             onClicked: root.openLinkedFeature( model.FeaturePair )
           }
 
-          onVisibleChanged: {
-            if(!visible) {
-              repeater.invisibleIds++
-            }
-          }
+          onVisibleChanged: root.recalculateVisibleItems()
         }
       }
 
@@ -161,10 +160,17 @@ MMInputs.MMBaseInput {
     }
   }
 
-  function recalculate() {
-    repeater.invisibleIds = 0
-    repeater.model = null
-    repeater.model = rmodel
+  function recalculateVisibleItems() {
+    let invisibles_count = 0
+
+    for ( let i = 0; i < repeater.count; i++ ) {
+      let delegate_i = repeater.itemAt( i )
+      if ( delegate_i && !delegate_i.visible ) {
+        invisibles_count++
+      }
+    }
+
+    repeater.invisibleIds = invisibles_count
   }
 
   Loader {


### PR DESCRIPTION
Fixes #3242

This pretty much reverts the logic to use what we had before e4b5d28a2. The updated logic with counting of items made invisible was more efficient in theory, but fragile in reality :slightly_smiling_face: 

The relation editor is probably quite prone to slowness if there are many related features, because Repeater may create many items even if they end up hidden and we may do many recalculations of number of hidden items. It may be a good idea to implement a custom "flow relation features" model, that would be aware of the flow parameters (number of rows, font metrics, spacing etc.) so that 1. we would only create few items even for large relations, 2. all layout logic would be in one place (and testable)