### PR TITLE
Update generic error message in login screen

### DIFF
--- a/app/qml/account/MMAccountController.qml
+++ b/app/qml/account/MMAccountController.qml
@@ -95,11 +95,11 @@ Item {
         } else
         {
           if (__merginApi.apiVersionStatus === MM.MerginApiStatus.INCOMPATIBLE) {
-            qsTr("Please update the app to use the latest features.")
+            qsTr( "Please update the app to use the latest features." )
           } else if (__merginApi.apiVersionStatus === MM.MerginApiStatus.PENDING) {
             ""
           } else {
-            qsTr("Server is currently unavailable - please try again later.")
+            qsTr( "Server is currently unavailable, check your connection or try again later." )
           }
         }
       }


### PR DESCRIPTION
Changed the generic error message, it is visible if the server is unavailable or the app does not have an internet connection. Previously the text did not mention the possibility of no internet connection.


<img src="https://github.com/MerginMaps/mobile/assets/22449698/c7370971-c393-47e3-a3da-42e88f72b25f" width=300>
