### PR TITLE
MMSwitchInput, MMSwitchFormEditor

### DIFF
--- a/app/qml/components/MMSwitch.qml
+++ b/app/qml/components/MMSwitch.qml
@@ -23,6 +23,14 @@ Switch {
   bottomPadding: 0
   leftPadding: 0
 
+  contentItem: Text {
+    text: root.text
+    font: __style.p5
+    color: root.enabled ? root.enabledFgColor : root.disabledFgColor
+    verticalAlignment: Text.AlignVCenter
+    leftPadding: root.indicator.width + ( text ? root.spacing : 0 )
+  }
+
   indicator: Rectangle {
     id: indicatorRectangle
 

--- a/app/qml/components/MMSwitch.qml
+++ b/app/qml/components/MMSwitch.qml
@@ -23,21 +23,12 @@ Switch {
   bottomPadding: 0
   leftPadding: 0
 
-  contentItem: Text {
-    text: root.text
-    font: __style.p5
-    color: root.enabled ? root.enabledFgColor : root.disabledFgColor
-    verticalAlignment: Text.AlignVCenter
-    leftPadding: root.indicator.width + ( text ? root.spacing : 0 )
-  }
-
   indicator: Rectangle {
     id: indicatorRectangle
 
     implicitWidth: 48 * __dp
     implicitHeight: 28 * __dp
     x: root.leftPadding
-    y: parent.height / 2 - height / 2
     radius: implicitHeight / 2
     color: root.checked ? root.checkedBgColor : root.uncheckedBgColor
 

--- a/app/qml/components/private/MMBaseSingleLineInput.qml
+++ b/app/qml/components/private/MMBaseSingleLineInput.qml
@@ -112,12 +112,12 @@ MMBaseInput {
             bottomMargin: -__style.margin16
           }
 
-          enabled: root.editState === "enabled"
-
           onClicked: function( mouse ) {
-            mouse.accepted = true
-            root.focus = true
-            root.leftContentClicked()
+            if ( root.editState === "enabled" ) {
+                mouse.accepted = true
+                root.focus = true
+                root.leftContentClicked()
+            }
           }
         }
       }
@@ -190,12 +190,12 @@ MMBaseInput {
             bottomMargin: -__style.margin16
           }
 
-          enabled: root.editState === "enabled"
-
           onClicked: function( mouse ) {
-            mouse.accepted = true
-            root.focus = true
-            root.rightContentClicked()
+            if ( root.editState === "enabled" ) {
+              mouse.accepted = true
+              root.focus = true
+              root.rightContentClicked()
+            }
           }
         }
       }

--- a/app/qml/components/private/MMBaseSingleLineInput.qml
+++ b/app/qml/components/private/MMBaseSingleLineInput.qml
@@ -36,6 +36,8 @@ MMBaseInput {
   property alias leftContentMouseArea: leftContentMouseAreaGroup
   property alias rightContentMouseArea: rightContentMouseAreaGroup
 
+  property bool rightContentVisible: rightContentGroup.children.length > 0
+
   signal textEdited( string text )
   signal leftContentClicked()
   signal rightContentClicked()
@@ -157,7 +159,7 @@ MMBaseInput {
         Layout.preferredWidth: rightContentGroup.width
         Layout.rightMargin: __style.margin20
 
-        visible: rightContentGroup.children.length > 0 && rightContentGroup.children[0].visible
+        visible: rightContentVisible
 
         Item {
           id: rightContentGroup

--- a/app/qml/components/private/MMBaseSingleLineInput.qml
+++ b/app/qml/components/private/MMBaseSingleLineInput.qml
@@ -37,8 +37,10 @@ MMBaseInput {
   property alias rightContentMouseArea: rightContentMouseAreaGroup
 
   property bool rightContentVisible: rightContentGroup.children.length > 0
+  property bool leftContentVisible: leftContentGroup.children.length > 0
 
   signal textEdited( string text )
+  signal textClicked()
   signal leftContentClicked()
   signal rightContentClicked()
 
@@ -88,7 +90,7 @@ MMBaseInput {
         Layout.preferredWidth: leftContentGroup.width
         Layout.leftMargin: __style.margin20
 
-        visible: leftContentGroup.children.length > 0 && leftContentGroup.children[0].visible
+        visible: leftContentVisible
 
         Item {
           id: leftContentGroup
@@ -152,6 +154,12 @@ MMBaseInput {
         background: Rectangle { color: __style.transparentColor }
 
         onTextEdited: root.textEdited( text )
+
+        onReleased: {
+          if ( root.editState !== "readOnly" ) {
+            root.textClicked()
+          }
+        }
       }
 
       Item {

--- a/app/qml/form/editors/MMFormNumberEditor.qml
+++ b/app/qml/form/editors/MMFormNumberEditor.qml
@@ -53,7 +53,6 @@ MMPrivateComponents.MMBaseSingleLineInput {
     root.rememberValueBoxClicked( checkboxChecked )
   }
 
-  leftContentMouseArea.enabled: root.editState === "enabled" && internal.canSubtractStep
   leftContent: MMComponents.MMIcon {
     id: leftIcon
 
@@ -95,8 +94,6 @@ MMPrivateComponents.MMBaseSingleLineInput {
     }
   }
 
-  rightContentMouseArea.enabled: root.editState === "enabled" && internal.canAddStep
-
   rightContent: MMComponents.MMIcon {
     id: rightIcon
 
@@ -106,8 +103,10 @@ MMPrivateComponents.MMBaseSingleLineInput {
   }
 
   onLeftContentClicked: {
-    let decremented = Number( textField.text ) - internal.step
-    root.editorValueChanged( decremented.toFixed( internal.precision ), false )
+    if ( internal.canSubtractStep ) {
+      let decremented = Number( textField.text ) - internal.step
+      root.editorValueChanged( decremented.toFixed( internal.precision ), false )
+    }
   }
 
   onTextEdited: ( text ) => {
@@ -117,8 +116,10 @@ MMPrivateComponents.MMBaseSingleLineInput {
   }
 
   onRightContentClicked: {
-    let incremented = Number( textField.text ) + internal.step
-    root.editorValueChanged( incremented.toFixed( internal.precision ), false )
+    if ( internal.canAddStep ) {
+      let incremented = Number( textField.text ) + internal.step
+      root.editorValueChanged( incremented.toFixed( internal.precision ), false )
+    }
   }
 
   QtObject {

--- a/app/qml/form/editors/MMFormSwitchEditor.qml
+++ b/app/qml/form/editors/MMFormSwitchEditor.qml
@@ -8,8 +8,7 @@
  ***************************************************************************/
 
 import QtQuick
-import QtQuick.Controls
-import "../../components"
+
 import "../../inputs"
 
 /*
@@ -18,9 +17,10 @@ import "../../inputs"
  * These properties are injected here via 'fieldXYZ' properties and captured with underscore `_`.
  *
  * Should be used only within feature form.
+ * See MMBaseSingleLineInput
  */
 
-MMBaseInput {
+MMSwitchInput {
   id: root
 
   property var _field: parent.field
@@ -45,47 +45,22 @@ MMBaseInput {
   warningMsg: _fieldWarningMessage
   errorMsg: _fieldErrorMessage
 
-  enabled: !_fieldIsReadOnly
-
-  hasFocus: rightSwitch.focus
+  readOnly: _fieldIsReadOnly
 
   hasCheckbox: _fieldRememberValueSupported
   checkboxChecked: _fieldRememberValueState
 
+  text: checked ? internal.checkedStateValue : internal.uncheckedStateValue
+
+  checked: _fieldValue === internal.checkedStateValue
+
+  onToggled: {
+    let newVal = checked ? internal.checkedStateValue : internal.uncheckedStateValue
+    editorValueChanged( newVal, false )
+  }
+
   onCheckboxCheckedChanged: {
-    root.rememberValueBoxClicked( checkboxChecked )
-  }
-
-  content: Text {
-    id: textField
-
-    width: parent.width
-    anchors.verticalCenter: parent.verticalCenter
-
-    text: rightSwitch.checked ? internal.checkedStateValue : internal.uncheckedStateValue
-
-    color: __style.nightColor
-    font: __style.p5
-    elide: Text.ElideRight
-  }
-
-  onContentClicked: {
-    rightSwitch.toggle()
-  }
-
-  rightAction: MMSwitch {
-    id: rightSwitch
-
-    height: parent.height
-    x: -__style.margin20
-
-    uncheckedBgColor: __style.lightGreenColor
-    checked: root._fieldValue === internal.checkedStateValue
-
-    onCheckedChanged: {
-      let newVal = rightSwitch.checked ? internal.checkedStateValue : internal.uncheckedStateValue
-      root.editorValueChanged( newVal, false )
-    }
+    rememberValueBoxClicked( checkboxChecked )
   }
 
   function getConfigValue( configValue, defaultValue ) {

--- a/app/qml/inputs/MMSwitchInput.qml
+++ b/app/qml/inputs/MMSwitchInput.qml
@@ -30,8 +30,6 @@ MMPrivateComponents.MMBaseSingleLineInput {
   rightContent: MMComponents.MMSwitch {
     id: switchComponent
 
-    anchors.verticalCenter: parent.verticalCenter
-
     uncheckedBgColor: __style.lightGreenColor
   }
 

--- a/app/qml/inputs/MMSwitchInput.qml
+++ b/app/qml/inputs/MMSwitchInput.qml
@@ -8,49 +8,41 @@
  ***************************************************************************/
 
 import QtQuick
-import QtQuick.Controls
-import QtQuick.Controls.Basic
-import "../components"
+
+import "../components" as MMComponents
+import "../components/private" as MMPrivateComponents
 
 /*
  * Common switch input to use in the app.
  *
- * See MMBaseInput for more properties.
+ * See MMBaseSingleLineInput for more properties.
  */
 
-MMBaseInput {
+MMPrivateComponents.MMBaseSingleLineInput {
   id: root
 
-  property alias text: textField.text
-  property alias switchComponent: switchComponent
+  property alias checked: switchComponent.checked
+  //! emitted when interactively toggled by the user via touch, mouse, or keyboard.
+  signal toggled()
 
-  hasFocus: textField.activeFocus
+  textField.readOnly: true
 
-  content: TextField {
-    id: textField
-
-    anchors.fill: parent
-
-    readOnly: true
-    placeholderTextColor: __style.darkGreyColor
-    color: root.enabled ? __style.nightColor : __style.mediumGreenColor
-
-    font: __style.p5
-    hoverEnabled: true
-
-    background: Rectangle {
-      color: __style.transparentColor
-    }
-
-    onTextEdited: root.textEdited( textField.text )
-  }
-
-  rightAction: MMSwitch {
+  rightContent: MMComponents.MMSwitch {
     id: switchComponent
 
     anchors.verticalCenter: parent.verticalCenter
-    x: -20 * __dp // TODO why is this needed? bacause of how baseinput works :(
 
     uncheckedBgColor: __style.lightGreenColor
+  }
+
+  textField.onReleased: toggleSwitchComponent()
+
+  onRightContentClicked: toggleSwitchComponent()
+
+  function toggleSwitchComponent() {
+    if ( !readOnly) {
+      switchComponent.toggle()
+      toggled()
+    }
   }
 }

--- a/app/qml/inputs/MMSwitchInput.qml
+++ b/app/qml/inputs/MMSwitchInput.qml
@@ -33,14 +33,12 @@ MMPrivateComponents.MMBaseSingleLineInput {
     uncheckedBgColor: __style.lightGreenColor
   }
 
-  textField.onReleased: toggleSwitchComponent()
+  onTextClicked: toggleSwitchComponent()
 
   onRightContentClicked: toggleSwitchComponent()
 
   function toggleSwitchComponent() {
-    if ( !readOnly) {
-      switchComponent.toggle()
-      toggled()
-    }
+    switchComponent.toggle()
+    toggled()
   }
 }

--- a/app/qml/inputs/MMTextInput.qml
+++ b/app/qml/inputs/MMTextInput.qml
@@ -28,8 +28,9 @@ MMPrivateComponents.MMBaseSingleLineInput {
     size: __style.icon24
     source: __style.closeIcon
     color: root.editState === "enabled" ? __style.forestColor : __style.mediumGreenColor
-    visible: root.showClearIcon && textField.activeFocus && textField.text.length > 0
   }
+
+  rightContentVisible: root.showClearIcon && textField.activeFocus && textField.text.length > 0
 
   onRightContentClicked: textField.clear()
 }

--- a/app/qml/layers/MMLayerDetailPage.qml
+++ b/app/qml/layers/MMLayerDetailPage.qml
@@ -77,17 +77,9 @@ Page {
 
             title: qsTr( "Settings" )
             text: qsTr( "Visible on map" )
-            switchComponent.checked: layerDetailData.isVisible
+            checked: layerDetailData.isVisible
 
-            onContentClicked: {
-              toggleVisiblity()
-            }
-
-            onRightActionClicked: {
-              toggleVisiblity()
-            }
-
-            function toggleVisiblity() {
+            onToggled: {
               __activeProject.switchLayerTreeNodeVisibility( layerDetailData.layerTreeNode )
             }
           }


### PR DESCRIPTION
Rework of Switch.

The Switch is not visible in Form unless `&& rightContentGroup.children[0].visible` check is removed in `rightContentGroupContainer`.