### PR TITLE
Unabling project reloading after project sync in home/projects page

### DIFF
--- a/app/qml/main.qml
+++ b/app/qml/main.qml
@@ -961,11 +961,6 @@ ApplicationWindow {
     function onProjectReloaded( project ) {
       map.clear()
 
-      if ( __activeProject.isProjectLoaded() )
-      {
-        projectController.hidePanel()
-      }
-
       __appSettings.defaultProject = __activeProject.localProject.qgisProjectFilePath ?? ""
       __appSettings.activeProject = __activeProject.localProject.qgisProjectFilePath ?? ""
     }


### PR DESCRIPTION
When syncing from the Home/Projects page, the project does not open automatically after the synchronization is completed.

Fixes #3358 