### PR TITLE
Don't emit networkErrorOccurred when cancelling operations

### DIFF
--- a/core/merginapi.cpp
+++ b/core/merginapi.cpp
@@ -38,6 +38,7 @@ const QSet<QString> MerginApi::sIgnoreExtensions = QSet<QString>() << "gpkg-shm"
 const QSet<QString> MerginApi::sIgnoreImageExtensions = QSet<QString>() << "jpg" << "jpeg" << "png";
 const QSet<QString> MerginApi::sIgnoreFiles = QSet<QString>() << "mergin.json" << ".DS_Store";
 const int MerginApi::UPLOAD_CHUNK_SIZE = 10 * 1024 * 1024; // Should be the same as on Mergin server
+const QString MerginApi::sSyncCanceledMessage = QObject::tr( "Synchronisation canceled" );
 
 
 MerginApi::MerginApi( LocalProjectsManager &localProjects, QObject *parent )
@@ -431,7 +432,7 @@ void MerginApi::downloadItemReplyFinished()
     if ( serverMsg.isEmpty() )
     {
       if ( r->error() == QNetworkReply::OperationCanceledError )
-        serverMsg = tr( "Synchronisation canceled" );
+        serverMsg = sSyncCanceledMessage;
       else
         serverMsg = r->errorString();
     }
@@ -2106,7 +2107,7 @@ void MerginApi::pushStartReplyFinished()
     QByteArray data = r->readAll();
     QString serverMsg = extractServerErrorMsg( data );
     if ( r->error() == QNetworkReply::OperationCanceledError )
-      serverMsg = tr( "Synchronisation canceled" );
+      serverMsg = sSyncCanceledMessage;
 
     QString code = extractServerErrorCode( data );
     bool showLimitReachedDialog = EnumHelper::isEqual( code, ErrorCode::StorageLimitHit );
@@ -2196,7 +2197,7 @@ void MerginApi::pushFileReplyFinished()
   {
     QString serverMsg = extractServerErrorMsg( r->readAll() );
     if ( r->error() == QNetworkReply::OperationCanceledError )
-      serverMsg = tr( "Synchronisation canceled" );
+      serverMsg = sSyncCanceledMessage;
 
     CoreUtils::log( "push " + projectFullName, QStringLiteral( "FAILED - %1. %2" ).arg( r->errorString(), serverMsg ) );
 
@@ -2235,7 +2236,7 @@ void MerginApi::pullInfoReplyFinished()
   {
     QString serverMsg = extractServerErrorMsg( r->readAll() );
     if ( r->error() == QNetworkReply::OperationCanceledError )
-      serverMsg = tr( "Synchronisation canceled" );
+      serverMsg = sSyncCanceledMessage;
 
     QString message = QStringLiteral( "Network API error: %1(): %2" ).arg( QStringLiteral( "projectInfo" ), r->errorString() );
     CoreUtils::log( "pull " + projectFullName, QStringLiteral( "FAILED - %1" ).arg( message ) );
@@ -2759,7 +2760,7 @@ void MerginApi::pushInfoReplyFinished()
   {
     QString serverMsg = extractServerErrorMsg( r->readAll() );
     if ( r->error() == QNetworkReply::OperationCanceledError )
-      serverMsg = tr( "Synchronisation canceled" );
+      serverMsg = sSyncCanceledMessage;
 
     QString message = QStringLiteral( "Network API error: %1(): %2" ).arg( QStringLiteral( "projectInfo" ), r->errorString() );
     CoreUtils::log( "push " + projectFullName, QStringLiteral( "FAILED - %1" ).arg( message ) );
@@ -2842,7 +2843,7 @@ void MerginApi::pushFinishReplyFinished()
   {
     QString serverMsg = extractServerErrorMsg( r->readAll() );
     if ( r->error() == QNetworkReply::OperationCanceledError )
-      serverMsg = tr( "Synchronisation canceled" );
+      serverMsg = sSyncCanceledMessage;
 
     QString message = QStringLiteral( "Network API error: %1(): %2. %3" ).arg( QStringLiteral( "pushFinish" ), r->errorString(), serverMsg );
     CoreUtils::log( "push " + projectFullName, QStringLiteral( "FAILED - %1" ).arg( message ) );

--- a/core/merginapi.cpp
+++ b/core/merginapi.cpp
@@ -442,9 +442,16 @@ void MerginApi::downloadItemReplyFinished()
       // the first failed request will abort all the other pending requests too, and finish pull with error
       abortPullItems( projectFullName );
 
-      // signal a networking error - we may retry
-      int httpCode = r->attribute( QNetworkRequest::HttpStatusCodeAttribute ).toInt();
-      emit networkErrorOccurred( serverMsg, QStringLiteral( "Mergin API error: downloadFile" ), httpCode, projectFullName );
+      if ( r->error() == QNetworkReply::OperationCanceledError )
+      {
+        // user cancelled, do not emit
+      }
+      else
+      {
+        // signal a networking error - we may retry
+        int httpCode = r->attribute( QNetworkRequest::HttpStatusCodeAttribute ).toInt();
+        emit networkErrorOccurred( serverMsg, QStringLiteral( "Mergin API error: downloadFile" ), httpCode, projectFullName );
+      }
     }
     else
     {
@@ -2130,6 +2137,10 @@ void MerginApi::pushStartReplyFinished()
         deleteProject( projectNamespace, projectName, false );
       }
     }
+    else if ( r->error() == QNetworkReply::OperationCanceledError )
+    {
+      // user cancelled, do not emit
+    }
     else
     {
       int httpCode = r->attribute( QNetworkRequest::HttpStatusCodeAttribute ).toInt();
@@ -2191,8 +2202,15 @@ void MerginApi::pushFileReplyFinished()
     QString serverMsg = extractServerErrorMsg( r->readAll() );
     CoreUtils::log( "push " + projectFullName, QStringLiteral( "FAILED - %1. %2" ).arg( r->errorString(), serverMsg ) );
 
-    int httpCode = r->attribute( QNetworkRequest::HttpStatusCodeAttribute ).toInt();
-    emit networkErrorOccurred( serverMsg, QStringLiteral( "Mergin API error: pushFile" ), httpCode, projectFullName );
+    if ( r->error() == QNetworkReply::OperationCanceledError )
+    {
+      // user cancelled, do not emit
+    }
+    else
+    {
+      int httpCode = r->attribute( QNetworkRequest::HttpStatusCodeAttribute ).toInt();
+      emit networkErrorOccurred( serverMsg, QStringLiteral( "Mergin API error: pushFile" ), httpCode, projectFullName );
+    }
 
     transaction.replyPushFile->deleteLater();
     transaction.replyPushFile = nullptr;
@@ -2228,8 +2246,15 @@ void MerginApi::pullInfoReplyFinished()
     QString message = QStringLiteral( "Network API error: %1(): %2" ).arg( QStringLiteral( "projectInfo" ), r->errorString() );
     CoreUtils::log( "pull " + projectFullName, QStringLiteral( "FAILED - %1" ).arg( message ) );
 
-    int httpCode = r->attribute( QNetworkRequest::HttpStatusCodeAttribute ).toInt();
-    emit networkErrorOccurred( serverMsg, QStringLiteral( "Mergin API error: pullInfo" ), httpCode, projectFullName );
+    if ( r->error() == QNetworkReply::OperationCanceledError )
+    {
+      // user cancelled, do not emit
+    }
+    else
+    {
+      int httpCode = r->attribute( QNetworkRequest::HttpStatusCodeAttribute ).toInt();
+      emit networkErrorOccurred( serverMsg, QStringLiteral( "Mergin API error: pullInfo" ), httpCode, projectFullName );
+    }
 
     transaction.replyPullProjectInfo->deleteLater();
     transaction.replyPullProjectInfo = nullptr;
@@ -2749,8 +2774,15 @@ void MerginApi::pushInfoReplyFinished()
     QString message = QStringLiteral( "Network API error: %1(): %2" ).arg( QStringLiteral( "projectInfo" ), r->errorString() );
     CoreUtils::log( "push " + projectFullName, QStringLiteral( "FAILED - %1" ).arg( message ) );
 
-    int httpCode = r->attribute( QNetworkRequest::HttpStatusCodeAttribute ).toInt();
-    emit networkErrorOccurred( serverMsg, QStringLiteral( "Mergin API error: pushInfo" ), httpCode, projectFullName );
+    if ( r->error() == QNetworkReply::OperationCanceledError )
+    {
+      // user cancelled, do not emit
+    }
+    else
+    {
+      int httpCode = r->attribute( QNetworkRequest::HttpStatusCodeAttribute ).toInt();
+      emit networkErrorOccurred( serverMsg, QStringLiteral( "Mergin API error: pushInfo" ), httpCode, projectFullName );
+    }
 
     transaction.replyPushProjectInfo->deleteLater();
     transaction.replyPushProjectInfo = nullptr;
@@ -2829,8 +2861,15 @@ void MerginApi::pushFinishReplyFinished()
     QString message = QStringLiteral( "Network API error: %1(): %2. %3" ).arg( QStringLiteral( "pushFinish" ), r->errorString(), serverMsg );
     CoreUtils::log( "push " + projectFullName, QStringLiteral( "FAILED - %1" ).arg( message ) );
 
-    int httpCode = r->attribute( QNetworkRequest::HttpStatusCodeAttribute ).toInt();
-    emit networkErrorOccurred( serverMsg, QStringLiteral( "Mergin API error: pushFinish" ), httpCode, projectFullName );
+    if ( r->error() == QNetworkReply::OperationCanceledError )
+    {
+      // user cancelled, do not emit
+    }
+    else
+    {
+      int httpCode = r->attribute( QNetworkRequest::HttpStatusCodeAttribute ).toInt();
+      emit networkErrorOccurred( serverMsg, QStringLiteral( "Mergin API error: pushFinish" ), httpCode, projectFullName );
+    }
 
     // remove temporary diff files
     const auto diffFiles = transaction.pushDiffFiles;

--- a/core/merginapi.cpp
+++ b/core/merginapi.cpp
@@ -430,7 +430,10 @@ void MerginApi::downloadItemReplyFinished()
     QString serverMsg = extractServerErrorMsg( r->readAll() );
     if ( serverMsg.isEmpty() )
     {
-      serverMsg = r->errorString();
+      if ( r->error() == QNetworkReply::OperationCanceledError )
+        serverMsg = tr( "Synchronisation canceled" );
+      else
+        serverMsg = r->errorString();
     }
     CoreUtils::log( "pull " + projectFullName, QStringLiteral( "FAILED - %1. %2" ).arg( r->errorString(), serverMsg ) );
 
@@ -442,16 +445,9 @@ void MerginApi::downloadItemReplyFinished()
       // the first failed request will abort all the other pending requests too, and finish pull with error
       abortPullItems( projectFullName );
 
-      if ( r->error() == QNetworkReply::OperationCanceledError )
-      {
-        // user cancelled, do not emit
-      }
-      else
-      {
-        // signal a networking error - we may retry
-        int httpCode = r->attribute( QNetworkRequest::HttpStatusCodeAttribute ).toInt();
-        emit networkErrorOccurred( serverMsg, QStringLiteral( "Mergin API error: downloadFile" ), httpCode, projectFullName );
-      }
+      // signal a networking error - we may retry
+      int httpCode = r->attribute( QNetworkRequest::HttpStatusCodeAttribute ).toInt();
+      emit networkErrorOccurred( serverMsg, QStringLiteral( "Mergin API error: downloadFile" ), httpCode, projectFullName );
     }
     else
     {
@@ -2109,6 +2105,9 @@ void MerginApi::pushStartReplyFinished()
   {
     QByteArray data = r->readAll();
     QString serverMsg = extractServerErrorMsg( data );
+    if ( r->error() == QNetworkReply::OperationCanceledError )
+      serverMsg = tr( "Synchronisation canceled" );
+
     QString code = extractServerErrorCode( data );
     bool showLimitReachedDialog = EnumHelper::isEqual( code, ErrorCode::StorageLimitHit );
 
@@ -2136,10 +2135,6 @@ void MerginApi::pushStartReplyFinished()
         detachProjectFromMergin( projectNamespace, projectName, false );
         deleteProject( projectNamespace, projectName, false );
       }
-    }
-    else if ( r->error() == QNetworkReply::OperationCanceledError )
-    {
-      // user cancelled, do not emit
     }
     else
     {
@@ -2200,17 +2195,13 @@ void MerginApi::pushFileReplyFinished()
   else
   {
     QString serverMsg = extractServerErrorMsg( r->readAll() );
+    if ( r->error() == QNetworkReply::OperationCanceledError )
+      serverMsg = tr( "Synchronisation canceled" );
+
     CoreUtils::log( "push " + projectFullName, QStringLiteral( "FAILED - %1. %2" ).arg( r->errorString(), serverMsg ) );
 
-    if ( r->error() == QNetworkReply::OperationCanceledError )
-    {
-      // user cancelled, do not emit
-    }
-    else
-    {
-      int httpCode = r->attribute( QNetworkRequest::HttpStatusCodeAttribute ).toInt();
-      emit networkErrorOccurred( serverMsg, QStringLiteral( "Mergin API error: pushFile" ), httpCode, projectFullName );
-    }
+    int httpCode = r->attribute( QNetworkRequest::HttpStatusCodeAttribute ).toInt();
+    emit networkErrorOccurred( serverMsg, QStringLiteral( "Mergin API error: pushFile" ), httpCode, projectFullName );
 
     transaction.replyPushFile->deleteLater();
     transaction.replyPushFile = nullptr;
@@ -2243,18 +2234,14 @@ void MerginApi::pullInfoReplyFinished()
   else
   {
     QString serverMsg = extractServerErrorMsg( r->readAll() );
+    if ( r->error() == QNetworkReply::OperationCanceledError )
+      serverMsg = tr( "Synchronisation canceled" );
+
     QString message = QStringLiteral( "Network API error: %1(): %2" ).arg( QStringLiteral( "projectInfo" ), r->errorString() );
     CoreUtils::log( "pull " + projectFullName, QStringLiteral( "FAILED - %1" ).arg( message ) );
 
-    if ( r->error() == QNetworkReply::OperationCanceledError )
-    {
-      // user cancelled, do not emit
-    }
-    else
-    {
-      int httpCode = r->attribute( QNetworkRequest::HttpStatusCodeAttribute ).toInt();
-      emit networkErrorOccurred( serverMsg, QStringLiteral( "Mergin API error: pullInfo" ), httpCode, projectFullName );
-    }
+    int httpCode = r->attribute( QNetworkRequest::HttpStatusCodeAttribute ).toInt();
+    emit networkErrorOccurred( serverMsg, QStringLiteral( "Mergin API error: pullInfo" ), httpCode, projectFullName );
 
     transaction.replyPullProjectInfo->deleteLater();
     transaction.replyPullProjectInfo = nullptr;
@@ -2771,18 +2758,14 @@ void MerginApi::pushInfoReplyFinished()
   else
   {
     QString serverMsg = extractServerErrorMsg( r->readAll() );
+    if ( r->error() == QNetworkReply::OperationCanceledError )
+      serverMsg = tr( "Synchronisation canceled" );
+
     QString message = QStringLiteral( "Network API error: %1(): %2" ).arg( QStringLiteral( "projectInfo" ), r->errorString() );
     CoreUtils::log( "push " + projectFullName, QStringLiteral( "FAILED - %1" ).arg( message ) );
 
-    if ( r->error() == QNetworkReply::OperationCanceledError )
-    {
-      // user cancelled, do not emit
-    }
-    else
-    {
-      int httpCode = r->attribute( QNetworkRequest::HttpStatusCodeAttribute ).toInt();
-      emit networkErrorOccurred( serverMsg, QStringLiteral( "Mergin API error: pushInfo" ), httpCode, projectFullName );
-    }
+    int httpCode = r->attribute( QNetworkRequest::HttpStatusCodeAttribute ).toInt();
+    emit networkErrorOccurred( serverMsg, QStringLiteral( "Mergin API error: pushInfo" ), httpCode, projectFullName );
 
     transaction.replyPushProjectInfo->deleteLater();
     transaction.replyPushProjectInfo = nullptr;
@@ -2858,18 +2841,14 @@ void MerginApi::pushFinishReplyFinished()
   else
   {
     QString serverMsg = extractServerErrorMsg( r->readAll() );
+    if ( r->error() == QNetworkReply::OperationCanceledError )
+      serverMsg = tr( "Synchronisation canceled" );
+
     QString message = QStringLiteral( "Network API error: %1(): %2. %3" ).arg( QStringLiteral( "pushFinish" ), r->errorString(), serverMsg );
     CoreUtils::log( "push " + projectFullName, QStringLiteral( "FAILED - %1" ).arg( message ) );
 
-    if ( r->error() == QNetworkReply::OperationCanceledError )
-    {
-      // user cancelled, do not emit
-    }
-    else
-    {
-      int httpCode = r->attribute( QNetworkRequest::HttpStatusCodeAttribute ).toInt();
-      emit networkErrorOccurred( serverMsg, QStringLiteral( "Mergin API error: pushFinish" ), httpCode, projectFullName );
-    }
+    int httpCode = r->attribute( QNetworkRequest::HttpStatusCodeAttribute ).toInt();
+    emit networkErrorOccurred( serverMsg, QStringLiteral( "Mergin API error: pushFinish" ), httpCode, projectFullName );
 
     // remove temporary diff files
     const auto diffFiles = transaction.pushDiffFiles;

--- a/core/merginapi.h
+++ b/core/merginapi.h
@@ -374,6 +374,7 @@ class MerginApi: public QObject
     static const QString sMerginConfigFile;
     static const QString sMarketingPageRoot;
     static const QString sDefaultApiRoot;
+    static const QString sSyncCanceledMessage;
 
     static QString defaultApiRoot() { return sDefaultApiRoot; }
 


### PR DESCRIPTION
Partially fixes #3217 : 1. which was happening on all operations that can be cancelled

2. and 3. are not fixed and are also present in the currently released version