### PR TITLE
Handling attempt to upload a project after reaching the project limit

### DIFF
--- a/app/synchronizationmanager.cpp
+++ b/app/synchronizationmanager.cpp
@@ -233,8 +233,8 @@ void SynchronizationManager::onProjectSyncProgressChanged( const QString &projec
 
 void SynchronizationManager::onProjectCreated( const QString &projectFullName, bool result )
 {
-  // 'projectFullName' is in the format "namespace/projectName" and
-  // 'mSyncProcess' stores projects in the format "projectName" only
+  // 'projectFullName' is in the format "namespace/projectName" and 'mSyncProcess' stores
+  // projects that were not previously uploaded to the server in the format "projectName".
   QString projectNamespace, projectName;
   MerginApi::extractProjectName( projectFullName, projectNamespace, projectName );
 

--- a/app/synchronizationmanager.cpp
+++ b/app/synchronizationmanager.cpp
@@ -233,9 +233,11 @@ void SynchronizationManager::onProjectSyncProgressChanged( const QString &projec
 
 void SynchronizationManager::onProjectCreated( const QString &projectFullName, bool result )
 {
-  if ( !result && mSyncProcesses.contains( projectFullName ) )
+  QString projectName = projectFullName.section( '/', 1, 1 );
+
+  if ( !result && mSyncProcesses.contains( projectName ) )
   {
-    mSyncProcesses.remove( projectFullName );
+    mSyncProcesses.remove( projectName );
   }
 }
 

--- a/app/synchronizationmanager.cpp
+++ b/app/synchronizationmanager.cpp
@@ -231,22 +231,12 @@ void SynchronizationManager::onProjectSyncProgressChanged( const QString &projec
 
 }
 
-void SynchronizationManager::onProjectCreated(const QString &projectFullName, bool result)
+void SynchronizationManager::onProjectCreated( const QString &projectFullName, bool result )
 {
-    if (!result)
-    {
-        qDebug() << "Project creation result is false for:" << projectFullName; // Debug statement
-        //qDebug() << "mSyncProcesses" << mSyncProcesses;
-        if (mSyncProcesses.contains(projectFullName))
-        {
-            qDebug() << "Removing project from sync processes:" << projectFullName; // Debug statement
-            mSyncProcesses.remove(projectFullName);
-        }
-    }
-    else
-    {
-        qDebug() << "Project creation result is true for:" << projectFullName; // Debug statement
-    }
+  if ( !result && mSyncProcesses.contains( projectFullName ) )
+  {
+    mSyncProcesses.remove( projectFullName );
+  }
 }
 
 void SynchronizationManager::onProjectSyncFailure(

--- a/app/synchronizationmanager.cpp
+++ b/app/synchronizationmanager.cpp
@@ -233,7 +233,8 @@ void SynchronizationManager::onProjectSyncProgressChanged( const QString &projec
 
 void SynchronizationManager::onProjectCreated( const QString &projectFullName, bool result )
 {
-  QString projectName = projectFullName.section( '/', 1, 1 );
+  QString projectNamespace, projectName;
+  MerginApi::extractProjectName( projectFullName, projectNamespace, projectName );
 
   if ( !result && mSyncProcesses.contains( projectName ) )
   {

--- a/app/synchronizationmanager.cpp
+++ b/app/synchronizationmanager.cpp
@@ -23,6 +23,7 @@ SynchronizationManager::SynchronizationManager(
     QObject::connect( mMerginApi, &MerginApi::pushCanceled, this, &SynchronizationManager::onProjectSyncCanceled );
     QObject::connect( mMerginApi, &MerginApi::syncProjectFinished, this, &SynchronizationManager::onProjectSyncFinished );
     QObject::connect( mMerginApi, &MerginApi::networkErrorOccurred, this, &SynchronizationManager::onProjectSyncFailure );
+    QObject::connect( mMerginApi, &MerginApi::projectCreated, this, &SynchronizationManager::onProjectCreated );
     QObject::connect( mMerginApi, &MerginApi::projectAttachedToMergin, this, &SynchronizationManager::onProjectAttachedToMergin );
     QObject::connect( mMerginApi, &MerginApi::syncProjectStatusChanged, this, &SynchronizationManager::onProjectSyncProgressChanged );
     QObject::connect( mMerginApi, &MerginApi::projectReloadNeededAfterSync, this, &SynchronizationManager::onProjectReloadNeededAfterSync );
@@ -228,6 +229,24 @@ void SynchronizationManager::onProjectSyncProgressChanged( const QString &projec
     emit syncProgressChanged( projectFullName, progress );
   }
 
+}
+
+void SynchronizationManager::onProjectCreated(const QString &projectFullName, bool result)
+{
+    if (!result)
+    {
+        qDebug() << "Project creation result is false for:" << projectFullName; // Debug statement
+        //qDebug() << "mSyncProcesses" << mSyncProcesses;
+        if (mSyncProcesses.contains(projectFullName))
+        {
+            qDebug() << "Removing project from sync processes:" << projectFullName; // Debug statement
+            mSyncProcesses.remove(projectFullName);
+        }
+    }
+    else
+    {
+        qDebug() << "Project creation result is true for:" << projectFullName; // Debug statement
+    }
 }
 
 void SynchronizationManager::onProjectSyncFailure(

--- a/app/synchronizationmanager.cpp
+++ b/app/synchronizationmanager.cpp
@@ -233,6 +233,8 @@ void SynchronizationManager::onProjectSyncProgressChanged( const QString &projec
 
 void SynchronizationManager::onProjectCreated( const QString &projectFullName, bool result )
 {
+  // 'projectFullName' is in the format "namespace/projectName" and
+  // 'mSyncProcess' stores projects in the format "projectName" only
   QString projectNamespace, projectName;
   MerginApi::extractProjectName( projectFullName, projectNamespace, projectName );
 

--- a/app/synchronizationmanager.h
+++ b/app/synchronizationmanager.h
@@ -86,7 +86,7 @@ class SynchronizationManager : public QObject
     void onProjectSyncFailure( const QString &message, const QString &topic, int httpCode, const QString &projectFullName );
     void onProjectAttachedToMergin( const QString &projectFullName, const QString &previousName );
     void onProjectReloadNeededAfterSync( const QString &projectFullName );
-    void onProjectCreated(const QString &projectName, bool result);
+    void onProjectCreated( const QString &projectName, bool result );
 
   private:
 

--- a/app/synchronizationmanager.h
+++ b/app/synchronizationmanager.h
@@ -86,6 +86,7 @@ class SynchronizationManager : public QObject
     void onProjectSyncFailure( const QString &message, const QString &topic, int httpCode, const QString &projectFullName );
     void onProjectAttachedToMergin( const QString &projectFullName, const QString &previousName );
     void onProjectReloadNeededAfterSync( const QString &projectFullName );
+    void onProjectCreated(const QString &projectName, bool result);
 
   private:
 

--- a/core/merginapi.cpp
+++ b/core/merginapi.cpp
@@ -1181,7 +1181,7 @@ void MerginApi::createProjectFinished()
 
     CoreUtils::log( "create " + projectFullName, message );
 
-    emit projectCreated( projectFullName, false );
+    emit projectCreated( projectName, false );
 
     if ( showLimitReachedDialog )
     {


### PR DESCRIPTION
When attempting to upload a local only project, if the workspace project limit has been reached, the project is now removed from the synchronization pending list and is completely deleted if the project is removed by the user.


https://github.com/MerginMaps/mobile/assets/155513369/73233041-f390-4cc7-b0c3-9a7b7402fe09



Fixes #3403 