### PR TITLE
Fixing app freeze when switching pages

### DIFF
--- a/app/qml/components/MMToolbar.qml
+++ b/app/qml/components/MMToolbar.qml
@@ -119,6 +119,8 @@ Rectangle {
       text: model.btnData.text
 
       onClicked: {
+        // Prevent freezing by clearing focus from all elements
+        // See more: https://github.com/MerginMaps/mobile/issues/3389
         root.forceActiveFocus()
         root.index = model.index
         model.btnData.clicked()

--- a/app/qml/components/MMToolbar.qml
+++ b/app/qml/components/MMToolbar.qml
@@ -120,7 +120,7 @@ Rectangle {
 
       onClicked: {
         // Prevent freezing by clearing focus from all elements
-        // See more: https://github.com/MerginMaps/mobile/issues/3389
+        // See more at https://github.com/MerginMaps/mobile/issues/3389
         root.forceActiveFocus()
         root.index = model.index
         model.btnData.clicked()

--- a/app/qml/components/MMToolbar.qml
+++ b/app/qml/components/MMToolbar.qml
@@ -119,6 +119,7 @@ Rectangle {
       text: model.btnData.text
 
       onClicked: {
+        root.forceActiveFocus()
         root.index = model.index
         model.btnData.clicked()
       }


### PR DESCRIPTION
Prevent freezing by clearing focus from all elements when `MMToolbar` is clicked on short button delegate(Home, Projects or Explore buttons).
Fixes #3389 