### PR TITLE
Remove leading zero in month number for iOS versions

### DIFF
--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -174,7 +174,7 @@ jobs:
         run: |
             BUILD_NUM=$GITHUB_RUN_NUMBER$((GITHUB_RUN_ATTEMPT + OFFFSET))
 
-            TIMESTAMP=`date "+%y.%m"`
+            TIMESTAMP=`date "+%y.%-m"`
             CF_BUNDLE_VERSION=${TIMESTAMP}.${BUILD_NUM}
 
             echo "INPUT_VERSION_CODE=${CF_BUNDLE_VERSION}" >> $GITHUB_ENV


### PR DESCRIPTION
Changes version numbers from `24.04.xyz` to `24.4.xyz`. This makes it easier to search for versions in AppStoreConnect as Apple considers the numbers to be integers.