### PR TITLE
make sure notifications are always on top

### DIFF
--- a/app/qml/components/MMNotificationView.qml
+++ b/app/qml/components/MMNotificationView.qml
@@ -14,6 +14,10 @@ Item {
   implicitHeight: ApplicationWindow.window?.height ?? 0
   implicitWidth: ApplicationWindow.window?.width ?? 0
 
+  // Make sure it is always rendered in front of everything else in the scene, including popups
+  parent: Overlay.overlay
+  z: 1
+
   Repeater {
     id: repeater
 

--- a/app/qml/main.qml
+++ b/app/qml/main.qml
@@ -743,7 +743,6 @@ ApplicationWindow {
     }
   }
 
-  // Should be the top-most visual item
   MMNotificationView {}
 
   MMListDrawer {


### PR DESCRIPTION
According to https://doc.qt.io/qt-6/qml-qtquick-controls-popup.html#showing-non-child-items-in-front-of-popup

Fixes: #3232