### PR TITLE
send uuid in HTTP request

### DIFF
--- a/app/appsettings.cpp
+++ b/app/appsettings.cpp
@@ -13,13 +13,12 @@
 #include <QSettings>
 #include <QFileInfo>
 
-const QString AppSettings::INPUTAPP_GROUP_NAME = QStringLiteral( "inputApp" );
 const QString AppSettings::POSITION_PROVIDERS_GROUP = QStringLiteral( "inputApp/positionProviders" );
 
 AppSettings::AppSettings( QObject *parent ): QObject( parent )
 {
   QSettings settings;
-  settings.beginGroup( INPUTAPP_GROUP_NAME );
+  settings.beginGroup( CoreUtils::QSETTINGS_APP_GROUP_NAME );
   QString path = settings.value( "defaultProject", "" ).toString();
   QString layer = settings.value( "defaultLayer/"  + path, "" ).toString();
   double gpsTolerance = settings.value( "gpsTolerance", 10 ).toDouble();
@@ -250,7 +249,7 @@ void AppSettings::savePositionProviders( const QVariantList &providers )
 void AppSettings::setValue( const QString &key, const QVariant &value )
 {
   QSettings settings;
-  settings.beginGroup( INPUTAPP_GROUP_NAME );
+  settings.beginGroup( CoreUtils::QSETTINGS_APP_GROUP_NAME );
   settings.setValue( key, value );
   settings.endGroup();
 }
@@ -258,7 +257,7 @@ void AppSettings::setValue( const QString &key, const QVariant &value )
 QVariant AppSettings::value( const QString &key, const QVariant &defaultValue )
 {
   QSettings settings;
-  settings.beginGroup( INPUTAPP_GROUP_NAME );
+  settings.beginGroup( CoreUtils::QSETTINGS_APP_GROUP_NAME );
   QVariant value = settings.value( key, defaultValue );
   settings.endGroup();
 

--- a/app/appsettings.h
+++ b/app/appsettings.h
@@ -80,7 +80,6 @@ class AppSettings: public QObject
     QString ignoreMigrateVersion() const;
     void setIgnoreMigrateVersion( const QString &version );
 
-    static const QString INPUTAPP_GROUP_NAME;
     static const QString POSITION_PROVIDERS_GROUP;
 
   public slots:

--- a/app/inputhelp.cpp
+++ b/app/inputhelp.cpp
@@ -235,6 +235,7 @@ QVector<QString> InputHelp::logHeader( bool isHtml )
 {
   QVector<QString> retLines;
   retLines.push_back( QStringLiteral( "Input App: %1 - %2 (%3)" ).arg( CoreUtils::appVersion() ).arg( InputUtils::appPlatform() ).arg( CoreUtils::appVersionCode() ) );
+  retLines.push_back( QStringLiteral( "Device UUID: %1" ).arg( CoreUtils::deviceUuid() ) );
   retLines.push_back( QStringLiteral( "Data Dir: %1" ).arg( InputUtils::appDataDir() ) );
   retLines.push_back( QStringLiteral( "System: %1" ).arg( QSysInfo::prettyProductName() ) );
   retLines.push_back( QStringLiteral( "Mergin URL: %1" ).arg( mMerginApi->apiRoot() ) );

--- a/app/main.cpp
+++ b/app/main.cpp
@@ -394,6 +394,7 @@ int main( int argc, char *argv[] )
 #endif
   qDebug() << "Mergin Maps Input App" << version << InputUtils::appPlatform() << "(" << CoreUtils::appVersionCode() << ")";
   qDebug() << "Built with QGIS " << VERSION_INT << " and QT " << qVersion();
+  qDebug() << "Device uuid " << CoreUtils::deviceUuid();
 
   // Set/Get enviroment
   QString dataDir = getDataDir();

--- a/app/test/testposition.cpp
+++ b/app/test/testposition.cpp
@@ -15,6 +15,7 @@
 
 #include "qgsapplication.h"
 #include "appsettings.h"
+#include "coreutils.h"
 #include "position/positionkit.h"
 #include "position/providers/simulatedpositionprovider.h"
 
@@ -261,11 +262,11 @@ void TestPosition::testPositionProviderKeysInSettings()
   QCOMPARE( positionKit->positionProvider()->name(), "testProviderA" );
   QCOMPARE( positionKit->positionProvider()->type(), "external" );
 
-  QCOMPARE( rawSettings.value( AppSettings::INPUTAPP_GROUP_NAME + "/activePositionProviderId" ).toString(), "AA:BB:CC:DD:EE:FF" );
+  QCOMPARE( rawSettings.value( CoreUtils::QSETTINGS_APP_GROUP_NAME + "/activePositionProviderId" ).toString(), "AA:BB:CC:DD:EE:FF" );
 
   positionKit->setPositionProvider( positionKit->constructProvider( "internal", "devicegps" ) );
 
-  QCOMPARE( rawSettings.value( AppSettings::INPUTAPP_GROUP_NAME + "/activePositionProviderId" ).toString(), "devicegps" );
+  QCOMPARE( rawSettings.value( CoreUtils::QSETTINGS_APP_GROUP_NAME + "/activePositionProviderId" ).toString(), "devicegps" );
 
   // even without appSettings provider model should have two items in desktop build: simulated and internal provider
   PositionProvidersModel providersModel;

--- a/core/coreutils.cpp
+++ b/core/coreutils.cpp
@@ -54,8 +54,8 @@ QString CoreUtils::deviceUuid()
 
 QString CoreUtils::appInfo()
 {
-  return QString( "%1/%2 (%3/%4) %5" ).arg( QCoreApplication::applicationName() ).arg( QCoreApplication::applicationVersion() )
-         .arg( QSysInfo::productType() ).arg( QSysInfo::productVersion() ).arg( deviceUuid() );
+  return QString( "%1/%2 (%3/%4)" ).arg( QCoreApplication::applicationName() ).arg( QCoreApplication::applicationVersion() )
+         .arg( QSysInfo::productType() ).arg( QSysInfo::productVersion() );
 }
 
 QString CoreUtils::appVersion()

--- a/core/coreutils.h
+++ b/core/coreutils.h
@@ -102,6 +102,13 @@ class CoreUtils
      */
     static QString nameAbbr( const QString &name, const QString &email );
 
+    /**
+     *  Returns unique identifier of the device
+     *  The UUID is stored in QSettings and is randomly generated on first app run.
+     */
+    static QString deviceUuid();
+
+    static const QString QSETTINGS_APP_GROUP_NAME;
   private:
     static QString sLogFile;
     static int CHECKSUM_CHUNK_SIZE;

--- a/core/merginapi.cpp
+++ b/core/merginapi.cpp
@@ -308,6 +308,8 @@ QNetworkRequest MerginApi::getDefaultRequest( bool withAuth )
   QNetworkRequest request;
   QString info = CoreUtils::appInfo();
   request.setRawHeader( "User-Agent", QByteArray( info.toUtf8() ) );
+  QString deviceId = CoreUtils::deviceUuid();
+  request.setRawHeader( "X-Device-Id", QByteArray( deviceId.toUtf8() ) );
   if ( withAuth )
     request.setRawHeader( "Authorization", QByteArray( "Bearer " + mUserAuth->authToken() ) );
 


### PR DESCRIPTION
Add GUID to each HTTP request and also show it in the diagnosis log. GUID is generated on first run or the app.
We use `X-Device-Id` with uuid as custom header