### PR TITLE
Use actual project folder in the created project notification

### DIFF
--- a/app/projectwizard.cpp
+++ b/app/projectwizard.cpp
@@ -134,7 +134,8 @@ void ProjectWizard::createProject( QString const &projectName, FieldsModel *fiel
   project.writePath( projectGpkgPath );
   project.write( projectFilepath );
 
-  emit notifySuccess( tr( "Project %1 created" ).arg( projectName ) );
+  const QString folderName = projectDir.mid( mDataDir.size() + 1 );
+  emit notifySuccess( tr( "Project %1 created" ).arg( folderName ) );
   emit projectCreated( projectDir, projectName );
 }
 


### PR DESCRIPTION
When creating a new project using a name that already exists in the local projects, then the projectDir is modified and a ` (1)` is appended / incremented.

However the notification was still using the project name, which is _not displayed_ in the list of projects.

Now the notification says _Project myProject (1) created_