### PR TITLE
Support for multiple lines in map tip for images

### DIFF
--- a/app/attributes/attributepreviewcontroller.cpp
+++ b/app/attributes/attributepreviewcontroller.cpp
@@ -115,16 +115,22 @@ QVector<QPair<QString, QString>> AttributePreviewController::mapTipFields( )
   return lst;
 }
 
-QString AttributePreviewController::mapTipImage( )
+QString AttributePreviewController::mapTipImage()
 {
   QgsExpressionContext context( globalProjectLayerScopes( mFeatureLayerPair.layer() ) );
   context.setFeature( mFeatureLayerPair.feature() );
   QString mapTip = mFeatureLayerPair.layer()->mapTipTemplate();
   QStringList lst = mapTip.split( '\n' ); // first line is "# image"
+
   if ( lst.count() >= 2 )
-    return QgsExpression::replaceExpressionText( lst[1], &context );
+  {
+    QString expression = lst.mid( 1 ).join( '\n' );
+    return QgsExpression::replaceExpressionText( expression, &context );
+  }
   else
+  {
     return QString();
+  }
 }
 
 QString AttributePreviewController::mapTipHtml( )

--- a/app/attributes/attributepreviewcontroller.cpp
+++ b/app/attributes/attributepreviewcontroller.cpp
@@ -119,18 +119,8 @@ QString AttributePreviewController::mapTipImage()
 {
   QgsExpressionContext context( globalProjectLayerScopes( mFeatureLayerPair.layer() ) );
   context.setFeature( mFeatureLayerPair.feature() );
-  QString mapTip = mFeatureLayerPair.layer()->mapTipTemplate();
-  QStringList lst = mapTip.split( '\n' ); // first line is "# image"
-
-  if ( lst.count() >= 2 )
-  {
-    QString expression = lst.mid( 1 ).join( '\n' );
-    return QgsExpression::replaceExpressionText( expression, &context );
-  }
-  else
-  {
-    return QString();
-  }
+  QString mapTip = mFeatureLayerPair.layer()->mapTipTemplate().remove( "# image\n" ); // first line is "# image"
+  return QgsExpression::replaceExpressionText( mapTip, &context );
 }
 
 QString AttributePreviewController::mapTipHtml( )

--- a/app/test/testattributepreviewcontroller.cpp
+++ b/app/test/testattributepreviewcontroller.cpp
@@ -35,49 +35,49 @@ void TestAttributePreviewController::cleanupTestCase()
 
 void TestAttributePreviewController::testMultilineMapTips()
 {
-    // Layer creation
-    QgsVectorLayer *layerPhoto =
-        new QgsVectorLayer( QStringLiteral( "Point?field=fldtxt:string" ),
-                           QStringLiteral( "layer" ),
-                           QStringLiteral( "memory" )
-                           );
-    QVERIFY( layerPhoto && layerPhoto->isValid() );
-    layerPhoto->setMapTipTemplate( "# image\nfile:///my/path/to/image/[%\n  CASE WHEN fldtxt = 'myphoto' THEN\n    'hello.jpg'\n  ELSE\n    'world.jpg'\n  END\n%]" );
+  // Layer creation
+  QgsVectorLayer *layerPhoto =
+    new QgsVectorLayer( QStringLiteral( "Point?field=fldtxt:string" ),
+                        QStringLiteral( "layer" ),
+                        QStringLiteral( "memory" )
+                      );
+  QVERIFY( layerPhoto && layerPhoto->isValid() );
+  layerPhoto->setMapTipTemplate( "# image\nfile:///my/path/to/image/[%\n  CASE WHEN fldtxt = 'myphoto' THEN\n    'hello.jpg'\n  ELSE\n    'world.jpg'\n  END\n%]" );
 
-    // Feature 1 set up
-    QgsFeature p1( layerPhoto->dataProvider()->fields() );
-    p1.setAttribute( QStringLiteral( "fldtxt" ), "myphoto" );
-    layerPhoto->dataProvider()->addFeatures( QgsFeatureList() << p1 );
+  // Feature 1 set up
+  QgsFeature p1( layerPhoto->dataProvider()->fields() );
+  p1.setAttribute( QStringLiteral( "fldtxt" ), "myphoto" );
+  layerPhoto->dataProvider()->addFeatures( QgsFeatureList() << p1 );
 
-    // Feature 2 set up
-    QgsFeature p2( layerPhoto->dataProvider()->fields() );
-    p2.setAttribute( QStringLiteral( "fldtxt" ), "notmyphoto" );
-    layerPhoto->dataProvider()->addFeatures( QgsFeatureList() << p2 );
-    QgsProject::instance()->addMapLayer( layerPhoto );
+  // Feature 2 set up
+  QgsFeature p2( layerPhoto->dataProvider()->fields() );
+  p2.setAttribute( QStringLiteral( "fldtxt" ), "notmyphoto" );
+  layerPhoto->dataProvider()->addFeatures( QgsFeatureList() << p2 );
+  QgsProject::instance()->addMapLayer( layerPhoto );
 
-    // Controller setup
-    AttributePreviewController controller;
-    controller.setProject( QgsProject::instance() );
-    QCOMPARE( controller.type(), AttributePreviewController::Empty );
+  // Controller setup
+  AttributePreviewController controller;
+  controller.setProject( QgsProject::instance() );
+  QCOMPARE( controller.type(), AttributePreviewController::Empty );
 
-    // Assertion for matching feature
-    FeatureLayerPair pair1( p1, layerPhoto );
-    controller.setFeatureLayerPair( pair1 );
-    QCOMPARE( controller.type(), AttributePreviewController::Photo );
-    QCOMPARE( controller.photo(), "file:///my/path/to/image/hello.jpg" );
+  // Assertion for matching feature
+  FeatureLayerPair pair1( p1, layerPhoto );
+  controller.setFeatureLayerPair( pair1 );
+  QCOMPARE( controller.type(), AttributePreviewController::Photo );
+  QCOMPARE( controller.photo(), "file:///my/path/to/image/hello.jpg" );
 
-    // Assertion for non-matching feature
-    FeatureLayerPair pair2( p2, layerPhoto );
-    controller.setFeatureLayerPair( pair2 );
-    QCOMPARE( controller.type(), AttributePreviewController::Photo );
-    QCOMPARE( controller.photo(), "file:///my/path/to/image/world.jpg" );
+  // Assertion for non-matching feature
+  FeatureLayerPair pair2( p2, layerPhoto );
+  controller.setFeatureLayerPair( pair2 );
+  QCOMPARE( controller.type(), AttributePreviewController::Photo );
+  QCOMPARE( controller.photo(), "file:///my/path/to/image/world.jpg" );
 
-    // Reset
-    controller.reset();
-    QCOMPARE( controller.type(), AttributePreviewController::Empty );
+  // Reset
+  controller.reset();
+  QCOMPARE( controller.type(), AttributePreviewController::Empty );
 
-    // Cleanup
-    QgsProject::instance()->removeAllMapLayers();
+  // Cleanup
+  QgsProject::instance()->removeAllMapLayers();
 }
 
 void TestAttributePreviewController::testPreviewForms()

--- a/app/test/testattributepreviewcontroller.cpp
+++ b/app/test/testattributepreviewcontroller.cpp
@@ -44,12 +44,12 @@ void TestAttributePreviewController::testMultilineMapTips()
   QVERIFY( layerPhoto && layerPhoto->isValid() );
   layerPhoto->setMapTipTemplate( "# image\nfile:///my/path/to/image/[%\n  CASE WHEN fldtxt = 'myphoto' THEN\n    'hello.jpg'\n  ELSE\n    'world.jpg'\n  END\n%]" );
 
-  // Feature 1 set up
+  // Feature 1 setup
   QgsFeature p1( layerPhoto->dataProvider()->fields() );
   p1.setAttribute( QStringLiteral( "fldtxt" ), "myphoto" );
   layerPhoto->dataProvider()->addFeatures( QgsFeatureList() << p1 );
 
-  // Feature 2 set up
+  // Feature 2 setup
   QgsFeature p2( layerPhoto->dataProvider()->fields() );
   p2.setAttribute( QStringLiteral( "fldtxt" ), "notmyphoto" );
   layerPhoto->dataProvider()->addFeatures( QgsFeatureList() << p2 );

--- a/app/test/testattributepreviewcontroller.h
+++ b/app/test/testattributepreviewcontroller.h
@@ -29,6 +29,7 @@ class TestAttributePreviewController: public QObject
     void cleanupTestCase();
 
     void testPreviewForms();
+    void testMultilineMapTips();
 
   private:
 };


### PR DESCRIPTION
`AttributePreviewController::mapTipImage()` now supports multiline text with expressions.
E.g.:

```
# image
file:///[%@project_folder%]/mapTip/[%
CASE WHEN "Checkbox" THEN
	'bear.png'
ELSE
	'beaver.png'
END
%]
```
In app:
<img src="https://github.com/MerginMaps/mobile/assets/155513369/fb4a88eb-0062-4ca8-9236-fad5881bc217" width="300">

Fixes #1106 