### PR TITLE
Enable predictive text on Android

### DIFF
--- a/app/main.cpp
+++ b/app/main.cpp
@@ -456,8 +456,6 @@ int main( int argc, char *argv[] )
   init_qgis( appBundleDir );
 
 #ifdef ANDROID
-  // See https://bugreports.qt.io/browse/QTBUG-86982 -> fix to make the predictive text disabled on Android
-  qputenv( "QT_ANDROID_ENABLE_WORKAROUND_TO_DISABLE_PREDICTIVE_TEXT", "1" );
   // See issue #3431 -> disable Android accessibility features to prevent ANRs
   qputenv( "QT_ANDROID_DISABLE_ACCESSIBILITY", "1" );
 #endif

--- a/app/qml/account/MMLoginPage.qml
+++ b/app/qml/account/MMLoginPage.qml
@@ -85,7 +85,7 @@ MMPage {
           width: parent.width
 
           title: qsTr( "Email or username" )
-          textField.inputMethodHints: Qt.ImhNoPredictiveText | Qt.ImhNoAutoUppercase | Qt.ImhEmailCharactersOnly
+          textField.inputMethodHints: Qt.ImhNoAutoUppercase | Qt.ImhEmailCharactersOnly
         }
 
         MMPasswordInput {
@@ -204,7 +204,9 @@ MMPage {
             textFieldBackground.color: __style.lightGreenColor
 
             text: root.apiRoot
-            textField.inputMethodHints: Qt.ImhNoPredictiveText | Qt.ImhNoAutoUppercase | Qt.ImhUrlCharactersOnly
+
+            // Qt.ImhNoPredictiveText must be accompanied by Qt.ImhSensitiveData, see https://bugreports.qt.io/browse/QTBUG-86982
+            textField.inputMethodHints: Qt.ImhNoPredictiveText | Qt.ImhSensitiveData | Qt.ImhNoAutoUppercase | Qt.ImhUrlCharactersOnly
           }
 
           MMListSpacer { height: __style.spacing40 }

--- a/app/qml/account/MMSignUpPage.qml
+++ b/app/qml/account/MMSignUpPage.qml
@@ -72,7 +72,7 @@ MMPage {
         width: parent.width
 
         title: qsTr( "Username" )
-        textField.inputMethodHints: Qt.ImhNoPredictiveText | Qt.ImhNoAutoUppercase
+        textField.inputMethodHints: Qt.ImhNoAutoUppercase
       }
 
       MMTextInput {
@@ -81,7 +81,7 @@ MMPage {
         width: parent.width
 
         title: qsTr( "Email" )
-        textField.inputMethodHints: Qt.ImhNoPredictiveText | Qt.ImhNoAutoUppercase | Qt.ImhEmailCharactersOnly
+        textField.inputMethodHints: Qt.ImhNoAutoUppercase | Qt.ImhEmailCharactersOnly
       }
 
       MMPasswordInput {

--- a/app/qml/components/private/MMBaseSingleLineInput.qml
+++ b/app/qml/components/private/MMBaseSingleLineInput.qml
@@ -161,8 +161,6 @@ MMBaseInput {
         leftPadding: leftContentGroupContainer.visible ? 0 : __style.margin20
         rightPadding: rightContentGroupContainer.visible ? 0 : __style.margin20
 
-        inputMethodHints: Qt.ImhNoPredictiveText
-
         placeholderTextColor: __style.darkGreyColor
 
         font: __style.p5

--- a/app/qml/form/editors/MMFormTextEditor.qml
+++ b/app/qml/form/editors/MMFormTextEditor.qml
@@ -44,7 +44,6 @@ MMPrivateComponents.MMBaseSingleLineInput {
   text: _fieldValue === undefined || _fieldValueIsNull ? '' : _fieldValue
 
   readOnly: _fieldIsReadOnly
-  textField.inputMethodHints: root._field.isNumeric ? Qt.ImhNoPredictiveText | Qt.ImhFormattedNumbersOnly : Qt.ImhNoPredictiveText
 
   title: _fieldShouldShowTitle ? _fieldTitle : ""
 
@@ -73,6 +72,13 @@ MMPrivateComponents.MMBaseSingleLineInput {
     }
 
     root.editorValueChanged( val, val === "" )
+  }
+
+  Component.onCompleted: {
+    // Use numerical keyboard for number fields configured as texts
+    if ( root._field.isNumeric ) {
+      textField.inputMethodHints |= Qt.ImhFormattedNumbersOnly
+    }
   }
 
   QtObject {

--- a/app/qml/form/editors/MMFormTextMultilineEditor.qml
+++ b/app/qml/form/editors/MMFormTextMultilineEditor.qml
@@ -83,8 +83,6 @@ MMPrivateComponents.MMBaseInput {
     }
     placeholderTextColor: __style.darkGreyColor
 
-    inputMethodHints: Qt.ImhNoPredictiveText
-
     readOnly: root.editState !== "enabled"
 
     background: Rectangle {

--- a/app/qml/inputs/MMPasswordInput.qml
+++ b/app/qml/inputs/MMPasswordInput.qml
@@ -17,7 +17,8 @@ MMPrivateComponents.MMBaseSingleLineInput {
 
   textField.echoMode: eyeButton.pressed ? TextInput.Normal : TextInput.Password
 
-  textField.inputMethodHints: Qt.ImhNoPredictiveText | Qt.ImhNoAutoUppercase | Qt.ImhSensitiveData | Qt.ImhHiddenText
+  // Qt.ImhNoPredictiveText must be accompanied by Qt.ImhSensitiveData, see https://bugreports.qt.io/browse/QTBUG-86982
+  textField.inputMethodHints: Qt.ImhNoPredictiveText | Qt.ImhSensitiveData | Qt.ImhNoAutoUppercase | Qt.ImhHiddenText
 
   rightContent: MMComponents.MMIcon {
     id: eyeButton

--- a/app/qml/settings/components/MMSettingsInput.qml
+++ b/app/qml/settings/components/MMSettingsInput.qml
@@ -56,7 +56,7 @@ MMSettingsItem {
             textFieldBackground.color: __style.lightGreenColor
 
             text: root.value
-            textField.inputMethodHints: Qt.ImhNoPredictiveText | Qt.ImhNoAutoUppercase
+            textField.inputMethodHints: Qt.ImhNoAutoUppercase
           }
 
           MMComponents.MMListSpacer { height: __style.spacing40 }


### PR DESCRIPTION
It seems to be working fine for me now with Qt 6.6.3 without any special hacks we had before. I tested Samsung and Google keyboards and they are working just fine with any type of editors in the form.

> Note: to disable predictive text on Android, one needs to either set `QT_ANDROID_ENABLE_WORKAROUND_TO_DISABLE_PREDICTIVE_TEXT` env variable (this then applies to all inputs) or set `Qt.ImhNoPredictiveText | Qt.ImhSensitiveData` as `inputMethodHints` (this then applies only to that one input). See https://bugreports.qt.io/browse/QTBUG-86982?focusedId=706751&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-706751 for more info

Resolves #3434 

If the tests are ok, we can close https://github.com/MerginMaps/mobile/issues/1768, https://github.com/MerginMaps/mobile/issues/2471, https://github.com/MerginMaps/mobile/issues/2475 and https://github.com/MerginMaps/mobile/issues/2568