### PR TITLE
Fixing QtNativeAccessibility related ANRs

### DIFF
--- a/app/main.cpp
+++ b/app/main.cpp
@@ -458,6 +458,8 @@ int main( int argc, char *argv[] )
 #ifdef ANDROID
   // See https://bugreports.qt.io/browse/QTBUG-86982 -> fix to make the predictive text disabled on Android
   qputenv( "QT_ANDROID_ENABLE_WORKAROUND_TO_DISABLE_PREDICTIVE_TEXT", "1" );
+  // See issue #3431 -> disable Android accessibility features for the application
+  qputenv("QT_ANDROID_DISABLE_ACCESSIBILITY", "1");
 #endif
 
   // AppSettings has to be initialized after QGIS app init (because of correct reading/writing QSettings).

--- a/app/main.cpp
+++ b/app/main.cpp
@@ -459,7 +459,7 @@ int main( int argc, char *argv[] )
   // See https://bugreports.qt.io/browse/QTBUG-86982 -> fix to make the predictive text disabled on Android
   qputenv( "QT_ANDROID_ENABLE_WORKAROUND_TO_DISABLE_PREDICTIVE_TEXT", "1" );
   // See issue #3431 -> disable Android accessibility features for the application
-  qputenv("QT_ANDROID_DISABLE_ACCESSIBILITY", "1");
+  qputenv( "QT_ANDROID_DISABLE_ACCESSIBILITY", "1" );
 #endif
 
   // AppSettings has to be initialized after QGIS app init (because of correct reading/writing QSettings).

--- a/app/main.cpp
+++ b/app/main.cpp
@@ -458,7 +458,7 @@ int main( int argc, char *argv[] )
 #ifdef ANDROID
   // See https://bugreports.qt.io/browse/QTBUG-86982 -> fix to make the predictive text disabled on Android
   qputenv( "QT_ANDROID_ENABLE_WORKAROUND_TO_DISABLE_PREDICTIVE_TEXT", "1" );
-  // See issue #3431 -> disable Android accessibility features for the application
+  // See issue #3431 -> disable Android accessibility features to prevent ANRs
   qputenv( "QT_ANDROID_DISABLE_ACCESSIBILITY", "1" );
 #endif
 


### PR DESCRIPTION
Set QT_ANDROID_DISABLE_ACCESSIBILITY environment variable to disable accessibility features and prevent ANRs.

Fixes #3431 