### PR TITLE
Bind left/right content mouse areas to enabled state by default

### DIFF
--- a/app/qml/components/private/MMBaseSingleLineInput.qml
+++ b/app/qml/components/private/MMBaseSingleLineInput.qml
@@ -108,6 +108,8 @@ MMBaseInput {
             bottomMargin: -__style.margin16
           }
 
+          enabled: root.editState === "enabled"
+
           onClicked: function( mouse ) {
             mouse.accepted = true
             root.focus = true
@@ -177,6 +179,8 @@ MMBaseInput {
             rightMargin: -__style.margin20
             bottomMargin: -__style.margin16
           }
+
+          enabled: root.editState === "enabled"
 
           onClicked: function( mouse ) {
             mouse.accepted = true


### PR DESCRIPTION
Let's bind `enabled` property of left/right content mouse area to the `editState === "enabled"` so that we do not need to bind it individually in each input/editor