### PR TITLE
Photo editor fixes

### DIFF
--- a/app/qml/form/components/photo/MMPhotoAttachment.qml
+++ b/app/qml/form/components/photo/MMPhotoAttachment.qml
@@ -58,6 +58,8 @@ Rectangle {
           horizontalAlignment: Text.AlignHCenter
           verticalAlignment: Text.AlignVCenter
           elide: Text.ElideMiddle
+
+          visible: root.enabled
         }
       }
 
@@ -95,6 +97,8 @@ Rectangle {
           horizontalAlignment: Text.AlignHCenter
           verticalAlignment: Text.AlignVCenter
           elide: Text.ElideMiddle
+
+          visible: root.enabled
         }
       }
 

--- a/app/qml/form/editors/MMFormPhotoEditor.qml
+++ b/app/qml/form/editors/MMFormPhotoEditor.qml
@@ -88,7 +88,8 @@ MMFormPhotoViewer {
   photoUrl: internal.absoluteImagePath
   hasCameraCapability: __androidUtils.isAndroid || __iosUtils.isIos
 
-  on_FieldValueChanged: internal.calculateAbsoluteImagePath()
+  on_FieldValueChanged: internal.setAbsoluteImagePath()
+  on_FieldValueIsNullChanged: internal.setAbsoluteImagePath()
 
   onCapturePhotoClicked: internal.capturePhoto()
   onChooseFromGalleryClicked: internal.chooseFromGallery()
@@ -200,27 +201,25 @@ MMFormPhotoViewer {
 
     property string imageSourceToDelete // used to postpone image deletion to when the form is saved
 
-    function calculateAbsoluteImagePath() {
+    //
+    // Sets path of the assigned photo to the absoluteImagePath.
+    //  - absoluteImagePath is the actual path on the device and is used by QML Image to show the image
+    //
+    function setAbsoluteImagePath() {
       let absolutePath = __inputUtils.getAbsolutePath( root._fieldValue, internal.prefixToRelativePath )
 
-      if ( root.photoComponent.status === Image.Error ) {
-        root.photoState = "notAvailable"
+      if ( !root._fieldValue || root._fieldValueIsNull ) {
+        root.photoState = "notSet"
         absoluteImagePath = ""
-        return
       }
       else if ( root._fieldValue && __inputUtils.fileExists( absolutePath ) ) {
         root.photoState = "valid"
         absoluteImagePath = "file://" + absolutePath
-        return
       }
-      else if ( !root._fieldValue || root._fieldValueIsNullfield ) {
-        root.photoState = "notSet"
+      else {
+        root.photoState = "notAvailable"
         absoluteImagePath = ""
-        return
       }
-
-      root.photoState = "notAvailable"
-      absoluteImagePath = "file://" + absolutePath
     }
 
     /**


### PR DESCRIPTION
Fixes #3405 

Also hides the texts for input when the editor is empty and the form is read-only

| Empty state - editable | Empty state - readonly |
|--------|--------|
| <img width="343" alt="image" src="https://github.com/MerginMaps/mobile/assets/22449698/295c6c26-800e-444c-a499-4abaf7f336cd"> | <img width="356" alt="image" src="https://github.com/MerginMaps/mobile/assets/22449698/8494fd02-47d6-49be-881a-f4b72c54d9e3"> | 


The resolution for #3405:
 - we were checking the state of QML Image component when setting its source -> this is wrong as the last state should not have any impact on the new source that is to be set. Not sure why we were doing that, but this should fix it now.