### PR TITLE
Fix multiline editor

### DIFF
--- a/app/qml/form/editors/MMFormTextMultilineEditor.qml
+++ b/app/qml/form/editors/MMFormTextMultilineEditor.qml
@@ -63,7 +63,7 @@ MMPrivateComponents.MMBaseInput {
     width: parent.width
     height: Math.max( implicitHeight, internal.minHeight )
 
-    text: _fieldValue === undefined || _fieldValueIsNull ? '' : _fieldValue
+    text: _fieldValue === undefined ? '' : _fieldValue
     textFormat: root._fieldConfig['UseHtml'] ? TextEdit.RichText : TextEdit.PlainText
 
     topPadding: __style.margin12


### PR DESCRIPTION
Binding to the `TextArea::text` property led to a loop. `_fieldValueIsNull` was still false when `_fieldValue` was changed and it blocked the new string to appear. 

The binding is now the same as it was previously.

Fixes #3361 