### PR TITLE
Fix code layout CI - install previous astyle

### DIFF
--- a/.github/workflows/code_style.yml
+++ b/.github/workflows/code_style.yml
@@ -27,21 +27,18 @@ jobs:
     if: ( github.repository == 'MerginMaps/mobile' ) && (!contains(github.event.head_commit.message, 'Translate '))
     runs-on: macos-latest
     steps:
-      - name: Install astyle
-        run: |
-          python3 -m venv ./venv
-          source ./venv/bin/activate
-          sudo pip3 install astyle===3.4.13
-          # brew update
-          # brew install astyle
 
       - name: Checkout input
         uses: actions/checkout@v3
         with:
           path: input
 
-      - name: Run astyle check
+      - name: Install astyle and run the check
         run: |
+          python3 -m venv ./venv
+          source ./venv/bin/activate
+          sudo pip3 install astyle===3.4.13
+          
           ./input/scripts/format_cpp.bash
 
   code_style_cmake:

--- a/.github/workflows/code_style.yml
+++ b/.github/workflows/code_style.yml
@@ -29,8 +29,11 @@ jobs:
     steps:
       - name: Install astyle
         run: |
-          brew update
-          brew install astyle
+          python3 -m venv ./venv
+          source ./venv/bin/activate
+          sudo pip3 install astyle===3.4.13
+          # brew update
+          # brew install astyle
 
       - name: Checkout input
         uses: actions/checkout@v3


### PR DESCRIPTION
New `astyle` version (3.4.15) did not work well, see https://sourceforge.net/p/astyle/bugs/570/

I reverted it back to 3.4.13, it was not available in homebrew, so I installed it via pip. Not sure if it is a good idea, all of us will need to install it via pip now. Another option is to either build it locally or write custom `astyle.rb` definition file for homebrew (see https://github.com/Cloudxtreme/ds-cli/blob/0d511740f049834bd5e6872a8878fb237b531a03/platform/mac/homebrew/Library/Formula/astyle.rb#L4)

This way it works at least here! :) 