### PR TITLE
remove syncInProgressAnimation leftover

### DIFF
--- a/app/qml/main.qml
+++ b/app/qml/main.qml
@@ -814,7 +814,7 @@ ApplicationWindow {
     {
       if ( projectFullName === __activeProject.projectFullName() )
       {
-        syncInProgressAnimation.stop()
+        syncButton.iconRotateAnimationRunning = false
       }
     }
 
@@ -898,7 +898,6 @@ ApplicationWindow {
     {
       if ( projectFullName === __activeProject.projectFullName() )
       {
-        syncInProgressAnimation.stop()
         missingAuthDialog.open()
       }
     }


### PR DESCRIPTION
Call to non existing `syncInProgressAnimation.stop()` was breaking the sync button logic

Fixes #3216