### PR TITLE
Fix offline issues in Projects page with no/expired token

### DIFF
--- a/app/qml/project/MMProjectController.qml
+++ b/app/qml/project/MMProjectController.qml
@@ -303,7 +303,7 @@ Item {
               if ( !__merginApi.apiSupportsWorkspaces ) {
                 return false;
               }
-              if ( !__merginApi.userAuth.hasAuthData() ) {
+              if ( !__merginApi.userAuth.hasValidToken() ) {
                 return false;
               }
               // do not show the banner in case of accepting invitation or creating a workspace
@@ -623,6 +623,10 @@ Item {
       stackView.pending = false
     }
 
+    function onListProjectsFailed() {
+      stackView.pending = false
+    }
+
     function onApiVersionStatusChanged() {
       stackView.pending = false
 
@@ -642,7 +646,7 @@ Item {
     function onAuthChanged() {
       stackView.pending = false
 
-      if ( __merginApi.userAuth.hasAuthData() ) {
+      if ( __merginApi.userAuth.hasValidToken() ) {
 
         if ( __merginApi.serverType === MM.MerginServerType.OLD || ( stackView.currentItem.objectName === "loginPage" ) ) {
           stackView.popPage( "loginPage" )

--- a/core/merginuserauth.h
+++ b/core/merginuserauth.h
@@ -36,7 +36,7 @@ class MerginUserAuth: public QObject
 
     //! Returns true if we have a token and it is not expired,
     //! i.e. we should be good to do authenticated requests.
-    bool hasValidToken() const;
+    Q_INVOKABLE bool hasValidToken() const;
 
     void clear();
 


### PR DESCRIPTION

1. incorrect "no workspace detected" message
2. endless busy wait on the home tab (unable to switch projects)
3. endless loop of requesting projects in the second tab

The hasAuthData() function is confusing - one may think it returns whether we are logged in, but in fact it only tells whether username+password have been set.

Before:


https://github.com/MerginMaps/mobile/assets/193367/3976e964-ff10-4ae4-89fc-a8c946cdfac6


After:


https://github.com/MerginMaps/mobile/assets/193367/2e65f78f-3244-41f9-a4a1-bef432ea1618

