### PR TITLE
Fix ANR when opening project with searchbar focus

### DIFF
--- a/app/qml/project/MMProjectHomeTab.qml
+++ b/app/qml/project/MMProjectHomeTab.qml
@@ -142,6 +142,19 @@ Item {
     }
 
     onOpenProjectRequested: function( projectFilePath ) {
+
+      //
+      // There was an issue when closing the projects controller while having the searchbar textField focused
+      // (not neccessarily with keyboard opened). This is a kind-of workaround and hotfix.
+      // It might be related to https://bugreports.qt.io/browse/QTBUG-123876 as it started
+      // to occur more frequently when we upgraded to Qt 6.6.3
+      //
+      // See https://github.com/MerginMaps/mobile/issues/3027
+      //
+      if ( searchBar.textField.activeFocus ) {
+        searchBar.textField.focus = false
+      }
+
       root.openProjectRequested( projectFilePath )
     }
     onShowLocalChangesRequested: function( projectId ) {

--- a/app/qml/project/MMProjectServerTab.qml
+++ b/app/qml/project/MMProjectServerTab.qml
@@ -64,6 +64,19 @@ Item {
     }
 
     onOpenProjectRequested: function( projectFilePath ) {
+
+      //
+      // There was an issue when closing the projects controller while having the searchbar textField focused
+      // (not neccessarily with keyboard opened). This is a kind-of workaround and hotfix.
+      // It might be related to https://bugreports.qt.io/browse/QTBUG-123876 as it started
+      // to occur more frequently when we upgraded to Qt 6.6.3
+      //
+      // See https://github.com/MerginMaps/mobile/issues/3027
+      //
+      if ( searchBar.textField.activeFocus ) {
+        searchBar.textField.focus = false
+      }
+
       root.openProjectRequested( projectFilePath )
     }
     onShowLocalChangesRequested: function( projectId ) {


### PR DESCRIPTION
Weird bug here.. When we were trying to set `visible` property of the entire project controller (`MMProjectController.qml`) to false while `searchBar` had focus, the app would freeze (ANR). I spent a few hours debugging and have not found anything interesting. I believe this is coming from Qt (most likely https://bugreports.qt.io/browse/QTBUG-123876) as it started to appear in Qt 6.6.0 and even more in 6.6.3.
Ideally, the best fix would be to have the `MMProjectController` instantiated dynamically when needed and not play around with the `visible` property. However, that would be a massive change for now.

Resolves #3027 

Thanks @raherin for all the details in the bug report, they helped a lot! Can you please try this build and see if it fixes the issue also for your phone?