### PR TITLE
Open sync failed dialog when "willRetry" notification is clicked

### DIFF
--- a/app/notificationmodel.cpp
+++ b/app/notificationmodel.cpp
@@ -150,6 +150,12 @@ void NotificationModel::onNotificationClicked( uint id )
           emit showSwitchWorkspaceActionClicked();
           break;
         }
+        case NotificationType::ActionType::ShowSyncFailedDialog:
+        {
+          remove( id );
+          emit showSyncFailedDialogClicked();
+          break;
+        }
         default: break;
       }
     }

--- a/app/notificationmodel.h
+++ b/app/notificationmodel.h
@@ -41,7 +41,8 @@ class NotificationType
     {
       NoAction,
       ShowProjectIssuesAction,
-      ShowSwitchWorkspaceAction
+      ShowSwitchWorkspaceAction,
+      ShowSyncFailedDialog
     };
     Q_ENUM( ActionType )
 
@@ -109,6 +110,7 @@ class NotificationModel : public QAbstractListModel
     void rowCountChanged();
     void showProjectIssuesActionClicked();
     void showSwitchWorkspaceActionClicked();
+    void showSyncFailedDialogClicked();
 
   private:
     void add( const QString &message, uint interval, NotificationType::MessageType type = NotificationType::Information, NotificationType::IconType icon = NotificationType::NoneIcon, NotificationType::ActionType action = NotificationType::ActionType::NoAction );

--- a/app/qml/main.qml
+++ b/app/qml/main.qml
@@ -837,9 +837,8 @@ ApplicationWindow {
           syncFailedDialog.detailedText = qsTr( "Details" ) + ": " + errorMessage
           if ( willRetry )
           {
-            // TODO: open sync failed dialogue when clicked on the notification
-            //HERE1)
-            __notificationModel.addError( qsTr( "There was an issue during synchronisation, we will try again. Click to learn more" ) )
+            __notificationModel.addError( qsTr( "There was an issue during synchronisation, we will try again. Click to learn more" ),
+            MM.NotificationType.ShowSyncFailedDialog )
           }
           else
           {

--- a/app/qml/main.qml
+++ b/app/qml/main.qml
@@ -838,6 +838,7 @@ ApplicationWindow {
           if ( willRetry )
           {
             // TODO: open sync failed dialogue when clicked on the notification
+            //HERE1)
             __notificationModel.addError( qsTr( "There was an issue during synchronisation, we will try again. Click to learn more" ) )
           }
           else
@@ -924,6 +925,9 @@ ApplicationWindow {
     function onShowSwitchWorkspaceActionClicked() {
       stateManager.state = "projects"
       projectController.showSelectWorkspacePage()
+    }
+    function onShowSyncFailedDialogClicked() {
+      syncFailedDialog.open()
     }
   }
 


### PR DESCRIPTION
When a sync error of type "willRetry" (maintenance mode) occurs and its notification is displayed, the syncFailedDialog opens upon clicking it.

https://github.com/MerginMaps/mobile/assets/155513369/f00a57e0-015d-4f23-a54c-0fa4818e7606

Fixes #3451 