### PR TITLE
Fixing issue where the close button is rendered within the safe area in landscape mode

### DIFF
--- a/app/qml/components/MMDrawerHeader.qml
+++ b/app/qml/components/MMDrawerHeader.qml
@@ -55,7 +55,7 @@ Rectangle {
     id: closeBtn
 
     anchors {
-      right: parent.right //__style.safeAreaRight  //parent.right - __style.safeAreaRight //__style.pageMargins //ApplicationWindow.window.safeArea.left
+      right: parent.right
       rightMargin: __style.pageMargins + __style.safeAreaRight
       verticalCenter: parent.verticalCenter
     }

--- a/app/qml/components/MMDrawerHeader.qml
+++ b/app/qml/components/MMDrawerHeader.qml
@@ -55,8 +55,8 @@ Rectangle {
     id: closeBtn
 
     anchors {
-      right: parent.right
-      rightMargin: __style.pageMargins
+      right: parent.right //__style.safeAreaRight  //parent.right - __style.safeAreaRight //__style.pageMargins //ApplicationWindow.window.safeArea.left
+      rightMargin: __style.pageMargins + __style.safeAreaRight
       verticalCenter: parent.verticalCenter
     }
 


### PR DESCRIPTION
Following https://github.com/MerginMaps/mobile/issues/3324, the fix now ensures that the closeBtn is no longer within the safe area while in landscape mode.