### PR TITLE
Fixing BusyIndicator position in ProjectList

### DIFF
--- a/app/qml/project/MMProjectList.qml
+++ b/app/qml/project/MMProjectList.qml
@@ -182,9 +182,14 @@ Item {
   Component {
     id: loadingSpinnerComponent
 
-    MMComponents.MMBusyIndicator {
-      x: parent.width / 2 - width / 2
-      running: controllerModel.isLoading
+    Item {
+      width:listview.width
+      height: listview.height
+
+      MMComponents.MMBusyIndicator {
+        anchors.centerIn: parent
+        running: controllerModel.isLoading
+      }
     }
   }
 


### PR DESCRIPTION
| Fixed BusyIndicator position | Second option: centered horizontally only (not applied) |
|--------|--------|
|<img src="https://github.com/MerginMaps/mobile/assets/155513369/00278f96-5718-4db7-a6c6-5c53db7cba90" width="300">| <img src="https://github.com/MerginMaps/mobile/assets/155513369/fd338b99-6be5-4942-b3dd-4cb4d0275e32" width="300"> |

Fixes #3356 