### PR TITLE
Conditioning closing through dragging in MMListDrawer and MMListMultiselectDrawer

### DIFF
--- a/app/qml/components/MMListDrawer.qml
+++ b/app/qml/components/MMListDrawer.qml
@@ -18,7 +18,7 @@ MMDrawer {
   property bool showFullScreen: false
   property alias emptyStateDelegate: emptyStateDelegateLoader.sourceComponent
 
-  interactive: false
+  interactive: !listViewComponent.interactive
 
   drawerContent: Item {
     width: parent.width

--- a/app/qml/components/MMListDrawer.qml
+++ b/app/qml/components/MMListDrawer.qml
@@ -18,6 +18,8 @@ MMDrawer {
   property bool showFullScreen: false
   property alias emptyStateDelegate: emptyStateDelegateLoader.sourceComponent
 
+  interactive: false
+
   drawerContent: Item {
     width: parent.width
     height: {

--- a/app/qml/components/MMListMultiselectDrawer.qml
+++ b/app/qml/components/MMListMultiselectDrawer.qml
@@ -31,6 +31,8 @@ MMDrawer {
   signal searchTextChanged( string searchText )
   signal selectionFinished( var selectedItems )
 
+  interactive: !listViewComponent.interactive
+
   drawerBottomMargin: 0
 
   drawerContent: Item {


### PR DESCRIPTION
MMListDrawer and MMListMultiselectDrawer closure via dragging is now disabled when the listViewContent's interactive property is set to true (contentHeight > height). This change impacts drawers like MMMapThemeDrawer and featurePairSelection (features list drawer).

Fixes #3412 