### PR TITLE
Fixing project limit hit problem 

### DIFF
--- a/app/qml/main.qml
+++ b/app/qml/main.qml
@@ -875,6 +875,8 @@ ApplicationWindow {
       }
       projectLimitDialog.maxProjectNumber = maxProjects
       projectLimitDialog.open()
+
+      syncButton.iconRotateAnimationRunning = false
     }
 
     function onProjectDataChanged( projectFullName ) {


### PR DESCRIPTION
Note: When we press "More options" (three dots) -> "Upload" on the homepage, it may take a while for the projectLimitDialog to appear. However, it will eventually show up after some time, depending on the connection quality.

Fixes #3364 