### PR TITLE
Fixing override of relations editor bug

### DIFF
--- a/app/inpututils.cpp
+++ b/app/inpututils.cpp
@@ -1046,7 +1046,7 @@ const QUrl InputUtils::getThemeIcon( const QString &name )
   return QUrl( path );
 }
 
-const QUrl InputUtils::getFormEditorType( const QString &widgetNameIn, const QVariantMap &config, const QgsField &field, const QgsRelation &relation )
+const QUrl InputUtils::getFormEditorType( const QString &widgetNameIn, const QVariantMap &config, const QgsField &field, const QgsRelation &relation, const QString &fieldName )
 {
   QString widgetName = widgetNameIn.toLower();
 
@@ -1129,7 +1129,7 @@ const QUrl InputUtils::getFormEditorType( const QString &widgetNameIn, const QVa
     }
 
     // Mind this hack - fields with `no-gallery-use` won't use gallery, but normal word tags instead
-    if ( field.name().contains( "nogallery", Qt::CaseInsensitive ) || field.alias().contains( "nogallery", Qt::CaseInsensitive ) )
+    if ( fieldName.contains( "nogallery", Qt::CaseInsensitive ) || field.alias().contains( "nogallery", Qt::CaseInsensitive ) )
     {
       useGallery = false;
     }

--- a/app/inpututils.cpp
+++ b/app/inpututils.cpp
@@ -1046,7 +1046,7 @@ const QUrl InputUtils::getThemeIcon( const QString &name )
   return QUrl( path );
 }
 
-const QUrl InputUtils::getFormEditorType( const QString &widgetNameIn, const QVariantMap &config, const QgsField &field, const QgsRelation &relation, const QString &fieldName )
+const QUrl InputUtils::getFormEditorType( const QString &widgetNameIn, const QVariantMap &config, const QgsField &field, const QgsRelation &relation, const QString &editorTitle )
 {
   QString widgetName = widgetNameIn.toLower();
 
@@ -1129,7 +1129,7 @@ const QUrl InputUtils::getFormEditorType( const QString &widgetNameIn, const QVa
     }
 
     // Mind this hack - fields with `no-gallery-use` won't use gallery, but normal word tags instead
-    if ( fieldName.contains( "nogallery", Qt::CaseInsensitive ) || field.alias().contains( "nogallery", Qt::CaseInsensitive ) )
+    if ( editorTitle.contains( "nogallery", Qt::CaseInsensitive ) )
     {
       useGallery = false;
     }

--- a/app/inpututils.h
+++ b/app/inpututils.h
@@ -387,7 +387,7 @@ class InputUtils: public QObject
       * \param config map coming from QGIS describing this field
       * \param field qgsfield instance of this field
       */
-    Q_INVOKABLE static const QUrl getFormEditorType( const QString &widgetNameIn, const QVariantMap &config = QVariantMap(), const QgsField &field = QgsField(), const QgsRelation &relation = QgsRelation() );
+    Q_INVOKABLE static const QUrl getFormEditorType( const QString &widgetNameIn, const QVariantMap &config = QVariantMap(), const QgsField &field = QgsField(), const QgsRelation &relation = QgsRelation() , const QString &fieldName = QString() );
 
     /**
      * \copydoc QgsCoordinateFormatter::format()

--- a/app/inpututils.h
+++ b/app/inpututils.h
@@ -387,7 +387,7 @@ class InputUtils: public QObject
       * \param config map coming from QGIS describing this field
       * \param field qgsfield instance of this field
       */
-    Q_INVOKABLE static const QUrl getFormEditorType( const QString &widgetNameIn, const QVariantMap &config = QVariantMap(), const QgsField &field = QgsField(), const QgsRelation &relation = QgsRelation(), const QString &fieldName = QString() );
+    Q_INVOKABLE static const QUrl getFormEditorType( const QString &widgetNameIn, const QVariantMap &config = QVariantMap(), const QgsField &field = QgsField(), const QgsRelation &relation = QgsRelation(), const QString &editorTitle = QString() );
 
     /**
      * \copydoc QgsCoordinateFormatter::format()

--- a/app/inpututils.h
+++ b/app/inpututils.h
@@ -387,7 +387,7 @@ class InputUtils: public QObject
       * \param config map coming from QGIS describing this field
       * \param field qgsfield instance of this field
       */
-    Q_INVOKABLE static const QUrl getFormEditorType( const QString &widgetNameIn, const QVariantMap &config = QVariantMap(), const QgsField &field = QgsField(), const QgsRelation &relation = QgsRelation() , const QString &fieldName = QString() );
+    Q_INVOKABLE static const QUrl getFormEditorType( const QString &widgetNameIn, const QVariantMap &config = QVariantMap(), const QgsField &field = QgsField(), const QgsRelation &relation = QgsRelation(), const QString &fieldName = QString() );
 
     /**
      * \copydoc QgsCoordinateFormatter::format()

--- a/app/qml/form/MMFormPage.qml
+++ b/app/qml/form/MMFormPage.qml
@@ -296,7 +296,7 @@ Page {
 
         source: {
           if ( model.EditorWidget !== undefined ) {
-            return __inputUtils.getFormEditorType( model.EditorWidget, model.EditorWidgetConfig, model.Field, model.Relation )
+            return __inputUtils.getFormEditorType( model.EditorWidget, model.EditorWidgetConfig, model.Field, model.Relation, model.Name )
           }
 
           return ''


### PR DESCRIPTION
Fixing check for whether `FormItem::name` has `nogallery` flag in the form's label name in `Relation Editor` widget type.

<img src="https://github.com/MerginMaps/mobile/assets/155513369/c85fb370-a388-4d38-93e5-56949d1b1df1" width="450">

Fixes #3452