### PR TITLE
Disable cache for list views

### DIFF
--- a/app/qml/CMakeLists.txt
+++ b/app/qml/CMakeLists.txt
@@ -31,6 +31,7 @@ set(MM_QML
     components/MMListDrawer.qml
     components/MMListFooterSpacer.qml
     components/MMListMultiselectDrawer.qml
+    components/MMListView.qml
     components/MMListSpacer.qml
     components/MMBusyIndicator.qml
     components/MMMessage.qml

--- a/app/qml/account/MMHowYouFoundUsPage.qml
+++ b/app/qml/account/MMHowYouFoundUsPage.qml
@@ -71,7 +71,7 @@ MMPage {
     width: parent.width
     height: parent.height
 
-    ListView {
+    MMListView {
       id: listView
 
       width: parent.width

--- a/app/qml/components/MMListDrawer.qml
+++ b/app/qml/components/MMListDrawer.qml
@@ -43,7 +43,7 @@ MMDrawer {
       }
     }
 
-    ListView {
+    MMListView {
       id: listViewComponent
 
       width: parent.width

--- a/app/qml/components/MMListMultiselectDrawer.qml
+++ b/app/qml/components/MMListMultiselectDrawer.qml
@@ -82,7 +82,7 @@ MMDrawer {
           }
         }
 
-        ListView {
+        MMListView {
           id: listViewComponent
 
           width: parent.width

--- a/app/qml/components/MMListView.qml
+++ b/app/qml/components/MMListView.qml
@@ -1,0 +1,20 @@
+/***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+import QtQuick
+
+//
+// Hot-fix for hotfix https://github.com/MerginMaps/mobile/issues/3417
+// Seems like there is some issue with cache in ListView
+//
+
+ListView {
+
+  cacheBuffer: 0
+}

--- a/app/qml/components/MMToolbar.qml
+++ b/app/qml/components/MMToolbar.qml
@@ -41,7 +41,7 @@ Rectangle {
     // center the content
     x: __style.safeAreaLeft
 
-    ListView {
+    MMListView {
       id: toolbar
 
       onWidthChanged: root.recalculate()

--- a/app/qml/form/MMFormPage.qml
+++ b/app/qml/form/MMFormPage.qml
@@ -140,7 +140,7 @@ Page {
 
           property int tabIndex: model.TabIndex // from the repeater
 
-          ListView {
+          MMComponents.MMListView {
 
             anchors {
               fill: parent
@@ -170,8 +170,14 @@ Page {
               opacity: 1 // invisible
               height: 20 * __dp
             }
-          }
 
+            // boundsBehavior: Flickable.StopAtBounds
+            // bottomMargin: 0
+
+            cacheBuffer: 0
+            // 320 on macOS
+            Component.onCompleted: console.log(" -> cache:", cacheBuffer)
+          }
         }
       }
     }

--- a/app/qml/form/MMPreviewDrawer.qml
+++ b/app/qml/form/MMPreviewDrawer.qml
@@ -205,7 +205,7 @@ Item {
 
         visible: internal.showFields
 
-        ListView {
+        MMComponents.MMListView {
           width: parent.width
           height: contentHeight
 

--- a/app/qml/form/components/MMFeaturesListPageDrawer.qml
+++ b/app/qml/form/components/MMFeaturesListPageDrawer.qml
@@ -73,7 +73,7 @@ Drawer {
 
         MMComponents.MMListSpacer { height: __style.spacing20 }
 
-        ListView {
+        MMComponents.MMListView {
           id: listView
 
           width: parent.width

--- a/app/qml/form/editors/MMFormGalleryEditor.qml
+++ b/app/qml/form/editors/MMFormGalleryEditor.qml
@@ -30,7 +30,7 @@ MMPrivateComponents.MMBaseInput {
 
   title: _fieldShouldShowTitle ? _fieldTitle : ""
 
-  inputContent: ListView {
+  inputContent: MMComponents.MMListView {
     id: rowView
 
     width: parent.width

--- a/app/qml/gps/MMPositionProviderPage.qml
+++ b/app/qml/gps/MMPositionProviderPage.qml
@@ -27,7 +27,7 @@ MMComponents.MMPage {
     width: parent.width
     height: parent.height
 
-    ListView {
+    MMComponents.MMListView {
       id: listview
 
       property bool showTopTitle: visibleArea.yPosition * height > ( headerItem.contentHeight / 2 )

--- a/app/qml/layers/MMFeaturesListPage.qml
+++ b/app/qml/layers/MMFeaturesListPage.qml
@@ -44,7 +44,7 @@ MMComponents.MMPage {
       onSearchTextChanged: featuresModel.searchExpression = searchBar.text
     }
 
-    ListView {
+    MMComponents.MMListView {
       id: listView
 
       width: parent.width

--- a/app/qml/layers/MMLayersList.qml
+++ b/app/qml/layers/MMLayersList.qml
@@ -15,7 +15,7 @@ import QtQuick.Layouts
 import "../components" as MMComponents
 import "../inputs"
 
-ListView {
+MMComponents.MMListView {
   id: root
 
   property var basemodel: null

--- a/app/qml/project/MMProjectIssuesPage.qml
+++ b/app/qml/project/MMProjectIssuesPage.qml
@@ -31,7 +31,7 @@ MMComponents.MMPage {
   onBackClicked: root.visible = false
   pageHeader.title: qsTr("Project issues")
 
-  pageContent: ListView {
+  pageContent: MMComponents.MMListView {
     id: mainList
 
     anchors.fill: parent

--- a/app/qml/project/MMProjectList.qml
+++ b/app/qml/project/MMProjectList.qml
@@ -47,7 +47,7 @@ Item {
     controllerModel.listProjects( searchText )
   }
 
-  ListView {
+  MMComponents.MMListView {
     id: listview
 
     Component.onCompleted: {

--- a/app/qml/project/MMProjectStatusPage.qml
+++ b/app/qml/project/MMProjectStatusPage.qml
@@ -47,7 +47,7 @@ MMComponents.MMPage {
     MMComponents.MMListSpacer { id: spacer; height: __style.spacing40 }
 
     // With changes content
-    ListView {
+    MMComponents.MMListView {
       id: statusList
 
       anchors.top: spacer.bottom

--- a/app/qml/project/MMProjectWizardPage.qml
+++ b/app/qml/project/MMProjectWizardPage.qml
@@ -58,7 +58,7 @@ MMComponents.MMPage {
         verticalAlignment: Text.AlignVCenter
       }
 
-      ListView {
+      MMComponents.MMListView {
         id: fieldList
 
         model: fieldsModel

--- a/app/qml/settings/MMChangelogPage.qml
+++ b/app/qml/settings/MMChangelogPage.qml
@@ -21,7 +21,7 @@ MMPage {
   pageHeader.title: qsTr( "Changelog" )
   pageBottomMarginPolicy: MMPage.BottomMarginPolicy.PaintBehindSystemBar
 
-  pageContent: ListView {
+  pageContent: MMListView {
     width: parent.width
     height: parent.height
 


### PR DESCRIPTION
(hot)fixes  #3417 and fixes #3428 

We are disabling cache in ListViews, it proves to fix the scrolling issue. We will need to dig deeper then to understand what is actually happening + report to Qt.