### PR TITLE
PDF Viewing Feature

### DIFF
--- a/app/android/res/xml/file_paths.xml
+++ b/app/android/res/xml/file_paths.xml
@@ -1,4 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <paths xmlns:android="http://schemas.android.com/apk/res/android">
     <cache-path name="input_camera" path="./" />
+    <external-path
+        name="app_files"
+        path="Android/data/uk.co.lutraconsulting/" />
 </paths>

--- a/app/android/src/uk/co/lutraconsulting/InputActivity.java
+++ b/app/android/src/uk/co/lutraconsulting/InputActivity.java
@@ -130,24 +130,17 @@ public class InputActivity extends QtActivity
     keepSplashScreenVisible = false;
   }
 
-  public void openFile( String filePath ) {
-    Log.d( TAG, "Expected file path: " + filePath );
-
+  public bool openFile( String filePath ) {
     File file = new File( filePath );
 
     if ( !file.exists() ) {
-        Log.d( TAG, "File does not exist: " + filePath );
-        runOnUiThread( () -> Toast.makeText( getApplicationContext(), "File not available", Toast.LENGTH_SHORT ).show() );
-        return;
-    } else {
-        Log.d( TAG, "File exists: " + filePath );
+        return false;
     }
 
     Intent showFileIntent = new Intent( Intent.ACTION_VIEW );
 
     try {
         Uri fileUri = FileProvider.getUriForFile( this, "uk.co.lutraconsulting.fileprovider", file );
-        Log.d( TAG, "File URI: " + fileUri.toString() );
 
         showFileIntent.setData( fileUri );
 
@@ -155,15 +148,16 @@ public class InputActivity extends QtActivity
         // FLAG_ACTIVITY_NEW_TASK is used when starting an Activity from a non-Activity context.
         showFileIntent.setFlags( Intent.FLAG_ACTIVITY_NEW_TASK | Intent.FLAG_GRANT_READ_URI_PERMISSION );
       } catch ( IllegalArgumentException e ) {
-        Log.d( TAG, "FileProvider URI issue", e );
-        return;
+        return false;
     }
 
     if ( showFileIntent.resolveActivity( getPackageManager() ) != null ) {
         startActivity( showFileIntent );
     } else {
-        runOnUiThread( () -> Toast.makeText( getApplicationContext(), "No application for opening this file", Toast.LENGTH_SHORT ).show() );
+        return false;
     }
+
+    return true;
   }
 
   public void quitGracefully()

--- a/app/android/src/uk/co/lutraconsulting/InputActivity.java
+++ b/app/android/src/uk/co/lutraconsulting/InputActivity.java
@@ -28,6 +28,7 @@ import android.view.WindowInsetsController;
 import android.graphics.Insets;
 import android.graphics.Color;
 
+import android.app.Activity;
 import android.content.Intent;
 import android.net.Uri;
 import android.content.ActivityNotFoundException;
@@ -41,6 +42,7 @@ import androidx.core.splashscreen.SplashScreen;
 public class InputActivity extends QtActivity
 {
   private static final String TAG = "Mergin Maps Input Activity";
+  private static final int OPEN_FILE_REQUEST_CODE = 1;
   private boolean keepSplashScreenVisible = true;
 
   @Override
@@ -133,13 +135,15 @@ public class InputActivity extends QtActivity
   public boolean openFile( String filePath ) {
     File file = new File( filePath );
 
-    if ( !file.exists() ) {
+    if ( !file.exists() ) 
+    {
         return false;
     }
 
     Intent showFileIntent = new Intent( Intent.ACTION_VIEW );
 
-    try {
+    try 
+    {
         Uri fileUri = FileProvider.getUriForFile( this, "uk.co.lutraconsulting.fileprovider", file );
 
         showFileIntent.setData( fileUri );
@@ -147,17 +151,21 @@ public class InputActivity extends QtActivity
         // FLAG_GRANT_READ_URI_PERMISSION grants temporary read permission to the content URI.
         // FLAG_ACTIVITY_NEW_TASK is used when starting an Activity from a non-Activity context.
         showFileIntent.setFlags( Intent.FLAG_ACTIVITY_NEW_TASK | Intent.FLAG_GRANT_READ_URI_PERMISSION );
-      } catch ( IllegalArgumentException e ) {
+    } 
+    catch ( IllegalArgumentException e )
+    {
         return false;
     }
 
-    if ( showFileIntent.resolveActivity( getPackageManager() ) != null ) {
-        startActivity( showFileIntent );
-    } else {
-        return false;
+    try 
+    {
+      startActivityForResult( showFileIntent, OPEN_FILE_REQUEST_CODE );
+      return true;
+    } 
+    catch ( ActivityNotFoundException ex ) 
+    {
+      return false;
     }
-
-    return true;
   }
 
   public void quitGracefully()

--- a/app/android/src/uk/co/lutraconsulting/InputActivity.java
+++ b/app/android/src/uk/co/lutraconsulting/InputActivity.java
@@ -130,7 +130,7 @@ public class InputActivity extends QtActivity
     keepSplashScreenVisible = false;
   }
 
-  public bool openFile( String filePath ) {
+  public boolean openFile( String filePath ) {
     File file = new File( filePath );
 
     if ( !file.exists() ) {

--- a/app/android/src/uk/co/lutraconsulting/InputActivity.java
+++ b/app/android/src/uk/co/lutraconsulting/InputActivity.java
@@ -28,6 +28,13 @@ import android.view.WindowInsetsController;
 import android.graphics.Insets;
 import android.graphics.Color;
 
+import android.content.Intent;
+import android.net.Uri;
+import android.content.ActivityNotFoundException;
+import java.io.File;
+import androidx.core.content.FileProvider;
+import android.widget.Toast;
+
 import androidx.core.view.WindowCompat;
 import androidx.core.splashscreen.SplashScreen;
 
@@ -121,6 +128,42 @@ public class InputActivity extends QtActivity
   public void hideSplashScreen()
   {
     keepSplashScreenVisible = false;
+  }
+
+  public void openFile( String filePath ) {
+    Log.d( TAG, "Expected file path: " + filePath );
+
+    File file = new File( filePath );
+
+    if ( !file.exists() ) {
+        Log.d( TAG, "File does not exist: " + filePath );
+        runOnUiThread( () -> Toast.makeText( getApplicationContext(), "File not available", Toast.LENGTH_SHORT ).show() );
+        return;
+    } else {
+        Log.d( TAG, "File exists: " + filePath );
+    }
+
+    Intent showFileIntent = new Intent( Intent.ACTION_VIEW );
+
+    try {
+        Uri fileUri = FileProvider.getUriForFile( this, "uk.co.lutraconsulting.fileprovider", file );
+        Log.d( TAG, "File URI: " + fileUri.toString() );
+
+        showFileIntent.setData( fileUri );
+
+        // FLAG_GRANT_READ_URI_PERMISSION grants temporary read permission to the content URI.
+        // FLAG_ACTIVITY_NEW_TASK is used when starting an Activity from a non-Activity context.
+        showFileIntent.setFlags( Intent.FLAG_ACTIVITY_NEW_TASK | Intent.FLAG_GRANT_READ_URI_PERMISSION );
+      } catch ( IllegalArgumentException e ) {
+        Log.d( TAG, "FileProvider URI issue", e );
+        return;
+    }
+
+    if ( showFileIntent.resolveActivity( getPackageManager() ) != null ) {
+        startActivity( showFileIntent );
+    } else {
+        runOnUiThread( () -> Toast.makeText( getApplicationContext(), "No application for opening this file", Toast.LENGTH_SHORT ).show() );
+    }
   }
 
   public void quitGracefully()

--- a/app/android/src/uk/co/lutraconsulting/InputActivity.java
+++ b/app/android/src/uk/co/lutraconsulting/InputActivity.java
@@ -42,7 +42,6 @@ import androidx.core.splashscreen.SplashScreen;
 public class InputActivity extends QtActivity
 {
   private static final String TAG = "Mergin Maps Input Activity";
-  private static final int OPEN_FILE_REQUEST_CODE = 1;
   private boolean keepSplashScreenVisible = true;
 
   @Override
@@ -157,15 +156,16 @@ public class InputActivity extends QtActivity
         return false;
     }
 
-    try 
+    if ( showFileIntent.resolveActivity( getPackageManager() ) != null ) 
     {
-        startActivityForResult( showFileIntent, OPEN_FILE_REQUEST_CODE );
-        return true;
+        startActivity( showFileIntent );
     } 
-    catch ( ActivityNotFoundException ex ) 
+    else 
     {
         return false;
     }
+    
+    return true;
   }
 
   public void quitGracefully()

--- a/app/android/src/uk/co/lutraconsulting/InputActivity.java
+++ b/app/android/src/uk/co/lutraconsulting/InputActivity.java
@@ -159,12 +159,12 @@ public class InputActivity extends QtActivity
 
     try 
     {
-      startActivityForResult( showFileIntent, OPEN_FILE_REQUEST_CODE );
-      return true;
+        startActivityForResult( showFileIntent, OPEN_FILE_REQUEST_CODE );
+        return true;
     } 
     catch ( ActivityNotFoundException ex ) 
     {
-      return false;
+        return false;
     }
   }
 

--- a/app/androidutils.cpp
+++ b/app/androidutils.cpp
@@ -233,7 +233,6 @@ bool AndroidUtils::openFile( const QString &filePath )
 #ifdef ANDROID
   auto activity = QJniObject( QNativeInterface::QAndroidApplication::context() );
   QJniObject jFilePath = QJniObject::fromString( filePath );
-  // Ensure the method signature includes 'Z' to indicate a boolean return type.
   result = activity.callMethod<jboolean>( "openFile", "(Ljava/lang/String;)Z", jFilePath.object<jstring>() );
 #endif
   return result;

--- a/app/androidutils.cpp
+++ b/app/androidutils.cpp
@@ -227,13 +227,16 @@ void AndroidUtils::hideSplashScreen()
 #endif
 }
 
-void AndroidUtils::openFile( const QString &filePath )
+bool AndroidUtils::openFile( const QString &filePath )
 {
+  bool result = false;
 #ifdef ANDROID
   auto activity = QJniObject( QNativeInterface::QAndroidApplication::context() );
   QJniObject jFilePath = QJniObject::fromString( filePath );
-  activity.callMethod<void>( "openFile", "(Ljava/lang/String;)V", jFilePath.object<jstring>() );
+  // Ensure the method signature includes 'Z' to indicate a boolean return type.
+  result = activity.callMethod<jboolean>( "openFile", "(Ljava/lang/String;)Z", jFilePath.object<jstring>() );
 #endif
+  return result;
 }
 
 bool AndroidUtils::requestStoragePermission()

--- a/app/androidutils.cpp
+++ b/app/androidutils.cpp
@@ -227,6 +227,15 @@ void AndroidUtils::hideSplashScreen()
 #endif
 }
 
+void AndroidUtils::openFile( const QString &filePath )
+{
+#ifdef ANDROID
+  auto activity = QJniObject( QNativeInterface::QAndroidApplication::context() );
+  QJniObject jFilePath = QJniObject::fromString( filePath );
+  activity.callMethod<void>( "openFile", "(Ljava/lang/String;)V", jFilePath.object<jstring>() );
+#endif
+}
+
 bool AndroidUtils::requestStoragePermission()
 {
 #ifdef ANDROID

--- a/app/androidutils.h
+++ b/app/androidutils.h
@@ -69,6 +69,7 @@ class AndroidUtils: public QObject
       */
     Q_INVOKABLE void callImagePicker( const QString &code = "" );
     Q_INVOKABLE void callCamera( const QString &targetPath, const QString &code = "" );
+    Q_INVOKABLE void openFile( const QString &filePath );
 
 #ifdef ANDROID
     const static int MEDIA_CODE = 101;

--- a/app/androidutils.h
+++ b/app/androidutils.h
@@ -69,7 +69,7 @@ class AndroidUtils: public QObject
       */
     Q_INVOKABLE void callImagePicker( const QString &code = "" );
     Q_INVOKABLE void callCamera( const QString &targetPath, const QString &code = "" );
-    Q_INVOKABLE void openFile( const QString &filePath );
+    Q_INVOKABLE bool openFile( const QString &filePath );
 
 #ifdef ANDROID
     const static int MEDIA_CODE = 101;

--- a/app/inpututils.cpp
+++ b/app/inpututils.cpp
@@ -2187,13 +2187,7 @@ void InputUtils::openLink( const QString &homePath, const QString &link )
 #ifdef Q_OS_ANDROID
         mAndroidUtils->openFile( absoluteLinkPath );
 #elif defined(Q_OS_IOS)
-        qWarning() << "IOS HERE";
-        //QUrl fileUrl = QUrl::fromLocalFile(absoluteLinkPath);
-
-        // Open the file with the default application
-        //QDesktopServices::openUrl(fileUrl);
         IosUtils::openFile( absoluteLinkPath );
-        qDebug() << "openLink ios";
 #else
         // Desktop environments
         QUrl fileUrl = QUrl::fromLocalFile( absoluteLinkPath );

--- a/app/inpututils.cpp
+++ b/app/inpututils.cpp
@@ -2185,9 +2185,11 @@ void InputUtils::openLink( const QString &homePath, const QString &link )
 bool InputUtils::openLink( const QString &homePath, const QString &link )
 >>>>>>> 247d842d (first part of post review changes)
 {
-  if ( link.startsWith( "project://" ) )
+  QString LOCAL_FILE_PREFIX = "project://";
+
+  if ( link.startsWith( LOCAL_FILE_PREFIX ) )
   {
-    QString relativePath = link.mid( QString( "project://" ).length() );
+    QString relativePath = link.mid( QString( LOCAL_FILE_PREFIX ).length() );
     QString absoluteLinkPath = homePath + QDir::separator() + relativePath;
     if ( !fileExists( absoluteLinkPath ) )
     {

--- a/app/inpututils.cpp
+++ b/app/inpututils.cpp
@@ -2180,37 +2180,37 @@ QString InputUtils::getDeviceModel()
 
 bool InputUtils::openLink( const QString &homePath, const QString &link )
 {
-    if ( link.startsWith( LOCAL_FILE_PREFIX ) )
+  if ( link.startsWith( LOCAL_FILE_PREFIX ) )
+  {
+    QString relativePath = link.mid( QString( LOCAL_FILE_PREFIX ).length() );
+    QString absoluteLinkPath = homePath + QDir::separator() + relativePath;
+    if ( !fileExists( absoluteLinkPath ) )
     {
-        QString relativePath = link.mid( QString( LOCAL_FILE_PREFIX ).length() );
-        QString absoluteLinkPath = homePath + QDir::separator() + relativePath;
-        if ( !fileExists( absoluteLinkPath ) )
-        {
-            return false;
-        }
+      return false;
+    }
 #ifdef Q_OS_ANDROID
-        if ( !mAndroidUtils->openFile( absoluteLinkPath ) )
-        {
-            return false;
-        }
-#elif defined(Q_OS_IOS)
-        if ( ! IosUtils::openFile( absoluteLinkPath ) )
-        {
-            return false;
-        }
-#else
-        // Desktop environments
-        QUrl fileUrl = QUrl::fromLocalFile( absoluteLinkPath );
-        if ( !QDesktopServices::openUrl( fileUrl ) )
-        {
-            return false;
-        }
-#endif
-    }
-    else
+    if ( !mAndroidUtils->openFile( absoluteLinkPath ) )
     {
-        QDesktopServices::openUrl( QUrl( link ) );
+      return false;
     }
+#elif defined(Q_OS_IOS)
+    if ( ! IosUtils::openFile( absoluteLinkPath ) )
+    {
+      return false;
+    }
+#else
+    // Desktop environments
+    QUrl fileUrl = QUrl::fromLocalFile( absoluteLinkPath );
+    if ( !QDesktopServices::openUrl( fileUrl ) )
+    {
+      return false;
+    }
+#endif
+  }
+  else
+  {
+    QDesktopServices::openUrl( QUrl( link ) );
+  }
 
-    return true;
+  return true;
 }

--- a/app/inpututils.cpp
+++ b/app/inpututils.cpp
@@ -53,7 +53,6 @@
 
 #include "imageutils.h"
 #include "variablesmanager.h"
-#include "notificationmodel.h"
 
 #include <Qt>
 #include <QDir>
@@ -2182,31 +2181,32 @@ QString InputUtils::getDeviceModel()
 
 void InputUtils::openLink( const QString &homePath, const QString &link )
 {
-    if ( link.startsWith( "project://" ) )
+  if ( link.startsWith( "project://" ) )
+  {
+    QString relativePath = link.mid( QString( "project://" ).length() );
+    QString absoluteLinkPath = homePath + QDir::separator() + relativePath;
+    if ( !fileExists( absoluteLinkPath ) )
     {
-        QString relativePath = link.mid( QString( "project://" ).length() );
-        QString absoluteLinkPath = homePath + QDir::separator() + relativePath;
-        if (!fileExists(absoluteLinkPath)){
-            QString errorMessage = tr("The specified file does not exist: %1").arg(relativePath);
-            QMessageBox::warning(nullptr, "File Not Found", errorMessage);
-            return;
-        }
+      QString errorMessage = tr( "The specified file does not exist: %1" ).arg( relativePath );
+      QMessageBox::warning( nullptr, "File Not Found", errorMessage );
+      return;
+    }
 #ifdef Q_OS_ANDROID
-        mAndroidUtils->openFile( absoluteLinkPath );
+    mAndroidUtils->openFile( absoluteLinkPath );
 #elif defined(Q_OS_IOS)
-        IosUtils::openFile( absoluteLinkPath );
+    IosUtils::openFile( absoluteLinkPath );
 #else
-        // Desktop environments
-        QUrl fileUrl = QUrl::fromLocalFile( absoluteLinkPath );
-        if ( !QDesktopServices::openUrl( fileUrl ) )
-        {
-            QString errorMessage = "Failed to open the file:" + absoluteLinkPath;
-            CoreUtils::log( "File  error", errorMessage );
-        }
-#endif
-    }
-    else
+    // Desktop environments
+    QUrl fileUrl = QUrl::fromLocalFile( absoluteLinkPath );
+    if ( !QDesktopServices::openUrl( fileUrl ) )
     {
-        QDesktopServices::openUrl( QUrl( link ) );
+      QString errorMessage = "Failed to open the file:" + absoluteLinkPath;
+      CoreUtils::log( "File  error", errorMessage );
     }
+#endif
+  }
+  else
+  {
+    QDesktopServices::openUrl( QUrl( link ) );
+  }
 }

--- a/app/inpututils.cpp
+++ b/app/inpututils.cpp
@@ -58,7 +58,7 @@
 #include <QDir>
 #include <QFile>
 #include <QFileInfo>
-#include <QRegularExpression>
+#include <QDesktopServices>
 #include <algorithm>
 #include <limits>
 #include <math.h>
@@ -2156,6 +2156,7 @@ QList<QgsPoint> InputUtils::parsePositionUpdates( const QString &data )
   return parsedUpdates;
 }
 
+<<<<<<< HEAD
 QString InputUtils::getManufacturer()
 {
 #ifdef Q_OS_ANDROID
@@ -2174,4 +2175,37 @@ QString InputUtils::getDeviceModel()
   return IosUtils::getDeviceModel();
 #endif
   return QStringLiteral( "N/A" );
+}
+
+void InputUtils::openLink( const QString &homePath, const QString &link )
+{
+  qDebug() << "LINK" << link;
+  qDebug() << "HOMEPATH" << homePath;
+
+  QString cleanedLink = link.trimmed();
+  static QRegularExpression re( "^\\?|\\?$" );
+  cleanedLink.remove( re );
+
+  qDebug() << "cleanedLink" << cleanedLink;
+
+  if ( cleanedLink.startsWith( "project://" ) )
+  {
+    QString relativePath = cleanedLink.mid( QString( "project://" ).length() );
+    QString absoluteLinkPath = homePath + QDir::separator() + relativePath;
+
+    qDebug() << "relativePath" << relativePath;
+    qDebug() << "absoluteLinkPath" << absoluteLinkPath;
+
+#ifdef Q_OS_ANDROID
+    qDebug() << "openLink android";
+    mAndroidUtils->openFile( absoluteLinkPath );
+#elif defined(Q_OS_IOS)
+    qDebug() << "openLink ios";
+#endif
+  }
+  else
+  {
+    cleanedLink.chop( 1 ); //remove \ from cleanedLink
+    QDesktopServices::openUrl( QUrl( cleanedLink ) );
+  }
 }

--- a/app/inpututils.cpp
+++ b/app/inpututils.cpp
@@ -59,6 +59,7 @@
 #include <QFile>
 #include <QFileInfo>
 #include <QDesktopServices>
+#include <QUrl>
 #include <algorithm>
 #include <limits>
 #include <math.h>
@@ -2179,33 +2180,42 @@ QString InputUtils::getDeviceModel()
 
 void InputUtils::openLink( const QString &homePath, const QString &link )
 {
-  qDebug() << "LINK" << link;
-  qDebug() << "HOMEPATH" << homePath;
+    qDebug() << "LINK" << link;
+    qDebug() << "HOMEPATH" << homePath;
 
-  QString cleanedLink = link.trimmed();
-  static QRegularExpression re( "^\\?|\\?$" );
-  cleanedLink.remove( re );
+    QString cleanedLink = link.trimmed();
+    static QRegularExpression re( "^\\?|\\?$" );
+    cleanedLink.remove( re );
+    cleanedLink.chop( 1 ); //remove \ from cleanedLink
 
-  qDebug() << "cleanedLink" << cleanedLink;
+    qDebug() << "cleanedLink" << cleanedLink;
 
-  if ( cleanedLink.startsWith( "project://" ) )
-  {
-    QString relativePath = cleanedLink.mid( QString( "project://" ).length() );
-    QString absoluteLinkPath = homePath + QDir::separator() + relativePath;
+    if ( cleanedLink.startsWith( "project://" ) )
+    {
+        QString relativePath = cleanedLink.mid( QString( "project://" ).length() );
+        QString absoluteLinkPath = homePath + QDir::separator() + relativePath;
 
-    qDebug() << "relativePath" << relativePath;
-    qDebug() << "absoluteLinkPath" << absoluteLinkPath;
+        QString testPath = "/Users/vmstar/Documents/Lutra/MM/mobile/app/android/assets/qgis-data/projects/PDF Viewing Project/dummy.pdf";
+        qDebug() << "relativePath" << relativePath;
+        qDebug() << "absoluteLinkPath" << absoluteLinkPath;
 
 #ifdef Q_OS_ANDROID
-    qDebug() << "openLink android";
-    mAndroidUtils->openFile( absoluteLinkPath );
+        qDebug() << "openLink android";
+        mAndroidUtils->openFile( absoluteLinkPath );
 #elif defined(Q_OS_IOS)
-    qDebug() << "openLink ios";
+        qDebug() << "openLink ios";
+        //IosUtils::openFile( )
+#else
+        // Desktop environments
+        QUrl fileUrl = QUrl::fromLocalFile( absoluteLinkPath );
+        if ( !QDesktopServices::openUrl( fileUrl ) )
+        {
+            qDebug() << "Failed to open the file:" << absoluteLinkPath;
+        }
 #endif
-  }
-  else
-  {
-    cleanedLink.chop( 1 ); //remove \ from cleanedLink
-    QDesktopServices::openUrl( QUrl( cleanedLink ) );
-  }
+    }
+    else
+    {
+        QDesktopServices::openUrl( QUrl( cleanedLink ) );
+    }
 }

--- a/app/inpututils.cpp
+++ b/app/inpututils.cpp
@@ -2180,26 +2180,32 @@ QString InputUtils::getDeviceModel()
 
 void InputUtils::openLink( const QString &homePath, const QString &link )
 {
-  if ( link.startsWith( "project://" ) )
-  {
-    QString relativePath = link.mid( QString( "project://" ).length() );
-    QString absoluteLinkPath = homePath + QDir::separator() + relativePath;
-#ifdef Q_OS_ANDROID
-    mAndroidUtils->openFile( absoluteLinkPath );
-#elif defined(Q_OS_IOS)
-    qDebug() << "openLink ios";
-#else
-    // Desktop environments
-    QUrl fileUrl = QUrl::fromLocalFile( absoluteLinkPath );
-    if ( !QDesktopServices::openUrl( fileUrl ) )
+    if ( link.startsWith( "project://" ) )
     {
-      QString errorMessage = "Failed to open the file:" + absoluteLinkPath;
-      CoreUtils::log( "File  error", errorMessage );
-    }
+        QString relativePath = link.mid( QString( "project://" ).length() );
+        QString absoluteLinkPath = homePath + QDir::separator() + relativePath;
+#ifdef Q_OS_ANDROID
+        mAndroidUtils->openFile( absoluteLinkPath );
+#elif defined(Q_OS_IOS)
+        qWarning() << "IOS HERE";
+        //QUrl fileUrl = QUrl::fromLocalFile(absoluteLinkPath);
+
+        // Open the file with the default application
+        //QDesktopServices::openUrl(fileUrl);
+        IosUtils::openFile( absoluteLinkPath );
+        qDebug() << "openLink ios";
+#else
+        // Desktop environments
+        QUrl fileUrl = QUrl::fromLocalFile( absoluteLinkPath );
+        if ( !QDesktopServices::openUrl( fileUrl ) )
+        {
+            QString errorMessage = "Failed to open the file:" + absoluteLinkPath;
+            CoreUtils::log( "File  error", errorMessage );
+        }
 #endif
-  }
-  else
-  {
-    QDesktopServices::openUrl( QUrl( link ) );
-  }
+    }
+    else
+    {
+        QDesktopServices::openUrl( QUrl( link ) );
+    }
 }

--- a/app/inpututils.cpp
+++ b/app/inpututils.cpp
@@ -53,10 +53,12 @@
 
 #include "imageutils.h"
 #include "variablesmanager.h"
+#include "notificationmodel.h"
 
 #include <Qt>
 #include <QDir>
 #include <QFile>
+#include <QMessageBox>
 #include <QFileInfo>
 #include <QDesktopServices>
 #include <QUrl>
@@ -2184,6 +2186,11 @@ void InputUtils::openLink( const QString &homePath, const QString &link )
     {
         QString relativePath = link.mid( QString( "project://" ).length() );
         QString absoluteLinkPath = homePath + QDir::separator() + relativePath;
+        if (!fileExists(absoluteLinkPath)){
+            QString errorMessage = tr("The specified file does not exist: %1").arg(relativePath);
+            QMessageBox::warning(nullptr, "File Not Found", errorMessage);
+            return;
+        }
 #ifdef Q_OS_ANDROID
         mAndroidUtils->openFile( absoluteLinkPath );
 #elif defined(Q_OS_IOS)

--- a/app/inpututils.cpp
+++ b/app/inpututils.cpp
@@ -2158,8 +2158,6 @@ QList<QgsPoint> InputUtils::parsePositionUpdates( const QString &data )
   return parsedUpdates;
 }
 
-<<<<<<< HEAD
-<<<<<<< HEAD
 QString InputUtils::getManufacturer()
 {
 #ifdef Q_OS_ANDROID
@@ -2180,42 +2178,39 @@ QString InputUtils::getDeviceModel()
   return QStringLiteral( "N/A" );
 }
 
-void InputUtils::openLink( const QString &homePath, const QString &link )
-=======
 bool InputUtils::openLink( const QString &homePath, const QString &link )
->>>>>>> 247d842d (first part of post review changes)
 {
-  if ( link.startsWith( LOCAL_FILE_PREFIX ) )
-  {
-    QString relativePath = link.mid( QString( LOCAL_FILE_PREFIX ).length() );
-    QString absoluteLinkPath = homePath + QDir::separator() + relativePath;
-    if ( !fileExists( absoluteLinkPath ) )
+    if ( link.startsWith( LOCAL_FILE_PREFIX ) )
     {
-      return false;
-    }
+        QString relativePath = link.mid( QString( LOCAL_FILE_PREFIX ).length() );
+        QString absoluteLinkPath = homePath + QDir::separator() + relativePath;
+        if ( !fileExists( absoluteLinkPath ) )
+        {
+            return false;
+        }
 #ifdef Q_OS_ANDROID
-    if ( !mAndroidUtils->openFile( absoluteLinkPath ) )
-    {
-      return false;
-    }
+        if ( !mAndroidUtils->openFile( absoluteLinkPath ) )
+        {
+            return false;
+        }
 #elif defined(Q_OS_IOS)
-    if ( ! IosUtils::openFile( absoluteLinkPath ) )
-    {
-      return false;
-    }
+        if ( ! IosUtils::openFile( absoluteLinkPath ) )
+        {
+            return false;
+        }
 #else
-    // Desktop environments
-    QUrl fileUrl = QUrl::fromLocalFile( absoluteLinkPath );
-    if ( !QDesktopServices::openUrl( fileUrl ) )
-    {
-      return false;
-    }
+        // Desktop environments
+        QUrl fileUrl = QUrl::fromLocalFile( absoluteLinkPath );
+        if ( !QDesktopServices::openUrl( fileUrl ) )
+        {
+            return false;
+        }
 #endif
-  }
-  else
-  {
-    QDesktopServices::openUrl( QUrl( link ) );
-  }
+    }
+    else
+    {
+        QDesktopServices::openUrl( QUrl( link ) );
+    }
 
-  return true;
+    return true;
 }

--- a/app/inpututils.cpp
+++ b/app/inpututils.cpp
@@ -2180,19 +2180,9 @@ QString InputUtils::getDeviceModel()
 
 void InputUtils::openLink( const QString &homePath, const QString &link )
 {
-    qDebug() << "LINK" << link;
-    qDebug() << "HOMEPATH" << homePath;
-
-    QString cleanedLink = link.trimmed();
-    static QRegularExpression re( "^\\?|\\?$" );
-    cleanedLink.remove( re );
-    cleanedLink.chop( 1 ); //remove \ from cleanedLink
-
-    qDebug() << "cleanedLink" << cleanedLink;
-
-    if ( cleanedLink.startsWith( "project://" ) )
+    if ( link.startsWith( "project://" ) )
     {
-        QString relativePath = cleanedLink.mid( QString( "project://" ).length() );
+        QString relativePath = link.mid( QString( "project://" ).length() );
         QString absoluteLinkPath = homePath + QDir::separator() + relativePath;
 
         QString testPath = "/Users/vmstar/Documents/Lutra/MM/mobile/app/android/assets/qgis-data/projects/PDF Viewing Project/dummy.pdf";
@@ -2200,22 +2190,21 @@ void InputUtils::openLink( const QString &homePath, const QString &link )
         qDebug() << "absoluteLinkPath" << absoluteLinkPath;
 
 #ifdef Q_OS_ANDROID
-        qDebug() << "openLink android";
         mAndroidUtils->openFile( absoluteLinkPath );
 #elif defined(Q_OS_IOS)
         qDebug() << "openLink ios";
-        //IosUtils::openFile( )
 #else
         // Desktop environments
         QUrl fileUrl = QUrl::fromLocalFile( absoluteLinkPath );
         if ( !QDesktopServices::openUrl( fileUrl ) )
         {
-            qDebug() << "Failed to open the file:" << absoluteLinkPath;
+            QString errorMessage = "Failed to open the file:" + absoluteLinkPath;
+            CoreUtils::log( "File  error", errorMessage );
         }
 #endif
     }
     else
     {
-        QDesktopServices::openUrl( QUrl( cleanedLink ) );
+        QDesktopServices::openUrl( QUrl( link ) );
     }
 }

--- a/app/inpututils.cpp
+++ b/app/inpututils.cpp
@@ -2180,31 +2180,31 @@ QString InputUtils::getDeviceModel()
 
 void InputUtils::openLink( const QString &homePath, const QString &link )
 {
-    if ( link.startsWith( "project://" ) )
-    {
-        QString relativePath = link.mid( QString( "project://" ).length() );
-        QString absoluteLinkPath = homePath + QDir::separator() + relativePath;
+  if ( link.startsWith( "project://" ) )
+  {
+    QString relativePath = link.mid( QString( "project://" ).length() );
+    QString absoluteLinkPath = homePath + QDir::separator() + relativePath;
 
-        QString testPath = "/Users/vmstar/Documents/Lutra/MM/mobile/app/android/assets/qgis-data/projects/PDF Viewing Project/dummy.pdf";
-        qDebug() << "relativePath" << relativePath;
-        qDebug() << "absoluteLinkPath" << absoluteLinkPath;
+    QString testPath = "/Users/vmstar/Documents/Lutra/MM/mobile/app/android/assets/qgis-data/projects/PDF Viewing Project/dummy.pdf";
+    qDebug() << "relativePath" << relativePath;
+    qDebug() << "absoluteLinkPath" << absoluteLinkPath;
 
 #ifdef Q_OS_ANDROID
-        mAndroidUtils->openFile( absoluteLinkPath );
+    mAndroidUtils->openFile( absoluteLinkPath );
 #elif defined(Q_OS_IOS)
-        qDebug() << "openLink ios";
+    qDebug() << "openLink ios";
 #else
-        // Desktop environments
-        QUrl fileUrl = QUrl::fromLocalFile( absoluteLinkPath );
-        if ( !QDesktopServices::openUrl( fileUrl ) )
-        {
-            QString errorMessage = "Failed to open the file:" + absoluteLinkPath;
-            CoreUtils::log( "File  error", errorMessage );
-        }
-#endif
-    }
-    else
+    // Desktop environments
+    QUrl fileUrl = QUrl::fromLocalFile( absoluteLinkPath );
+    if ( !QDesktopServices::openUrl( fileUrl ) )
     {
-        QDesktopServices::openUrl( QUrl( link ) );
+      QString errorMessage = "Failed to open the file:" + absoluteLinkPath;
+      CoreUtils::log( "File  error", errorMessage );
     }
+#endif
+  }
+  else
+  {
+    QDesktopServices::openUrl( QUrl( link ) );
+  }
 }

--- a/app/inpututils.cpp
+++ b/app/inpututils.cpp
@@ -2185,8 +2185,6 @@ void InputUtils::openLink( const QString &homePath, const QString &link )
 bool InputUtils::openLink( const QString &homePath, const QString &link )
 >>>>>>> 247d842d (first part of post review changes)
 {
-  QString LOCAL_FILE_PREFIX = "project://";
-
   if ( link.startsWith( LOCAL_FILE_PREFIX ) )
   {
     QString relativePath = link.mid( QString( LOCAL_FILE_PREFIX ).length() );

--- a/app/inpututils.cpp
+++ b/app/inpututils.cpp
@@ -2184,11 +2184,6 @@ void InputUtils::openLink( const QString &homePath, const QString &link )
   {
     QString relativePath = link.mid( QString( "project://" ).length() );
     QString absoluteLinkPath = homePath + QDir::separator() + relativePath;
-
-    QString testPath = "/Users/vmstar/Documents/Lutra/MM/mobile/app/android/assets/qgis-data/projects/PDF Viewing Project/dummy.pdf";
-    qDebug() << "relativePath" << relativePath;
-    qDebug() << "absoluteLinkPath" << absoluteLinkPath;
-
 #ifdef Q_OS_ANDROID
     mAndroidUtils->openFile( absoluteLinkPath );
 #elif defined(Q_OS_IOS)

--- a/app/inpututils.cpp
+++ b/app/inpututils.cpp
@@ -2159,6 +2159,7 @@ QList<QgsPoint> InputUtils::parsePositionUpdates( const QString &data )
 }
 
 <<<<<<< HEAD
+<<<<<<< HEAD
 QString InputUtils::getManufacturer()
 {
 #ifdef Q_OS_ANDROID
@@ -2180,6 +2181,9 @@ QString InputUtils::getDeviceModel()
 }
 
 void InputUtils::openLink( const QString &homePath, const QString &link )
+=======
+bool InputUtils::openLink( const QString &homePath, const QString &link )
+>>>>>>> 247d842d (first part of post review changes)
 {
   if ( link.startsWith( "project://" ) )
   {
@@ -2187,21 +2191,24 @@ void InputUtils::openLink( const QString &homePath, const QString &link )
     QString absoluteLinkPath = homePath + QDir::separator() + relativePath;
     if ( !fileExists( absoluteLinkPath ) )
     {
-      QString errorMessage = tr( "The specified file does not exist: %1" ).arg( relativePath );
-      QMessageBox::warning( nullptr, "File Not Found", errorMessage );
-      return;
+      return false;
     }
 #ifdef Q_OS_ANDROID
-    mAndroidUtils->openFile( absoluteLinkPath );
+    if ( !mAndroidUtils->openFile( absoluteLinkPath ) )
+    {
+      return false;
+    }
 #elif defined(Q_OS_IOS)
-    IosUtils::openFile( absoluteLinkPath );
+    if ( ! IosUtils::openFile( absoluteLinkPath ) )
+    {
+      return false;
+    }
 #else
     // Desktop environments
     QUrl fileUrl = QUrl::fromLocalFile( absoluteLinkPath );
     if ( !QDesktopServices::openUrl( fileUrl ) )
     {
-      QString errorMessage = "Failed to open the file:" + absoluteLinkPath;
-      CoreUtils::log( "File  error", errorMessage );
+      return false;
     }
 #endif
   }
@@ -2209,4 +2216,6 @@ void InputUtils::openLink( const QString &homePath, const QString &link )
   {
     QDesktopServices::openUrl( QUrl( link ) );
   }
+
+  return true;
 }

--- a/app/inpututils.h
+++ b/app/inpututils.h
@@ -174,6 +174,13 @@ class InputUtils: public QObject
      */
     Q_INVOKABLE static QString bytesToHumanSize( double bytes );
 
+    /**
+     * Opens the specified link in an appropriate application. For "project://" links, it converts them to
+     * absolute paths and opens with default file handlers. Other links are opened in the default web browser.
+     * @param link The link to open, either a "project://" link or a standard URL.
+     */
+    Q_INVOKABLE void openLink( const QString &homePath, const QString &link );
+
     Q_INVOKABLE bool acquireCameraPermission();
 
     Q_INVOKABLE bool isBluetoothTurnedOn();

--- a/app/inpututils.h
+++ b/app/inpututils.h
@@ -179,7 +179,7 @@ class InputUtils: public QObject
      * absolute paths and opens with default file handlers. Other links are opened in the default web browser.
      * @param link The link to open, either a "project://" link or a standard URL.
      */
-    Q_INVOKABLE void openLink( const QString &homePath, const QString &link );
+    Q_INVOKABLE bool openLink( const QString &homePath, const QString &link );
 
     Q_INVOKABLE bool acquireCameraPermission();
 

--- a/app/inpututils.h
+++ b/app/inpututils.h
@@ -610,6 +610,8 @@ class InputUtils: public QObject
     static QUrl iconFromGeometry( const Qgis::GeometryType &geometry );
 
     AndroidUtils *mAndroidUtils = nullptr; // not owned
+
+    const QString LOCAL_FILE_PREFIX = QStringLiteral( "project://" );
 };
 
 #endif // INPUTUTILS_H

--- a/app/ios/iosutils.cpp
+++ b/app/ios/iosutils.cpp
@@ -67,6 +67,7 @@ QVector<int> IosUtils::getSafeArea()
   return QVector<int>();
 }
 
+<<<<<<< HEAD
 QString IosUtils::getManufacturer()
 {
 #ifdef Q_OS_IOS
@@ -89,5 +90,11 @@ bool IosUtils::openFile( const QString &filePath )
     return openFileImpl( filePath );
 #else
     return false;
+=======
+bool IosUtils::openFile( const QString &filePath )
+{
+#ifdef Q_OS_IOS
+  return openFileImpl( filePath );
+>>>>>>> 247d842d (first part of post review changes)
 #endif
 }

--- a/app/ios/iosutils.cpp
+++ b/app/ios/iosutils.cpp
@@ -67,7 +67,6 @@ QVector<int> IosUtils::getSafeArea()
   return QVector<int>();
 }
 
-<<<<<<< HEAD
 QString IosUtils::getManufacturer()
 {
 #ifdef Q_OS_IOS
@@ -82,10 +81,13 @@ QString IosUtils::getDeviceModel()
   return getDeviceModelImpl();
 #endif
   return "";
-=======
-void IosUtils::openFile( const QString &filePath )
+}
+
+bool IosUtils::openFile( const QString &filePath )
 {
-  //qWarning() << "test";
-  openFileImpl( filePath ); //
->>>>>>> 05801f46 (ios pdf viewing)
+#ifdef Q_OS_IOS
+    return openFileImpl( filePath );
+#else
+    return false;
+#endif
 }

--- a/app/ios/iosutils.cpp
+++ b/app/ios/iosutils.cpp
@@ -86,7 +86,7 @@ QString IosUtils::getDeviceModel()
 bool IosUtils::openFile( const QString &filePath )
 {
 #ifdef Q_OS_IOS
-    return openFileImpl( filePath );
+  return openFileImpl( filePath );
 #else
   return false;
 #endif

--- a/app/ios/iosutils.cpp
+++ b/app/ios/iosutils.cpp
@@ -88,6 +88,6 @@ bool IosUtils::openFile( const QString &filePath )
 #ifdef Q_OS_IOS
     return openFileImpl( filePath );
 #else
-    return false;
+  return false;
 #endif
 }

--- a/app/ios/iosutils.cpp
+++ b/app/ios/iosutils.cpp
@@ -67,7 +67,6 @@ QVector<int> IosUtils::getSafeArea()
   return QVector<int>();
 }
 
-<<<<<<< HEAD
 QString IosUtils::getManufacturer()
 {
 #ifdef Q_OS_IOS
@@ -90,11 +89,5 @@ bool IosUtils::openFile( const QString &filePath )
     return openFileImpl( filePath );
 #else
     return false;
-=======
-bool IosUtils::openFile( const QString &filePath )
-{
-#ifdef Q_OS_IOS
-  return openFileImpl( filePath );
->>>>>>> 247d842d (first part of post review changes)
 #endif
 }

--- a/app/ios/iosutils.cpp
+++ b/app/ios/iosutils.cpp
@@ -67,6 +67,7 @@ QVector<int> IosUtils::getSafeArea()
   return QVector<int>();
 }
 
+<<<<<<< HEAD
 QString IosUtils::getManufacturer()
 {
 #ifdef Q_OS_IOS
@@ -81,4 +82,10 @@ QString IosUtils::getDeviceModel()
   return getDeviceModelImpl();
 #endif
   return "";
+=======
+void IosUtils::openFile( const QString &filePath )
+{
+  //qWarning() << "test";
+  openFileImpl( filePath ); //
+>>>>>>> 05801f46 (ios pdf viewing)
 }

--- a/app/ios/iosutils.h
+++ b/app/ios/iosutils.h
@@ -66,14 +66,10 @@ class IosUtils: public QObject
     void setIdleTimerDisabled();
 
     QVector<int> getSafeAreaImpl();
-<<<<<<< HEAD
+
     static QString getManufacturerImpl();
     static QString getDeviceModelImpl();
-
-=======
-
-    static void openFileImpl(const QString &filePath); //tesrtsasssaa
->>>>>>> 05801f46 (ios pdf viewing)
+    static void openFileImpl(const QString &filePath);
 };
 
 #endif // IOSUTILS_H

--- a/app/ios/iosutils.h
+++ b/app/ios/iosutils.h
@@ -43,7 +43,7 @@ class IosUtils: public QObject
 
     Q_INVOKABLE QVector<int> getSafeArea();
 
-    Q_INVOKABLE static void openFile( const QString &filePath );
+    Q_INVOKABLE static bool openFile( const QString &filePath );
 
     static Q_INVOKABLE QString getManufacturer();
     static Q_INVOKABLE QString getDeviceModel();
@@ -69,7 +69,7 @@ class IosUtils: public QObject
 
     static QString getManufacturerImpl();
     static QString getDeviceModelImpl();
-    static void openFileImpl(const QString &filePath);
+    static bool openFileImpl( const QString &filePath );
 };
 
 #endif // IOSUTILS_H

--- a/app/ios/iosutils.h
+++ b/app/ios/iosutils.h
@@ -42,8 +42,8 @@ class IosUtils: public QObject
     static QString readExif( const QString &filepath, const QString &tag );
 
     Q_INVOKABLE QVector<int> getSafeArea();
-    
-    Q_INVOKABLE static void openFile(const QString &filePath);
+
+    Q_INVOKABLE static void openFile( const QString &filePath );
 
     static Q_INVOKABLE QString getManufacturer();
     static Q_INVOKABLE QString getDeviceModel();

--- a/app/ios/iosutils.h
+++ b/app/ios/iosutils.h
@@ -42,6 +42,8 @@ class IosUtils: public QObject
     static QString readExif( const QString &filepath, const QString &tag );
 
     Q_INVOKABLE QVector<int> getSafeArea();
+    
+    Q_INVOKABLE static void openFile(const QString &filePath);
 
     static Q_INVOKABLE QString getManufacturer();
     static Q_INVOKABLE QString getDeviceModel();
@@ -64,9 +66,14 @@ class IosUtils: public QObject
     void setIdleTimerDisabled();
 
     QVector<int> getSafeAreaImpl();
+<<<<<<< HEAD
     static QString getManufacturerImpl();
     static QString getDeviceModelImpl();
 
+=======
+
+    static void openFileImpl(const QString &filePath); //tesrtsasssaa
+>>>>>>> 05801f46 (ios pdf viewing)
 };
 
 #endif // IOSUTILS_H

--- a/app/ios/iosutils.mm
+++ b/app/ios/iosutils.mm
@@ -14,16 +14,13 @@
  ***************************************************************************/
 
 #include <UIKit/UIKit.h>
-<<< <<< < HEAD
 #include <sys/utsname.h>
-== == == =
 #import <Foundation/Foundation.h>
 #import <UIKit/UIKit.h>
 #include <QString>
-  >>> >>> > 05801f46( ios pdf viewing )
 #include "iosutils.h"
 
-  void IosUtils::setIdleTimerDisabled()
+void IosUtils::setIdleTimerDisabled()
 {
   [[UIApplication sharedApplication] setIdleTimerDisabled:YES];
 }

--- a/app/ios/iosutils.mm
+++ b/app/ios/iosutils.mm
@@ -14,8 +14,15 @@
  ***************************************************************************/
 
 #include <UIKit/UIKit.h>
+<<<<<<< HEAD
 #include <sys/utsname.h>
+=======
+#import <Foundation/Foundation.h>
+#import <UIKit/UIKit.h>
+#include <QString>
+>>>>>>> 05801f46 (ios pdf viewing)
 #include "iosutils.h"
+#include "coreutils.h"
 
 void IosUtils::setIdleTimerDisabled()
 {
@@ -53,4 +60,33 @@ QString IosUtils::getDeviceModelImpl()
   uname( &systemInfo );
   QString deviceModel = QString::fromUtf8( systemInfo.machine );
   return deviceModel.toUpper();
+}
+
+@interface FileOpener : UIViewController <UIDocumentInteractionControllerDelegate>
+@end
+
+@implementation FileOpener
+
+- (UIViewController *)documentInteractionControllerViewControllerForPreview:(UIDocumentInteractionController *)ctrl {
+  return self;
+}
+
+@end
+
+void IosUtils::openFileImpl(const QString &filePath)
+{
+  static FileOpener *viewer = nil;
+  NSURL *resourceURL = [NSURL fileURLWithPath:filePath.toNSString()];
+  CoreUtils::log("PDF file encountered: ", [resourceURL path].UTF8String);
+
+  UIDocumentInteractionController *interactionCtrl = [UIDocumentInteractionController interactionControllerWithURL:resourceURL];
+  UIViewController *rootViewController = [[[[UIApplication sharedApplication] windows] firstObject] rootViewController];
+
+  viewer = [[FileOpener alloc] init];
+  [rootViewController addChildViewController: viewer];
+  interactionCtrl.delegate = (id<UIDocumentInteractionControllerDelegate>)viewer;
+
+  if (![interactionCtrl presentPreviewAnimated:NO]){
+    [interactionCtrl presentOptionsMenuFromRect:CGRectZero inView:viewer.view animated:NO];
+  }
 }

--- a/app/ios/iosutils.mm
+++ b/app/ios/iosutils.mm
@@ -66,13 +66,14 @@ QString IosUtils::getDeviceModelImpl()
 
 @implementation FileOpener
 
-- (UIViewController *)documentInteractionControllerViewControllerForPreview:(UIDocumentInteractionController *)ctrl {
+- ( UIViewController * )documentInteractionControllerViewControllerForPreview:( UIDocumentInteractionController * )ctrl
+{
   return self;
 }
 
 @end
 
-void IosUtils::openFileImpl(const QString &filePath)
+void IosUtils::openFileImpl( const QString &filePath )
 {
   static FileOpener *viewer = nil;
   NSURL *resourceURL = [NSURL fileURLWithPath:filePath.toNSString()];
@@ -82,9 +83,10 @@ void IosUtils::openFileImpl(const QString &filePath)
 
   viewer = [[FileOpener alloc] init];
   [rootViewController addChildViewController: viewer];
-  interactionCtrl.delegate = (id<UIDocumentInteractionControllerDelegate>)viewer;
+  interactionCtrl.delegate = ( id<UIDocumentInteractionControllerDelegate> )viewer;
 
-  if (![interactionCtrl presentPreviewAnimated:NO]){
+  if ( ![interactionCtrl presentPreviewAnimated:NO] )
+  {
     [interactionCtrl presentOptionsMenuFromRect:CGRectZero inView:viewer.view animated:NO];
   }
 }

--- a/app/ios/iosutils.mm
+++ b/app/ios/iosutils.mm
@@ -22,7 +22,6 @@
 #include <QString>
 >>>>>>> 05801f46 (ios pdf viewing)
 #include "iosutils.h"
-#include "coreutils.h"
 
 void IosUtils::setIdleTimerDisabled()
 {
@@ -77,7 +76,6 @@ void IosUtils::openFileImpl(const QString &filePath)
 {
   static FileOpener *viewer = nil;
   NSURL *resourceURL = [NSURL fileURLWithPath:filePath.toNSString()];
-  CoreUtils::log("PDF file encountered: ", [resourceURL path].UTF8String);
 
   UIDocumentInteractionController *interactionCtrl = [UIDocumentInteractionController interactionControllerWithURL:resourceURL];
   UIViewController *rootViewController = [[[[UIApplication sharedApplication] windows] firstObject] rootViewController];

--- a/app/ios/iosutils.mm
+++ b/app/ios/iosutils.mm
@@ -73,7 +73,7 @@ QString IosUtils::getDeviceModelImpl()
 
 @end
 
-void IosUtils::openFileImpl( const QString &filePath )
+bool IosUtils::openFileImpl( const QString &filePath )
 {
   static FileOpener *viewer = nil;
   NSURL *resourceURL = [NSURL fileURLWithPath:filePath.toNSString()];
@@ -87,6 +87,11 @@ void IosUtils::openFileImpl( const QString &filePath )
 
   if ( ![interactionCtrl presentPreviewAnimated:NO] )
   {
-    [interactionCtrl presentOptionsMenuFromRect:CGRectZero inView:viewer.view animated:NO];
+    if ( ![interactionCtrl presentOptionsMenuFromRect:CGRectZero inView:viewer.view animated:NO] )
+    {
+      return false;
+    }
   }
+
+  return true;
 }

--- a/app/ios/iosutils.mm
+++ b/app/ios/iosutils.mm
@@ -14,16 +14,16 @@
  ***************************************************************************/
 
 #include <UIKit/UIKit.h>
-<<<<<<< HEAD
+<<< <<< < HEAD
 #include <sys/utsname.h>
-=======
+== == == =
 #import <Foundation/Foundation.h>
 #import <UIKit/UIKit.h>
 #include <QString>
->>>>>>> 05801f46 (ios pdf viewing)
+  >>> >>> > 05801f46( ios pdf viewing )
 #include "iosutils.h"
 
-void IosUtils::setIdleTimerDisabled()
+  void IosUtils::setIdleTimerDisabled()
 {
   [[UIApplication sharedApplication] setIdleTimerDisabled:YES];
 }

--- a/app/qml/form/editors/MMFormRichTextViewer.qml
+++ b/app/qml/form/editors/MMFormRichTextViewer.qml
@@ -48,7 +48,12 @@ MMPrivateComponents.MMBaseInput {
       leftPadding: __style.margin20
       rightPadding: __style.margin20
 
-      onLinkActivated: ( link ) => __inputUtils.openLink( root._fieldHomePath, link.toString() )
+      onLinkActivated: function ( link ) {
+        if ( !__inputUtils.openLink( root._fieldHomePath, link.toString( ) ) )
+        {
+          __notificationModel.addError( "Could not open the file. It may not exist, could be invalid, or there might be no application available to open it." )
+        }
+      }
     }
   }
 }

--- a/app/qml/form/editors/MMFormRichTextViewer.qml
+++ b/app/qml/form/editors/MMFormRichTextViewer.qml
@@ -20,6 +20,7 @@ MMPrivateComponents.MMBaseInput {
   property bool _fieldShouldShowTitle: parent.fieldShouldShowTitle
 
   property string _fieldTitle: parent.fieldTitle
+  property string _fieldHomePath: parent.fieldHomePath
 
   title: _fieldShouldShowTitle ? _fieldTitle : ""
 
@@ -47,9 +48,8 @@ MMPrivateComponents.MMBaseInput {
       leftPadding: __style.margin20
       rightPadding: __style.margin20
 
-      onLinkActivated: function( link ) {
-        Qt.openUrlExternally( link )
-      }
+      //HERE
+      onLinkActivated: ( link ) => __inputUtils.openLink( root._fieldHomePath, link.toString() )
     }
   }
 }

--- a/app/qml/form/editors/MMFormRichTextViewer.qml
+++ b/app/qml/form/editors/MMFormRichTextViewer.qml
@@ -48,7 +48,6 @@ MMPrivateComponents.MMBaseInput {
       leftPadding: __style.margin20
       rightPadding: __style.margin20
 
-      //HERE
       onLinkActivated: ( link ) => __inputUtils.openLink( root._fieldHomePath, link.toString() )
     }
   }

--- a/app/qml/form/editors/MMFormTextMultilineEditor.qml
+++ b/app/qml/form/editors/MMFormTextMultilineEditor.qml
@@ -118,7 +118,13 @@ MMPrivateComponents.MMBaseInput {
       radius: __style.radius12
     }
 
-    onLinkActivated: ( link ) => __inputUtils.openLink( root._fieldHomePath, link.toString() )
+    onLinkActivated: function ( link ) {
+      if ( !__inputUtils.openLink( root._fieldHomePath, link.toString( ) ) )
+      {
+        __notificationModel.addError( "Could not open the file. It may not exist, could be invalid, or there might be no application available to open it." )
+      }
+    }
+
     onTextChanged: root.editorValueChanged( textArea.text, textArea.text === "" )
   }
 

--- a/app/qml/form/editors/MMFormTextMultilineEditor.qml
+++ b/app/qml/form/editors/MMFormTextMultilineEditor.qml
@@ -117,7 +117,7 @@ MMPrivateComponents.MMBaseInput {
       radius: __style.radius12
     }
 
-    onLinkActivated: ( link ) => Qt.openUrlExternally( link )
+    onLinkActivated: ( link ) => __inputUtils.openLink( root._fieldHomePath, link.toString() )
     onTextChanged: root.editorValueChanged( textArea.text, textArea.text === "" )
   }
 

--- a/app/qml/form/editors/MMFormTextMultilineEditor.qml
+++ b/app/qml/form/editors/MMFormTextMultilineEditor.qml
@@ -36,6 +36,7 @@ MMPrivateComponents.MMBaseInput {
   property string _fieldTitle: parent.fieldTitle
   property string _fieldErrorMessage: parent.fieldErrorMessage
   property string _fieldWarningMessage: parent.fieldWarningMessage
+  property string _fieldHomePath: parent.fieldHomePath
 
   property bool _fieldRememberValueSupported: parent.fieldRememberValueSupported
   property bool _fieldRememberValueState: parent.fieldRememberValueState

--- a/cmake_templates/AndroidManifest.xml.in
+++ b/cmake_templates/AndroidManifest.xml.in
@@ -100,10 +100,15 @@
         <service android:process=":trackingThread" android:name=".PositionTrackingService" android:foregroundServiceType="location" android:stopWithTask="true"/>
     </application>
 
-    <!-- Explicitly mention that we need to use external app for capturing an image -->
+    <!-- Explicitly mention that we need to use external app for capturing an image and open file-->
     <queries>
-      <intent>
+    <intent>
         <action android:name="android.media.action.IMAGE_CAPTURE" />
-      </intent>
+    </intent>
+    <intent>
+        <action android:name="android.intent.action.VIEW" />
+        <category android:name="android.intent.category.BROWSABLE" />
+        <data android:scheme="https" />
+    </intent>
     </queries>
 </manifest>

--- a/cmake_templates/AndroidManifest.xml.in
+++ b/cmake_templates/AndroidManifest.xml.in
@@ -107,6 +107,7 @@
     </intent>
     <intent>
         <action android:name="android.intent.action.VIEW" />
+        <action android:name="android.intent.action.OPEN_DOCUMENT" />
         <category android:name="android.intent.category.BROWSABLE" />
         <data android:scheme="https" />
     </intent>

--- a/cmake_templates/AndroidManifest.xml.in
+++ b/cmake_templates/AndroidManifest.xml.in
@@ -108,6 +108,7 @@
     <intent>
         <action android:name="android.intent.action.VIEW" />
         <action android:name="android.intent.action.OPEN_DOCUMENT" />
+        <action android:name="android.intent.action.GET_CONTENT" />
         <category android:name="android.intent.category.BROWSABLE" />
         <data android:scheme="https" />
     </intent>

--- a/cmake_templates/AndroidManifest.xml.in
+++ b/cmake_templates/AndroidManifest.xml.in
@@ -107,8 +107,6 @@
     </intent>
     <intent>
         <action android:name="android.intent.action.VIEW" />
-        <action android:name="android.intent.action.OPEN_DOCUMENT" />
-        <action android:name="android.intent.action.GET_CONTENT" />
         <category android:name="android.intent.category.BROWSABLE" />
         <data android:scheme="https" />
     </intent>


### PR DESCRIPTION
This feature can be used to open PDF files using the user’s system default application viewer, and can open formats such as links, PDFs, Docx, etc.
1. In a form that allows multiline entries, add text to the "Form Layout" widgets. This can be done in the "Default Value" section, or within the "HtmlWidget" field.
2. To embed a PDF file in the project, use the following HTML format:
-    For the "Default Value" section, enter:
    -    **`'<a href="project://dummy.pdf">Open File</a>' `** (include the HTML code inside single quotes).
-    For direct entry in the "HtmlWidget", use:
    -    **`<a href="project://dummy.pdf">Open File</a>`** (able to enter the HTML code without quotes).
3. After synchronizing the project, check the app to ensure that the fields display the link reference correctly.
4. 
| HTML Link | Invalid File |
|--------|--------|
|<img src="https://github.com/MerginMaps/mobile/assets/155513369/8eb4c584-466c-452b-a049-e8e5884bc324" width="200"> | <img src="https://github.com/MerginMaps/mobile/assets/155513369/5b30184d-b9db-4efa-8d45-d20ba596da2b" width="200"> |

5. When clicking into the HTML button, the PDF file will be opened using the default application of the system.
6. Additional Note: 

- In the case of a file inside a folder in the project directory, use the following format:
`<a href="project://files/sample.pdf">Open PDF File inside folder "files"</a>`
_sample.pdf file inside 'files' folder_