### PR TITLE
Rework the project list in home tab

### DIFF
--- a/app/mmstyle.h
+++ b/app/mmstyle.h
@@ -262,12 +262,15 @@ class MMStyle: public QObject
     Q_PROPERTY( double margin11 READ number11 CONSTANT )
     Q_PROPERTY( double margin12 READ number12 CONSTANT )
     Q_PROPERTY( double margin13 READ number13 CONSTANT )
+    Q_PROPERTY( double margin14 READ number14 CONSTANT )
     Q_PROPERTY( double margin16 READ number16 CONSTANT )
     Q_PROPERTY( double margin20 READ number20 CONSTANT )
+    Q_PROPERTY( double margin28 READ number28 CONSTANT )
     Q_PROPERTY( double margin30 READ number30 CONSTANT )
     Q_PROPERTY( double margin32 READ number32 CONSTANT )
     Q_PROPERTY( double margin36 READ number36 CONSTANT )
     Q_PROPERTY( double margin40 READ number40 CONSTANT )
+    Q_PROPERTY( double margin48 READ number48 CONSTANT )
     Q_PROPERTY( double margin54 READ number54 CONSTANT )
 
     // Page

--- a/app/projectsmodel.cpp
+++ b/app/projectsmodel.cpp
@@ -123,6 +123,10 @@ QVariant ProjectsModel::data( const QModelIndex &index, int role ) const
       CoreUtils::log( "Project error", "Found project that is not downloaded nor remote" );
       return QVariant();
     }
+    case ProjectIsActiveProject:
+    {
+      return QVariant( project.id() == mActiveProjectId );
+    }
     default:
     {
       if ( !project.isMergin() ) return QVariant();
@@ -160,6 +164,7 @@ QHash<int, QByteArray> ProjectsModel::roleNames() const
   roles[Roles::ProjectSyncPending]  = QStringLiteral( "ProjectSyncPending" ).toLatin1();
   roles[Roles::ProjectSyncProgress] = QStringLiteral( "ProjectSyncProgress" ).toLatin1();
   roles[Roles::ProjectRemoteError]  = QStringLiteral( "ProjectRemoteError" ).toLatin1();
+  roles[Roles::ProjectIsActiveProject]  = QStringLiteral( "ProjectIsActiveProject" ).toLatin1();
   return roles;
 }
 
@@ -707,4 +712,12 @@ void ProjectsModel::setSyncManager( SynchronizationManager *newSyncManager )
 
   mSyncManager = newSyncManager;
   emit syncManagerChanged( mSyncManager );
+}
+
+QString ProjectsModel::activeProjectId() const { return mActiveProjectId; }
+
+void ProjectsModel::setActiveProjectId( const QString &projectId )
+{
+  mActiveProjectId = projectId;
+  emit activeProjectIdChanged( mActiveProjectId );
 }

--- a/app/projectsmodel.h
+++ b/app/projectsmodel.h
@@ -61,7 +61,8 @@ class ProjectsModel : public QAbstractListModel
       ProjectStatus,
       ProjectSyncPending,
       ProjectSyncProgress,
-      ProjectRemoteError
+      ProjectRemoteError,
+      ProjectIsActiveProject
     };
     Q_ENUM( Roles )
 
@@ -102,6 +103,9 @@ class ProjectsModel : public QAbstractListModel
     //! Indicates that model is currently processing projects, filling its storage.
     //! Models loading starts when listProjectsAPI is sent and finishes after endResetModel signal is emitted when projects are merged.
     Q_PROPERTY( bool isLoading READ isLoading NOTIFY isLoadingChanged )
+
+    //! Use to store the active project id in the model, so that Roles::ProjectIsActiveProject can be used
+    Q_PROPERTY( QString activeProjectId READ activeProjectId WRITE setActiveProjectId NOTIFY activeProjectIdChanged )
 
     // Needed methods from QAbstractListModel
     Q_INVOKABLE QVariant data( const QModelIndex &index, int role ) const override;
@@ -144,6 +148,8 @@ class ProjectsModel : public QAbstractListModel
     LocalProjectsManager *localProjectsManager() const;
     ProjectsModel::ProjectModelTypes modelType() const;
 
+    QString activeProjectId() const;
+
     bool isLoading() const;
     bool hasMoreProjects() const;
 
@@ -173,6 +179,8 @@ class ProjectsModel : public QAbstractListModel
     void setSyncManager( SynchronizationManager *newSyncManager );
     void setLocalProjectsManager( LocalProjectsManager *localProjectsManager );
 
+    void setActiveProjectId( const QString &projectId );
+
   signals:
     void modelInitialized();
     void hasMoreProjectsChanged();
@@ -183,6 +191,8 @@ class ProjectsModel : public QAbstractListModel
     void modelTypeChanged( ProjectModelTypes type );
     void syncManagerChanged( SynchronizationManager *syncManager );
     void localProjectsManagerChanged( LocalProjectsManager *projectsManager );
+
+    void activeProjectIdChanged( QString projectId );
 
   private:
 
@@ -212,6 +222,8 @@ class ProjectsModel : public QAbstractListModel
     MerginApi *mBackend = nullptr; // not owned
     LocalProjectsManager *mLocalProjectsManager = nullptr; // not owned
     SynchronizationManager *mSyncManager = nullptr; // not owned
+
+    QString mActiveProjectId;
 };
 
 #endif // PROJECTSMODEL_H

--- a/app/projectsmodel.h
+++ b/app/projectsmodel.h
@@ -224,6 +224,8 @@ class ProjectsModel : public QAbstractListModel
     SynchronizationManager *mSyncManager = nullptr; // not owned
 
     QString mActiveProjectId;
+
+    friend class TestModels;
 };
 
 #endif // PROJECTSMODEL_H

--- a/app/projectsproxymodel.cpp
+++ b/app/projectsproxymodel.cpp
@@ -39,12 +39,12 @@ ProjectsModel *ProjectsProxyModel::projectSourceModel() const
 
 void ProjectsProxyModel::setactiveProjectAlwaysFirst( bool value )
 {
-  mactiveProjectAlwaysFirst = value;
+  mActiveProjectAlwaysFirst = value;
 }
 
 bool ProjectsProxyModel::activeProjectAlwaysFirst() const
 {
-  return mactiveProjectAlwaysFirst;
+  return mActiveProjectAlwaysFirst;
 }
 
 void ProjectsProxyModel::setSearchExpression( QString searchExpression )
@@ -70,7 +70,7 @@ bool ProjectsProxyModel::lessThan( const QModelIndex &left, const QModelIndex &r
 {
   if ( mModelType == ProjectsModel::LocalProjectsModel )
   {
-    if ( mactiveProjectAlwaysFirst )
+    if ( mActiveProjectAlwaysFirst )
     {
       bool lProjectIsActive = mModel->data( left, ProjectsModel::ProjectIsActiveProject ).toBool();
       bool rProjectIsActive = mModel->data( right, ProjectsModel::ProjectIsActiveProject ).toBool();

--- a/app/projectsproxymodel.cpp
+++ b/app/projectsproxymodel.cpp
@@ -37,9 +37,10 @@ ProjectsModel *ProjectsProxyModel::projectSourceModel() const
   return mModel;
 }
 
-void ProjectsProxyModel::setactiveProjectAlwaysFirst( bool value )
+void ProjectsProxyModel::setActiveProjectAlwaysFirst( bool value )
 {
   mActiveProjectAlwaysFirst = value;
+  invalidate();
 }
 
 bool ProjectsProxyModel::activeProjectAlwaysFirst() const

--- a/app/projectsproxymodel.cpp
+++ b/app/projectsproxymodel.cpp
@@ -37,6 +37,16 @@ ProjectsModel *ProjectsProxyModel::projectSourceModel() const
   return mModel;
 }
 
+void ProjectsProxyModel::setactiveProjectAlwaysFirst( bool value )
+{
+  mactiveProjectAlwaysFirst = value;
+}
+
+bool ProjectsProxyModel::activeProjectAlwaysFirst() const
+{
+  return mactiveProjectAlwaysFirst;
+}
+
 void ProjectsProxyModel::setSearchExpression( QString searchExpression )
 {
   if ( mSearchExpression == searchExpression )
@@ -60,6 +70,14 @@ bool ProjectsProxyModel::lessThan( const QModelIndex &left, const QModelIndex &r
 {
   if ( mModelType == ProjectsModel::LocalProjectsModel )
   {
+    if ( mactiveProjectAlwaysFirst )
+    {
+      bool lProjectIsActive = mModel->data( left, ProjectsModel::ProjectIsActiveProject ).toBool();
+      bool rProjectIsActive = mModel->data( right, ProjectsModel::ProjectIsActiveProject ).toBool();
+      if ( lProjectIsActive || rProjectIsActive )
+        return lProjectIsActive;
+    }
+
     bool lProjectIsMergin = mModel->data( left, ProjectsModel::ProjectIsMergin ).toBool();
     bool rProjectIsMergin = mModel->data( right, ProjectsModel::ProjectIsMergin ).toBool();
 

--- a/app/projectsproxymodel.h
+++ b/app/projectsproxymodel.h
@@ -29,12 +29,17 @@ class ProjectsProxyModel : public QSortFilterProxyModel
     Q_PROPERTY( QString searchExpression READ searchExpression WRITE setSearchExpression NOTIFY searchExpressionChanged )
     Q_PROPERTY( ProjectsModel *projectSourceModel READ projectSourceModel WRITE setProjectSourceModel )
 
+    //! When true, a project whose Roles::ProjectIsActiveProject is true is always sorted first
+    Q_PROPERTY( bool activeProjectAlwaysFirst READ activeProjectAlwaysFirst WRITE setactiveProjectAlwaysFirst )
+
   public:
     explicit ProjectsProxyModel( QObject *parent = nullptr );
     ~ProjectsProxyModel() override {};
 
     QString searchExpression() const;
     ProjectsModel *projectSourceModel() const;
+    void setactiveProjectAlwaysFirst( bool value );
+    bool activeProjectAlwaysFirst() const;
 
   public slots:
     void setSearchExpression( QString searchExpression );
@@ -52,6 +57,7 @@ class ProjectsProxyModel : public QSortFilterProxyModel
     ProjectsModel *mModel = nullptr; // not owned by this, needs to be set in order to proxy model to work
     ProjectsModel::ProjectModelTypes mModelType = ProjectsModel::EmptyProjectsModel;
     QString mSearchExpression;
+    bool mactiveProjectAlwaysFirst = false;
 };
 
 #endif // PROJECTSPROXYMODEL_H

--- a/app/projectsproxymodel.h
+++ b/app/projectsproxymodel.h
@@ -30,7 +30,7 @@ class ProjectsProxyModel : public QSortFilterProxyModel
     Q_PROPERTY( ProjectsModel *projectSourceModel READ projectSourceModel WRITE setProjectSourceModel )
 
     //! When true, a project whose Roles::ProjectIsActiveProject is true is always sorted first
-    Q_PROPERTY( bool activeProjectAlwaysFirst READ activeProjectAlwaysFirst WRITE setactiveProjectAlwaysFirst )
+    Q_PROPERTY( bool activeProjectAlwaysFirst READ activeProjectAlwaysFirst WRITE setActiveProjectAlwaysFirst )
 
   public:
     explicit ProjectsProxyModel( QObject *parent = nullptr );
@@ -38,7 +38,7 @@ class ProjectsProxyModel : public QSortFilterProxyModel
 
     QString searchExpression() const;
     ProjectsModel *projectSourceModel() const;
-    void setactiveProjectAlwaysFirst( bool value );
+    void setActiveProjectAlwaysFirst( bool value );
     bool activeProjectAlwaysFirst() const;
 
   public slots:
@@ -58,6 +58,8 @@ class ProjectsProxyModel : public QSortFilterProxyModel
     ProjectsModel::ProjectModelTypes mModelType = ProjectsModel::EmptyProjectsModel;
     QString mSearchExpression;
     bool mActiveProjectAlwaysFirst = false;
+
+    friend class TestModels;
 };
 
 #endif // PROJECTSPROXYMODEL_H

--- a/app/projectsproxymodel.h
+++ b/app/projectsproxymodel.h
@@ -57,7 +57,7 @@ class ProjectsProxyModel : public QSortFilterProxyModel
     ProjectsModel *mModel = nullptr; // not owned by this, needs to be set in order to proxy model to work
     ProjectsModel::ProjectModelTypes mModelType = ProjectsModel::EmptyProjectsModel;
     QString mSearchExpression;
-    bool mactiveProjectAlwaysFirst = false;
+    bool mActiveProjectAlwaysFirst = false;
 };
 
 #endif // PROJECTSPROXYMODEL_H

--- a/app/qml/project/MMProjectHomeTab.qml
+++ b/app/qml/project/MMProjectHomeTab.qml
@@ -94,125 +94,11 @@ Item {
     onClicked: root.createWorkspaceRequested()
   }
 
-  Component {
-    id: activeProjectComponent
-
-    Column {
-      id: currentProjectColumn
-
-      width: ListView.view.width
-
-      Text {
-        width: parent.width
-        height: 31 * __dp
-        text: qsTr("Currently open")
-        font: __style.p6
-        color: __style.nightColor
-        wrapMode: Text.WordWrap
-        verticalAlignment: Text.AlignVCenter
-        elide: Text.ElideRight
-      }
-
-      MMLine {}
-
-      Item { width: 1; height: 20 * __dp }
-
-      MMProjectDelegate {
-        id: activeProjectItem
-
-        property var model: projectlist.projectsModel
-        property var index: projectlist.projectsModel.projectModelIndexFromId(root.activeProjectId)
-
-        property string projectRemoteError: model.data(index, MM.ProjectsModel.ProjectRemoteError) ? model.data(index, MM.ProjectsModel.ProjectRemoteError) : ""
-
-        width: parent.width
-
-        projectIsOpened: true
-        projectDisplayName: model.data(index, MM.ProjectsModel.ProjectFullName) ? model.data(index, MM.ProjectsModel.ProjectFullName) : ""
-        projectId: model.data(index, MM.ProjectsModel.ProjectId) ? model.data(index, MM.ProjectsModel.ProjectId) : ""
-        projectDescription: model.data(index, MM.ProjectsModel.ProjectDescription) ? model.data(index, MM.ProjectsModel.ProjectDescription) : ""
-        projectIsInSync: model.data(index, MM.ProjectsModel.ProjectSyncPending) ? model.data(index, MM.ProjectsModel.ProjectSyncPending) : false
-        projectSyncProgress: model.data(index, MM.ProjectsModel.ProjectSyncProgress) ? model.data(index, MM.ProjectsModel.ProjectSyncProgress) : -1
-        property string projectFilePath: model.data(index, MM.ProjectsModel.ProjectFilePath) ? model.data(index, MM.ProjectsModel.ProjectFilePath) : ""
-
-        state: {
-          let status = model.data(index, MM.ProjectsModel.ProjectStatus) ? model.data(index, MM.ProjectsModel.ProjectStatus) : MM.ProjectStatus.NoVersion
-
-          if ( status === MM.ProjectStatus.NeedsSync ) {
-            return "NeedsSync"
-          }
-          else if ( status === MM.ProjectStatus.UpToDate )
-          {
-            return "UpToDate"
-          }
-          else if ( status === MM.ProjectStatus.NoVersion )
-          {
-            return "NeedsSync"
-          }
-
-          return "UpToDate" // fallback, should never happen
-        }
-
-        projectActionButtons: {
-          let status = model.data(index, MM.ProjectsModel.ProjectStatus) ? model.data(index, MM.ProjectsModel.ProjectStatus) : MM.ProjectStatus.NoVersion
-
-          if ( status === MM.ProjectStatus.NeedsSync ) {
-            return ["sync", "changes", "remove"]
-          }
-          else if ( status === MM.ProjectStatus.NoVersion ) {
-            return ["upload", "remove"]
-          }
-          return ["changes", "remove"] // UpToDate
-        }
-
-        onOpenRequested: root.openProjectRequested( projectFilePath )
-
-        onSyncRequested: {
-          if ( projectRemoteError ) {
-            __notificationModel.addError( qsTr( "Could not synchronize project, please make sure you are logged in and have sufficient rights." ) )
-          }
-          else if ( !model.data(index, MM.ProjectsModel.ProjectIsMergin) ) {
-            projectlist.projectsModel.migrateProject( projectId )
-          }
-          else {
-            projectlist.projectsModel.syncProject( projectId )
-          }
-        }
-
-        onMigrateRequested: projectlist.projectsModel.migrateProject( projectId )
-        onRemoveRequested: {
-          removeProjectDialog.relatedProjectId = projectId
-          removeProjectDialog.open()
-        }
-        onStopSyncRequested: projectlist.projectsModel.stopProjectSync( projectId )
-        onShowChangesRequested: root.showLocalChangesRequested( projectId )
-      }
-
-      Item { width: 1; height: 40 * __dp }
-
-      Text {
-        width: parent.width
-        height: 31 * __dp
-        text: qsTr("Downloaded projects")
-        font: __style.p6
-        color: __style.nightColor
-        wrapMode: Text.WordWrap
-        verticalAlignment: Text.AlignVCenter
-        elide: Text.ElideRight
-      }
-
-      MMLine {}
-
-      Item { width: 1; height: 20 * __dp }
-    }
-  }
-
   MMProjectList {
     id: projectlist
 
     projectModelType: MM.ProjectsModel.LocalProjectsModel
     activeProjectId: root.activeProjectId
-    hideActiveProject: true // TODO: do not hide when searching!
     searchText: searchBar.text
     spacing: root.spacing
 
@@ -230,28 +116,38 @@ Item {
       topMargin: root.spacing
     }
 
+    activeProjectAlwaysFirst: true
+    projectsModel.activeProjectId: root.activeProjectId
+
+    list.section {
+      property: "ProjectIsActiveProject"
+      criteria: ViewSection.FullString
+      delegate: Column {
+        width: ListView.view.width
+
+        Text {
+          width: parent.width
+          height: 31 * __dp
+          text: section === "true" ? qsTr("Currently open") : qsTr("Downloaded projects")
+          font: __style.p6
+          color: __style.nightColor
+          wrapMode: Text.WordWrap
+          verticalAlignment: Text.AlignVCenter
+          elide: Text.ElideRight
+        }
+
+        MMLine {}
+
+        Item { width: 1; height: 20 * __dp }
+
+        }
+    }
+
     onOpenProjectRequested: function( projectFilePath ) {
       root.openProjectRequested( projectFilePath )
     }
     onShowLocalChangesRequested: function( projectId ) {
       root.showLocalChangesRequested( projectId )
-    }
-
-    function updateListHeader() {
-      // ugly ugly ugly #2
-      projectlist.listHeader = null
-
-      if ( root.activeProjectId ) {
-        projectlist.listHeader = activeProjectComponent
-      }
-    }
-
-    onActiveProjectIdChanged: projectlist.updateListHeader()
-
-    Connections {
-      target: projectlist.projectsModel
-
-      function onModelReset() { projectlist.updateListHeader() }
     }
   }
 
@@ -261,11 +157,6 @@ Item {
     onRemoveClicked: {
       if (relatedProjectId === "") {
         return
-      }
-
-      if ( root.activeProjectId === relatedProjectId ) {
-        projectlist.activeProjectDeleted() // ugly, ugly, ugly
-        projectlist.listHeader = null
       }
 
       __inputUtils.log(

--- a/app/qml/project/MMProjectHomeTab.qml
+++ b/app/qml/project/MMProjectHomeTab.qml
@@ -32,7 +32,7 @@ Item {
     projectlist.refreshProjectList( searchBar.text )
   }
 
-  property int spacing: 10 * __dp
+  property int spacing: __style.margin12
 
   MMSearchInput {
     id: searchBar
@@ -113,7 +113,7 @@ Item {
         return searchBar.bottom
       }
       bottom: parent.bottom
-      topMargin: root.spacing
+      topMargin: __style.margin20
     }
 
     activeProjectAlwaysFirst: true
@@ -124,10 +124,10 @@ Item {
       criteria: ViewSection.FullString
       delegate: Column {
         width: ListView.view.width
+        spacing: __style.margin6
 
-        Text {
+        MMText {
           width: parent.width
-          height: 31 * __dp
           text: section === "true" ? qsTr("Currently open") : qsTr("Downloaded projects")
           font: __style.p6
           color: __style.nightColor
@@ -138,7 +138,7 @@ Item {
 
         MMLine {}
 
-        Item { width: 1; height: 20 * __dp }
+        Item { width: 1; height: __style.margin14 }
 
         }
     }

--- a/app/qml/project/MMProjectList.qml
+++ b/app/qml/project/MMProjectList.qml
@@ -25,11 +25,12 @@ Item {
   property string activeProjectId: ""
   property string searchText: ""
   property int spacing: 0
-  property bool hideActiveProject: false
+  property bool activeProjectAlwaysFirst: false
   property alias projectsProxyModel: viewModel
   property alias projectsModel: controllerModel
   property alias listHeader: listview.header
   property alias listFooter: listview.footer
+  property alias list: listview
 
   signal openProjectRequested( string projectFilePath )
   signal showLocalChangesRequested( string projectId )
@@ -78,6 +79,7 @@ Item {
     model: MM.ProjectsProxyModel {
       id: viewModel
 
+      activeProjectAlwaysFirst: root.activeProjectAlwaysFirst
       projectSourceModel: MM.ProjectsModel {
         id: controllerModel
 
@@ -94,8 +96,6 @@ Item {
 
       width: ListView.view.width
       height: visible ? implicitHeight : 0
-
-      visible: root.hideActiveProject ? !projectIsOpened : true
 
       projectDisplayName: root.projectModelType === MM.ProjectsModel.WorkspaceProjectsModel ? model.ProjectName : model.ProjectFullName
       projectId: model.ProjectId ? model.ProjectId : ""

--- a/app/qml/project/MMProjectServerTab.qml
+++ b/app/qml/project/MMProjectServerTab.qml
@@ -29,7 +29,7 @@ Item {
     projectlist.refreshProjectList( searchBar.text )
   }
 
-  property int spacing: 10 * __dp
+  property int spacing: __style.margin12
 
   MMSearchInput {
     id: searchBar
@@ -60,7 +60,7 @@ Item {
       right: parent.right
       top: searchBar.bottom
       bottom: parent.bottom
-      topMargin: root.spacing
+      topMargin: __style.margin20
     }
 
     onOpenProjectRequested: function( projectFilePath ) {

--- a/app/qml/project/components/MMProjectDelegate.qml
+++ b/app/qml/project/components/MMProjectDelegate.qml
@@ -40,8 +40,11 @@ Control {
 
   topPadding: __style.margin20
   rightPadding: __style.margin20
-  bottomPadding: __style.margin20
   leftPadding: __style.margin20
+  // The last item in a section ('currently open' vs 'downloaded projects' in Home tab) gets an extra
+  // 40 * __dp padding, then the inset is also grown to keep the background at the correct size
+  bottomPadding: ListView.section !== ListView.nextSection ? __style.margin20 + 40 * __dp : __style.margin20
+  bottomInset: ListView.section !== ListView.nextSection ? 40 * __dp : topInset
 
   states: [
     State { name: "OnServer" },

--- a/app/qml/project/components/MMProjectDelegate.qml
+++ b/app/qml/project/components/MMProjectDelegate.qml
@@ -42,9 +42,9 @@ Control {
   rightPadding: __style.margin20
   leftPadding: __style.margin20
   // The last item in a section ('currently open' vs 'downloaded projects' in Home tab) gets an extra
-  // 40 * __dp padding, then the inset is also grown to keep the background at the correct size
-  bottomPadding: ListView.section !== ListView.nextSection ? __style.margin20 + 40 * __dp : __style.margin20
-  bottomInset: ListView.section !== ListView.nextSection ? 40 * __dp : topInset
+  // __style.margin28 padding, then the inset is also grown to keep the background at the correct size
+  bottomPadding: ListView.section !== ListView.nextSection ? __style.margin48: __style.margin20
+  bottomInset: ListView.section !== ListView.nextSection ? + __style.margin28: topInset
 
   states: [
     State { name: "OnServer" },

--- a/app/test/testmodels.cpp
+++ b/app/test/testmodels.cpp
@@ -10,6 +10,8 @@
 #include "testmodels.h"
 #include "testutils.h"
 #include "featuresmodel.h"
+#include "projectsmodel.h"
+#include "projectsproxymodel.h"
 
 #include <QtTest/QtTest>
 
@@ -52,4 +54,98 @@ void TestModels::testFeaturesModel()
 
   QVariant title = fModel.data( fModel.index( 0 ), FeaturesModel::FeatureTitle );
   QCOMPARE( title, QStringLiteral( "First" ) );
+}
+
+void TestModels::testProjectsModel()
+{
+  Project p0;
+  p0.local.projectNamespace = QStringLiteral( "namespace" );
+  p0.local.projectName = QStringLiteral( "project_B" );
+  p0.local.projectDir = QStringLiteral( "project_B_dir" );
+
+  Project p1;
+  p1.local.projectNamespace = QStringLiteral( "namespace" );
+  p1.local.projectName = QStringLiteral( "project_A" );
+  p1.local.projectDir = QStringLiteral( "project_A_dir" );
+
+  Project p2;
+  p2.local.projectNamespace = QStringLiteral( "namespace" );
+  p2.local.projectName = QStringLiteral( "project_C" );
+  p2.local.projectDir = QStringLiteral( "project_C_dir" );
+
+  ProjectsModel model;
+  model.setModelType( ProjectsModel::LocalProjectsModel );
+  model.mProjects << p0 << p1 << p2;
+
+  QCOMPARE( model.rowCount(), 3 );
+
+  // test ProjectsModel::Roles::ProjectIsActiveProject
+
+  // No active project initially
+  QVERIFY( !model.data( model.index( 0 ), ProjectsModel::Roles::ProjectIsActiveProject ).toBool() );
+  QVERIFY( !model.data( model.index( 1 ), ProjectsModel::Roles::ProjectIsActiveProject ).toBool() );
+  QVERIFY( !model.data( model.index( 2 ), ProjectsModel::Roles::ProjectIsActiveProject ).toBool() );
+
+  // Set an active project
+  model.setActiveProjectId( p0.id() );
+  QCOMPARE( model.activeProjectId(), p0.id() );
+  QVERIFY( model.data( model.index( 0 ), ProjectsModel::Roles::ProjectIsActiveProject ).toBool() );
+  QVERIFY( !model.data( model.index( 1 ), ProjectsModel::Roles::ProjectIsActiveProject ).toBool() );
+  QVERIFY( !model.data( model.index( 2 ), ProjectsModel::Roles::ProjectIsActiveProject ).toBool() );
+
+  // Change active project
+  model.setActiveProjectId( p2.id() );
+  QCOMPARE( model.activeProjectId(), p2.id() );
+  QVERIFY( !model.data( model.index( 0 ), ProjectsModel::Roles::ProjectIsActiveProject ).toBool() );
+  QVERIFY( !model.data( model.index( 1 ), ProjectsModel::Roles::ProjectIsActiveProject ).toBool() );
+  QVERIFY( model.data( model.index( 2 ), ProjectsModel::Roles::ProjectIsActiveProject ).toBool() );
+}
+
+void TestModels::testProjectsProxyModel()
+{
+  Project p0;
+  p0.local.projectNamespace = QStringLiteral( "namespace" );
+  p0.local.projectName = QStringLiteral( "project_B" );
+  p0.local.projectDir = QStringLiteral( "project_B_dir" );
+
+  Project p1;
+  p1.local.projectNamespace = QStringLiteral( "namespace" );
+  p1.local.projectName = QStringLiteral( "project_A" );
+  p1.local.projectDir = QStringLiteral( "project_A_dir" );
+
+  Project p2;
+  p2.local.projectNamespace = QStringLiteral( "namespace" );
+  p2.local.projectName = QStringLiteral( "project_C" );
+  p2.local.projectDir = QStringLiteral( "project_C_dir" );
+
+  ProjectsModel model;
+  model.setModelType( ProjectsModel::LocalProjectsModel );
+  model.mProjects << p0 << p1 << p2;
+
+  QCOMPARE( model.rowCount(), 3 );
+
+  ProjectsProxyModel proxy;
+  proxy.setProjectSourceModel( &model );
+  proxy.initialize();
+
+  QCOMPARE( proxy.rowCount(), 3 );
+
+  // No active project initially, normally sorted
+  QCOMPARE( proxy.data( proxy.index( 0, 0 ), ProjectsModel::Roles::ProjectId ).toString(), p1.id() );
+  QCOMPARE( proxy.data( proxy.index( 1, 0 ), ProjectsModel::Roles::ProjectId ).toString(), p0.id() );
+  QCOMPARE( proxy.data( proxy.index( 2, 0 ), ProjectsModel::Roles::ProjectId ).toString(), p2.id() );
+
+  // Active project set, still normally sorted
+  model.setActiveProjectId( p2.id() );
+  proxy.invalidate(); // re-sort
+  QCOMPARE( proxy.data( proxy.index( 0, 0 ), ProjectsModel::Roles::ProjectId ).toString(), p1.id() );
+  QCOMPARE( proxy.data( proxy.index( 1, 0 ), ProjectsModel::Roles::ProjectId ).toString(), p0.id() );
+  QCOMPARE( proxy.data( proxy.index( 2, 0 ), ProjectsModel::Roles::ProjectId ).toString(), p2.id() );
+
+  // Active project always first set, active project is first
+  proxy.setActiveProjectAlwaysFirst( true );
+  QVERIFY( proxy.activeProjectAlwaysFirst() );
+  QCOMPARE( proxy.data( proxy.index( 0, 0 ), ProjectsModel::Roles::ProjectId ).toString(), p2.id() );
+  QCOMPARE( proxy.data( proxy.index( 1, 0 ), ProjectsModel::Roles::ProjectId ).toString(), p1.id() );
+  QCOMPARE( proxy.data( proxy.index( 2, 0 ), ProjectsModel::Roles::ProjectId ).toString(), p0.id() );
 }

--- a/app/test/testmodels.h
+++ b/app/test/testmodels.h
@@ -23,6 +23,9 @@ class TestModels : public QObject
     void cleanup(); // will be called after every testfunction.
 
     void testFeaturesModel();
+    void testProjectsModel();
+    void testProjectsProxyModel();
+
 };
 
 #endif // TESTMODELS_H


### PR DESCRIPTION
Fixes #3214

Change the way the active project is displayed on top of the list in Home tab into a less hacky one.

Now the ProjectsModel gets a `activeProjectId` property which _if_ set, then one can use the new `Roles::ProjectIsActiveProject` role on the model's contents.

We then split the projects list into two sections based on this new role.

`Roles::ProjectIsActiveProject` may be a bit misleading, as it might not return true on the active project, rather on the one passed into `ProjectsModel::activeProjectId`
