### PR TITLE
Error/warning message can have up to 10 lines

### DIFF
--- a/app/qml/components/private/MMBaseInput.qml
+++ b/app/qml/components/private/MMBaseInput.qml
@@ -205,7 +205,7 @@ Item {
 
 
           wrapMode: Text.Wrap
-          maximumLineCount: 2
+          maximumLineCount: 10
         }
       }
     }


### PR DESCRIPTION
Resolves #3456 

Error/warning messages can now span up to 10 lines

<img width="352" alt="image" src="https://github.com/MerginMaps/mobile/assets/22449698/913f7ea1-08d8-41d7-96e2-990a89685f19">
