### PR TITLE
Fix project opening

### DIFF
--- a/app/qml/main.qml
+++ b/app/qml/main.qml
@@ -938,6 +938,11 @@ ApplicationWindow {
     function onLoadingFinished() {
       projectLoadingPage.visible = false
 
+      if ( __activeProject.isProjectLoaded() )
+      {
+        projectController.hidePanel()
+      }
+
       // check location permission
       if ( locationPermission.status === Qt.Undetermined ) {
         locationPermission.request();


### PR DESCRIPTION
https://github.com/MerginMaps/mobile/pull/3401 was a good effort for fixing https://github.com/MerginMaps/mobile/issues/3358, however the correct solution was not to remove the code, but move it from `onProjectReloaded` to `onLoadingFinished` -> this signal is not emitted when doing reload of active project.

Resolves https://github.com/MerginMaps/mobile/issues/3358
Resolves https://github.com/MerginMaps/mobile/issues/3422 