### PR TITLE
Report available storage before syncing in diagnostic logs

### DIFF
--- a/app/inpututils.cpp
+++ b/app/inpututils.cpp
@@ -535,27 +535,7 @@ QString InputUtils::filesToString( QList<MerginFile> files )
 
 QString InputUtils::bytesToHumanSize( double bytes )
 {
-  const int precision = 1;
-  if ( bytes < 1e-5 )
-  {
-    return "0.0";
-  }
-  else if ( bytes < 1024.0 * 1024.0 )
-  {
-    return QString::number( bytes / 1024.0, 'f', precision ) + " KB";
-  }
-  else if ( bytes < 1024.0 * 1024.0 * 1024.0 )
-  {
-    return QString::number( bytes / 1024.0 / 1024.0, 'f', precision ) + " MB";
-  }
-  else if ( bytes < 1024.0 * 1024.0 * 1024.0 * 1024.0 )
-  {
-    return QString::number( bytes / 1024.0 / 1024.0 / 1024.0, 'f', precision ) + " GB";
-  }
-  else
-  {
-    return QString::number( bytes / 1024.0 / 1024.0 / 1024.0 / 1024.0, 'f', precision ) + " TB";
-  }
+  return CoreUtils::bytesToHumanSize( bytes );
 }
 
 bool InputUtils::acquireCameraPermission()

--- a/core/coreutils.cpp
+++ b/core/coreutils.cpp
@@ -282,7 +282,8 @@ QString CoreUtils::nameAbbr( const QString &name, const QString &email )
   if ( email.isEmpty() )
     return name.left( 2 ).toUpper();
 
-  return email.left( 2 ).toUpper();}
+  return email.left( 2 ).toUpper();
+}
 
 QString CoreUtils::getAvailableDeviceStorage()
 {

--- a/core/coreutils.cpp
+++ b/core/coreutils.cpp
@@ -32,279 +32,281 @@ int CoreUtils::CHECKSUM_CHUNK_SIZE = 65536;
 
 QString CoreUtils::deviceUuid()
 {
-    QString uuid;
+  QString uuid;
 
-    QSettings settings;
-    settings.beginGroup( QSETTINGS_APP_GROUP_NAME );
-    QVariant uuidEntry = settings.value( "deviceUuid" );
-    if ( uuidEntry.isNull() )
-    {
-        uuid = uuidWithoutBraces( QUuid::createUuid() );
-        CoreUtils::log( QStringLiteral( "Device" ), QStringLiteral( "deviceUuid generated: %1" ).arg( uuid ) );
-        settings.setValue( "deviceUuid", uuid );
-    }
-    else
-    {
-        uuid = uuidEntry.toString();
-    }
-    settings.endGroup();
+  QSettings settings;
+  settings.beginGroup( QSETTINGS_APP_GROUP_NAME );
+  QVariant uuidEntry = settings.value( "deviceUuid" );
+  if ( uuidEntry.isNull() )
+  {
+    uuid = uuidWithoutBraces( QUuid::createUuid() );
+    CoreUtils::log( QStringLiteral( "Device" ), QStringLiteral( "deviceUuid generated: %1" ).arg( uuid ) );
+    settings.setValue( "deviceUuid", uuid );
+  }
+  else
+  {
+    uuid = uuidEntry.toString();
+  }
+  settings.endGroup();
 
-    Q_ASSERT( !uuid.isEmpty() );
-    return uuid;
+  Q_ASSERT( !uuid.isEmpty() );
+  return uuid;
 }
 
 QString CoreUtils::appInfo()
 {
-    return QString( "%1/%2 (%3/%4)" ).arg( QCoreApplication::applicationName() ).arg( QCoreApplication::applicationVersion() )
-        .arg( QSysInfo::productType() ).arg( QSysInfo::productVersion() );
+  return QString( "%1/%2 (%3/%4)" ).arg( QCoreApplication::applicationName() ).arg( QCoreApplication::applicationVersion() )
+         .arg( QSysInfo::productType() ).arg( QSysInfo::productVersion() );
 }
 
 QString CoreUtils::appVersion()
 {
-    QString version;
+  QString version;
 #ifdef INPUT_VERSION
-    version = STR( INPUT_VERSION );
+  version = STR( INPUT_VERSION );
 #endif
-    return version;
+  return version;
 }
 
 QString CoreUtils::appVersionCode()
 {
-    QString version;
+  QString version;
 #ifdef INPUT_VERSION_CODE
-    version = STR( INPUT_VERSION_CODE );
+  version = STR( INPUT_VERSION_CODE );
 #endif
-    return version;
+  return version;
 }
 
 QString CoreUtils::localizedDateFromUTFString( QString timestamp )
 {
-    if ( timestamp.isEmpty() )
-        return QString();
+  if ( timestamp.isEmpty() )
+    return QString();
 
-    QDateTime dateTime = QDateTime::fromString( timestamp, Qt::ISODate );
-    if ( dateTime.isValid() )
-    {
-        QLocale locale = QLocale::system();
-        return locale.toString( dateTime.date(), locale.dateFormat( QLocale::ShortFormat ) );
-    }
-    else
-    {
-        qDebug() << "Unable to convert UTF " << timestamp << " to QDateTime";
-        return QString();
-    }
+  QDateTime dateTime = QDateTime::fromString( timestamp, Qt::ISODate );
+  if ( dateTime.isValid() )
+  {
+    QLocale locale = QLocale::system();
+    return locale.toString( dateTime.date(), locale.dateFormat( QLocale::ShortFormat ) );
+  }
+  else
+  {
+    qDebug() << "Unable to convert UTF " << timestamp << " to QDateTime";
+    return QString();
+  }
 }
 
 QString CoreUtils::uuidWithoutBraces( const QUuid &uuid )
 {
 #if QT_VERSION >= QT_VERSION_CHECK( 5, 11, 0 )
-    return uuid.toString( QUuid::WithoutBraces );
+  return uuid.toString( QUuid::WithoutBraces );
 #else
-    QString str = uuid.toString();
-    str = str.mid( 1, str.length() - 2 );  // remove braces
-    return str;
+  QString str = uuid.toString();
+  str = str.mid( 1, str.length() - 2 );  // remove braces
+  return str;
 #endif
 }
 
 bool CoreUtils::removeDir( const QString &dir )
 {
-    if ( dir.isEmpty() || dir == "/" )
-        return false;
+  if ( dir.isEmpty() || dir == "/" )
+    return false;
 
-    return QDir( dir ).removeRecursively();
+  return QDir( dir ).removeRecursively();
 }
 
 QString CoreUtils::downloadInProgressFilePath( const QString &projectDir )
 {
-    return projectDir + "/.mergin/.project.downloading";
+  return projectDir + "/.mergin/.project.downloading";
 }
 
 
 void CoreUtils::setLogFilename( const QString &value )
 {
-    sLogFile = value;
+  sLogFile = value;
 }
 
 QString CoreUtils::logFilename()
 {
-    return sLogFile;
+  return sLogFile;
 }
 
 void CoreUtils::log( const QString &topic, const QString &info )
 {
-    QString logFilePath;
-    QByteArray data;
-    data.append( QString( "%1 %2: %3\n" ).arg( QDateTime().currentDateTimeUtc().toString( Qt::ISODateWithMs ) ).arg( topic ).arg( info ).toUtf8() );
-    appendLog( data, sLogFile );
+  QString logFilePath;
+  QByteArray data;
+  data.append( QString( "%1 %2: %3\n" ).arg( QDateTime().currentDateTimeUtc().toString( Qt::ISODateWithMs ) ).arg( topic ).arg( info ).toUtf8() );
+  appendLog( data, sLogFile );
 }
 
 void CoreUtils::appendLog( const QByteArray &data, const QString &path )
 {
-    if ( path != LOG_TO_DEVNULL )
+  if ( path != LOG_TO_DEVNULL )
+  {
+    if ( path == LOG_TO_STDOUT )
     {
-        if ( path == LOG_TO_STDOUT )
-        {
-            QTextStream out( stdout );
-            out << data;
-        }
-        else
-        {
-            qDebug() << data;
-            QFile file( path );
-            if ( path.isEmpty() || !file.open( QIODevice::Append ) )
-            {
-                qDebug() << "ERROR: Invalid log file";
-                return;
-            }
-            file.write( data );
-            file.close();
-        }
+      QTextStream out( stdout );
+      out << data;
     }
+    else
+    {
+      qDebug() << data;
+      QFile file( path );
+      if ( path.isEmpty() || !file.open( QIODevice::Append ) )
+      {
+        qDebug() << "ERROR: Invalid log file";
+        return;
+      }
+      file.write( data );
+      file.close();
+    }
+  }
 }
 
 QString CoreUtils::findUniquePath( const QString &path )
 {
-    QFileInfo originalPath( path );
-    QString uniquePath = path;
+  QFileInfo originalPath( path );
+  QString uniquePath = path;
 
-    // are we dealing with directory?
-    bool isDirectory = originalPath.isDir();
+  // are we dealing with directory?
+  bool isDirectory = originalPath.isDir();
 
-    int i = 0;
-    QFileInfo f( uniquePath );
+  int i = 0;
+  QFileInfo f( uniquePath );
 
-    while ( f.exists() )
+  while ( f.exists() )
+  {
+    ++i; // let's start from 1
+
+    if ( isDirectory )
     {
-        ++i; // let's start from 1
-
-        if ( isDirectory )
-        {
-            uniquePath = path + " (" + QString::number( i ) + ')';
-        }
-        else // file
-        {
-            uniquePath = originalPath.path() + '/' + originalPath.baseName() + " (" + QString::number( i ) + ")." + originalPath.completeSuffix();
-        }
-        f.setFile( uniquePath );
+      uniquePath = path + " (" + QString::number( i ) + ')';
     }
+    else // file
+    {
+      uniquePath = originalPath.path() + '/' + originalPath.baseName() + " (" + QString::number( i ) + ")." + originalPath.completeSuffix();
+    }
+    f.setFile( uniquePath );
+  }
 
-    return uniquePath;
+  return uniquePath;
 }
 
 QByteArray CoreUtils::calculateChecksum( const QString &filePath )
 {
-    QFile f( filePath );
-    if ( f.open( QFile::ReadOnly ) )
+  QFile f( filePath );
+  if ( f.open( QFile::ReadOnly ) )
+  {
+    QCryptographicHash hash( QCryptographicHash::Sha1 );
+    QByteArray chunk = f.read( CHECKSUM_CHUNK_SIZE );
+    while ( !chunk.isEmpty() )
     {
-        QCryptographicHash hash( QCryptographicHash::Sha1 );
-        QByteArray chunk = f.read( CHECKSUM_CHUNK_SIZE );
-        while ( !chunk.isEmpty() )
-        {
-            hash.addData( chunk );
-            chunk = f.read( CHECKSUM_CHUNK_SIZE );
-        }
-        f.close();
-        return hash.result().toHex();
+      hash.addData( chunk );
+      chunk = f.read( CHECKSUM_CHUNK_SIZE );
     }
+    f.close();
+    return hash.result().toHex();
+  }
 
-    return QByteArray();
+  return QByteArray();
 }
 
 QString CoreUtils::createUniqueProjectDirectory( const QString &baseDataDir, const QString &projectName )
 {
-    QString projectDirPath = findUniquePath( baseDataDir + "/" + projectName );
-    QDir projectDir( projectDirPath );
-    if ( !projectDir.exists() )
-    {
-        QDir dir( "" );
-        dir.mkdir( projectDirPath );
-    }
-    return projectDirPath;
+  QString projectDirPath = findUniquePath( baseDataDir + "/" + projectName );
+  QDir projectDir( projectDirPath );
+  if ( !projectDir.exists() )
+  {
+    QDir dir( "" );
+    dir.mkdir( projectDirPath );
+  }
+  return projectDirPath;
 }
 
 bool CoreUtils::createEmptyFile( const QString &filePath )
 {
-    QFile newFile( filePath );
-    if ( !newFile.open( QIODevice::WriteOnly ) )
-        return false;
+  QFile newFile( filePath );
+  if ( !newFile.open( QIODevice::WriteOnly ) )
+    return false;
 
-    newFile.close();
-    return true;
+  newFile.close();
+  return true;
 }
 
 QString CoreUtils::generateConflictedCopyFileName( const QString &file, const QString &username, int version )
 {
-    if ( file.isEmpty() )
-        return QString();
+  if ( file.isEmpty() )
+    return QString();
 
-    QFileInfo f( file );
+  QFileInfo f( file );
 
-    QString suffix = f.completeSuffix();
-    if ( hasProjectFileExtension( file ) )
-    {
-        suffix += "~";
-    }
-    return QString( "%1/%2 (conflicted copy, %3 v%4).%5" ).arg( f.path(), f.baseName(), username, QString::number( version ).toUtf8(), suffix );
+  QString suffix = f.completeSuffix();
+  if ( hasProjectFileExtension( file ) )
+  {
+    suffix += "~";
+  }
+  return QString( "%1/%2 (conflicted copy, %3 v%4).%5" ).arg( f.path(), f.baseName(), username, QString::number( version ).toUtf8(), suffix );
 }
 
 QString CoreUtils::generateEditConflictFileName( const QString &file, const QString &username, int version )
 {
-    if ( file.isEmpty() )
-        return QString();
+  if ( file.isEmpty() )
+    return QString();
 
-    QFileInfo f( file );
-    return QString( "%1/%2 (edit conflict, %3 v%4).json" ).arg( f.path(), f.baseName(), username, QString::number( version ) );
+  QFileInfo f( file );
+  return QString( "%1/%2 (edit conflict, %3 v%4).json" ).arg( f.path(), f.baseName(), username, QString::number( version ) );
 }
 
 bool CoreUtils::hasProjectFileExtension( const QString filePath )
 {
-    return filePath.contains( ".qgs", Qt::CaseInsensitive ) || filePath.contains( ".qgz", Qt::CaseInsensitive );
+  return filePath.contains( ".qgs", Qt::CaseInsensitive ) || filePath.contains( ".qgz", Qt::CaseInsensitive );
 }
 
 bool CoreUtils::isValidName( const QString &name )
 {
-    static QRegularExpression reForbiddenmNames( R"([@#$%^&*\(\)\{\}\[\]\\\/\|\+=<>~\?:;,`\'\"]|^[\s^\.].*$|^CON$|^PRN$|^AUX$|^NUL$|^COM\d$|^LPT\d|^support$|^helpdesk$|^merginmaps$|^lutraconsulting$|^mergin$|^lutra$|^input$|^sales$|^admin$)", QRegularExpression::CaseInsensitiveOption );
-    QRegularExpressionMatch matchForbiddenNames = reForbiddenmNames.match( name );
-    return !matchForbiddenNames.hasMatch();
+  static QRegularExpression reForbiddenmNames( R"([@#$%^&*\(\)\{\}\[\]\\\/\|\+=<>~\?:;,`\'\"]|^[\s^\.].*$|^CON$|^PRN$|^AUX$|^NUL$|^COM\d$|^LPT\d|^support$|^helpdesk$|^merginmaps$|^lutraconsulting$|^mergin$|^lutra$|^input$|^sales$|^admin$)", QRegularExpression::CaseInsensitiveOption );
+  QRegularExpressionMatch matchForbiddenNames = reForbiddenmNames.match( name );
+  return !matchForbiddenNames.hasMatch();
 }
 
 QString CoreUtils::nameAbbr( const QString &name, const QString &email )
 {
-    if ( name.isEmpty() )
-        return email.left( 2 ).toUpper();
-
-    static QRegularExpression re( R"([\r\n\t ]+)" );
-    QStringList list = name.split( re, Qt::SplitBehaviorFlags::SkipEmptyParts );
-
-    if ( list.size() > 1 )
-        return QString( "%1%2" ).arg( list.first()[0], list.last()[0] ).toUpper();
-
-    if ( email.isEmpty() )
-        return name.left( 2 ).toUpper();
-
+  if ( name.isEmpty() )
     return email.left( 2 ).toUpper();
+
+  static QRegularExpression re( R"([\r\n\t ]+)" );
+  QStringList list = name.split( re, Qt::SplitBehaviorFlags::SkipEmptyParts );
+
+  if ( list.size() > 1 )
+    return QString( "%1%2" ).arg( list.first()[0], list.last()[0] ).toUpper();
+
+  if ( email.isEmpty() )
+    return name.left( 2 ).toUpper();
+
+  return email.left( 2 ).toUpper();
 }
 
 double CoreUtils::getAvailableDeviceStorage()
 {
-    QString appDir = QCoreApplication::applicationDirPath();
-    QStorageInfo storageInfo(appDir);
+  QString appDir = QCoreApplication::applicationDirPath();
+  QStorageInfo storageInfo( appDir );
 
-    if (storageInfo.isValid() && storageInfo.isReady()) {
-        return static_cast<qreal>(storageInfo.bytesAvailable());
-    }
+  if ( storageInfo.isValid() && storageInfo.isReady() )
+  {
+    return static_cast<qreal>( storageInfo.bytesAvailable() );
+  }
 
-    return 0.0;
+  return 0.0;
 }
 
 double CoreUtils::getTotalDeviceStorage()
 {
-    QString appDir = QCoreApplication::applicationDirPath();
-    QStorageInfo storageInfo(appDir);
+  QString appDir = QCoreApplication::applicationDirPath();
+  QStorageInfo storageInfo( appDir );
 
-    if (storageInfo.isValid() && storageInfo.isReady()) {
-        return static_cast<qreal>(storageInfo.bytesTotal());
-    }
+  if ( storageInfo.isValid() && storageInfo.isReady() )
+  {
+    return static_cast<qreal>( storageInfo.bytesTotal() );
+  }
 
-    return 0.0;
+  return 0.0;
 }

--- a/core/coreutils.cpp
+++ b/core/coreutils.cpp
@@ -282,8 +282,7 @@ QString CoreUtils::nameAbbr( const QString &name, const QString &email )
   if ( email.isEmpty() )
     return name.left( 2 ).toUpper();
 
-  return email.left( 2 ).toUpper();
-}
+  return email.left( 2 ).toUpper();}
 
 QString CoreUtils::getAvailableDeviceStorage()
 {
@@ -295,7 +294,7 @@ QString CoreUtils::getAvailableDeviceStorage()
     return bytesToHumanSize( storageInfo.bytesAvailable() );
   }
 
-  return "N/A";
+  return "N/A"; //
 }
 
 QString CoreUtils::getTotalDeviceStorage()

--- a/core/coreutils.cpp
+++ b/core/coreutils.cpp
@@ -285,28 +285,53 @@ QString CoreUtils::nameAbbr( const QString &name, const QString &email )
   return email.left( 2 ).toUpper();
 }
 
-double CoreUtils::getAvailableDeviceStorage()
+QString CoreUtils::getAvailableDeviceStorage()
 {
   QString appDir = QCoreApplication::applicationDirPath();
   QStorageInfo storageInfo( appDir );
 
   if ( storageInfo.isValid() && storageInfo.isReady() )
   {
-    return static_cast<qreal>( storageInfo.bytesAvailable() );
+    return bytesToHumanSize( storageInfo.bytesAvailable() );
   }
 
-  return 0.0;
+  return "N/A";
 }
 
-double CoreUtils::getTotalDeviceStorage()
+QString CoreUtils::getTotalDeviceStorage()
 {
   QString appDir = QCoreApplication::applicationDirPath();
   QStorageInfo storageInfo( appDir );
 
   if ( storageInfo.isValid() && storageInfo.isReady() )
   {
-    return static_cast<qreal>( storageInfo.bytesTotal() );
+    return bytesToHumanSize( storageInfo.bytesTotal() );
   }
 
-  return 0.0;
+  return "N/A";
+}
+
+QString CoreUtils::bytesToHumanSize( double bytes )
+{
+  const int precision = 1;
+  if ( bytes < 1e-5 )
+  {
+    return "0.0";
+  }
+  else if ( bytes < 1024.0 * 1024.0 )
+  {
+    return QString::number( bytes / 1024.0, 'f', precision ) + " KB";
+  }
+  else if ( bytes < 1024.0 * 1024.0 * 1024.0 )
+  {
+    return QString::number( bytes / 1024.0 / 1024.0, 'f', precision ) + " MB";
+  }
+  else if ( bytes < 1024.0 * 1024.0 * 1024.0 * 1024.0 )
+  {
+    return QString::number( bytes / 1024.0 / 1024.0 / 1024.0, 'f', precision ) + " GB";
+  }
+  else
+  {
+    return QString::number( bytes / 1024.0 / 1024.0 / 1024.0 / 1024.0, 'f', precision ) + " TB";
+  }
 }

--- a/core/coreutils.cpp
+++ b/core/coreutils.cpp
@@ -20,6 +20,7 @@
 #include <QTextStream>
 #include <QCryptographicHash>
 #include <QRegularExpression>
+#include <QStorageInfo>
 
 #include "qcoreapplication.h"
 
@@ -31,255 +32,279 @@ int CoreUtils::CHECKSUM_CHUNK_SIZE = 65536;
 
 QString CoreUtils::deviceUuid()
 {
-  QString uuid;
+    QString uuid;
 
-  QSettings settings;
-  settings.beginGroup( QSETTINGS_APP_GROUP_NAME );
-  QVariant uuidEntry = settings.value( "deviceUuid" );
-  if ( uuidEntry.isNull() )
-  {
-    uuid = uuidWithoutBraces( QUuid::createUuid() );
-    CoreUtils::log( QStringLiteral( "Device" ), QStringLiteral( "deviceUuid generated: %1" ).arg( uuid ) );
-    settings.setValue( "deviceUuid", uuid );
-  }
-  else
-  {
-    uuid = uuidEntry.toString();
-  }
-  settings.endGroup();
+    QSettings settings;
+    settings.beginGroup( QSETTINGS_APP_GROUP_NAME );
+    QVariant uuidEntry = settings.value( "deviceUuid" );
+    if ( uuidEntry.isNull() )
+    {
+        uuid = uuidWithoutBraces( QUuid::createUuid() );
+        CoreUtils::log( QStringLiteral( "Device" ), QStringLiteral( "deviceUuid generated: %1" ).arg( uuid ) );
+        settings.setValue( "deviceUuid", uuid );
+    }
+    else
+    {
+        uuid = uuidEntry.toString();
+    }
+    settings.endGroup();
 
-  Q_ASSERT( !uuid.isEmpty() );
-  return uuid;
+    Q_ASSERT( !uuid.isEmpty() );
+    return uuid;
 }
 
 QString CoreUtils::appInfo()
 {
-  return QString( "%1/%2 (%3/%4)" ).arg( QCoreApplication::applicationName() ).arg( QCoreApplication::applicationVersion() )
-         .arg( QSysInfo::productType() ).arg( QSysInfo::productVersion() );
+    return QString( "%1/%2 (%3/%4)" ).arg( QCoreApplication::applicationName() ).arg( QCoreApplication::applicationVersion() )
+        .arg( QSysInfo::productType() ).arg( QSysInfo::productVersion() );
 }
 
 QString CoreUtils::appVersion()
 {
-  QString version;
+    QString version;
 #ifdef INPUT_VERSION
-  version = STR( INPUT_VERSION );
+    version = STR( INPUT_VERSION );
 #endif
-  return version;
+    return version;
 }
 
 QString CoreUtils::appVersionCode()
 {
-  QString version;
+    QString version;
 #ifdef INPUT_VERSION_CODE
-  version = STR( INPUT_VERSION_CODE );
+    version = STR( INPUT_VERSION_CODE );
 #endif
-  return version;
+    return version;
 }
 
 QString CoreUtils::localizedDateFromUTFString( QString timestamp )
 {
-  if ( timestamp.isEmpty() )
-    return QString();
+    if ( timestamp.isEmpty() )
+        return QString();
 
-  QDateTime dateTime = QDateTime::fromString( timestamp, Qt::ISODate );
-  if ( dateTime.isValid() )
-  {
-    QLocale locale = QLocale::system();
-    return locale.toString( dateTime.date(), locale.dateFormat( QLocale::ShortFormat ) );
-  }
-  else
-  {
-    qDebug() << "Unable to convert UTF " << timestamp << " to QDateTime";
-    return QString();
-  }
+    QDateTime dateTime = QDateTime::fromString( timestamp, Qt::ISODate );
+    if ( dateTime.isValid() )
+    {
+        QLocale locale = QLocale::system();
+        return locale.toString( dateTime.date(), locale.dateFormat( QLocale::ShortFormat ) );
+    }
+    else
+    {
+        qDebug() << "Unable to convert UTF " << timestamp << " to QDateTime";
+        return QString();
+    }
 }
 
 QString CoreUtils::uuidWithoutBraces( const QUuid &uuid )
 {
 #if QT_VERSION >= QT_VERSION_CHECK( 5, 11, 0 )
-  return uuid.toString( QUuid::WithoutBraces );
+    return uuid.toString( QUuid::WithoutBraces );
 #else
-  QString str = uuid.toString();
-  str = str.mid( 1, str.length() - 2 );  // remove braces
-  return str;
+    QString str = uuid.toString();
+    str = str.mid( 1, str.length() - 2 );  // remove braces
+    return str;
 #endif
 }
 
 bool CoreUtils::removeDir( const QString &dir )
 {
-  if ( dir.isEmpty() || dir == "/" )
-    return false;
+    if ( dir.isEmpty() || dir == "/" )
+        return false;
 
-  return QDir( dir ).removeRecursively();
+    return QDir( dir ).removeRecursively();
 }
 
 QString CoreUtils::downloadInProgressFilePath( const QString &projectDir )
 {
-  return projectDir + "/.mergin/.project.downloading";
+    return projectDir + "/.mergin/.project.downloading";
 }
 
 
 void CoreUtils::setLogFilename( const QString &value )
 {
-  sLogFile = value;
+    sLogFile = value;
 }
 
 QString CoreUtils::logFilename()
 {
-  return sLogFile;
+    return sLogFile;
 }
 
 void CoreUtils::log( const QString &topic, const QString &info )
 {
-  QString logFilePath;
-  QByteArray data;
-  data.append( QString( "%1 %2: %3\n" ).arg( QDateTime().currentDateTimeUtc().toString( Qt::ISODateWithMs ) ).arg( topic ).arg( info ).toUtf8() );
-  appendLog( data, sLogFile );
+    QString logFilePath;
+    QByteArray data;
+    data.append( QString( "%1 %2: %3\n" ).arg( QDateTime().currentDateTimeUtc().toString( Qt::ISODateWithMs ) ).arg( topic ).arg( info ).toUtf8() );
+    appendLog( data, sLogFile );
 }
 
 void CoreUtils::appendLog( const QByteArray &data, const QString &path )
 {
-  if ( path != LOG_TO_DEVNULL )
-  {
-    if ( path == LOG_TO_STDOUT )
+    if ( path != LOG_TO_DEVNULL )
     {
-      QTextStream out( stdout );
-      out << data;
+        if ( path == LOG_TO_STDOUT )
+        {
+            QTextStream out( stdout );
+            out << data;
+        }
+        else
+        {
+            qDebug() << data;
+            QFile file( path );
+            if ( path.isEmpty() || !file.open( QIODevice::Append ) )
+            {
+                qDebug() << "ERROR: Invalid log file";
+                return;
+            }
+            file.write( data );
+            file.close();
+        }
     }
-    else
-    {
-      qDebug() << data;
-      QFile file( path );
-      if ( path.isEmpty() || !file.open( QIODevice::Append ) )
-      {
-        qDebug() << "ERROR: Invalid log file";
-        return;
-      }
-      file.write( data );
-      file.close();
-    }
-  }
 }
 
 QString CoreUtils::findUniquePath( const QString &path )
 {
-  QFileInfo originalPath( path );
-  QString uniquePath = path;
+    QFileInfo originalPath( path );
+    QString uniquePath = path;
 
-  // are we dealing with directory?
-  bool isDirectory = originalPath.isDir();
+    // are we dealing with directory?
+    bool isDirectory = originalPath.isDir();
 
-  int i = 0;
-  QFileInfo f( uniquePath );
+    int i = 0;
+    QFileInfo f( uniquePath );
 
-  while ( f.exists() )
-  {
-    ++i; // let's start from 1
-
-    if ( isDirectory )
+    while ( f.exists() )
     {
-      uniquePath = path + " (" + QString::number( i ) + ')';
-    }
-    else // file
-    {
-      uniquePath = originalPath.path() + '/' + originalPath.baseName() + " (" + QString::number( i ) + ")." + originalPath.completeSuffix();
-    }
-    f.setFile( uniquePath );
-  }
+        ++i; // let's start from 1
 
-  return uniquePath;
+        if ( isDirectory )
+        {
+            uniquePath = path + " (" + QString::number( i ) + ')';
+        }
+        else // file
+        {
+            uniquePath = originalPath.path() + '/' + originalPath.baseName() + " (" + QString::number( i ) + ")." + originalPath.completeSuffix();
+        }
+        f.setFile( uniquePath );
+    }
+
+    return uniquePath;
 }
 
 QByteArray CoreUtils::calculateChecksum( const QString &filePath )
 {
-  QFile f( filePath );
-  if ( f.open( QFile::ReadOnly ) )
-  {
-    QCryptographicHash hash( QCryptographicHash::Sha1 );
-    QByteArray chunk = f.read( CHECKSUM_CHUNK_SIZE );
-    while ( !chunk.isEmpty() )
+    QFile f( filePath );
+    if ( f.open( QFile::ReadOnly ) )
     {
-      hash.addData( chunk );
-      chunk = f.read( CHECKSUM_CHUNK_SIZE );
+        QCryptographicHash hash( QCryptographicHash::Sha1 );
+        QByteArray chunk = f.read( CHECKSUM_CHUNK_SIZE );
+        while ( !chunk.isEmpty() )
+        {
+            hash.addData( chunk );
+            chunk = f.read( CHECKSUM_CHUNK_SIZE );
+        }
+        f.close();
+        return hash.result().toHex();
     }
-    f.close();
-    return hash.result().toHex();
-  }
 
-  return QByteArray();
+    return QByteArray();
 }
 
 QString CoreUtils::createUniqueProjectDirectory( const QString &baseDataDir, const QString &projectName )
 {
-  QString projectDirPath = findUniquePath( baseDataDir + "/" + projectName );
-  QDir projectDir( projectDirPath );
-  if ( !projectDir.exists() )
-  {
-    QDir dir( "" );
-    dir.mkdir( projectDirPath );
-  }
-  return projectDirPath;
+    QString projectDirPath = findUniquePath( baseDataDir + "/" + projectName );
+    QDir projectDir( projectDirPath );
+    if ( !projectDir.exists() )
+    {
+        QDir dir( "" );
+        dir.mkdir( projectDirPath );
+    }
+    return projectDirPath;
 }
 
 bool CoreUtils::createEmptyFile( const QString &filePath )
 {
-  QFile newFile( filePath );
-  if ( !newFile.open( QIODevice::WriteOnly ) )
-    return false;
+    QFile newFile( filePath );
+    if ( !newFile.open( QIODevice::WriteOnly ) )
+        return false;
 
-  newFile.close();
-  return true;
+    newFile.close();
+    return true;
 }
 
 QString CoreUtils::generateConflictedCopyFileName( const QString &file, const QString &username, int version )
 {
-  if ( file.isEmpty() )
-    return QString();
+    if ( file.isEmpty() )
+        return QString();
 
-  QFileInfo f( file );
+    QFileInfo f( file );
 
-  QString suffix = f.completeSuffix();
-  if ( hasProjectFileExtension( file ) )
-  {
-    suffix += "~";
-  }
-  return QString( "%1/%2 (conflicted copy, %3 v%4).%5" ).arg( f.path(), f.baseName(), username, QString::number( version ).toUtf8(), suffix );
+    QString suffix = f.completeSuffix();
+    if ( hasProjectFileExtension( file ) )
+    {
+        suffix += "~";
+    }
+    return QString( "%1/%2 (conflicted copy, %3 v%4).%5" ).arg( f.path(), f.baseName(), username, QString::number( version ).toUtf8(), suffix );
 }
 
 QString CoreUtils::generateEditConflictFileName( const QString &file, const QString &username, int version )
 {
-  if ( file.isEmpty() )
-    return QString();
+    if ( file.isEmpty() )
+        return QString();
 
-  QFileInfo f( file );
-  return QString( "%1/%2 (edit conflict, %3 v%4).json" ).arg( f.path(), f.baseName(), username, QString::number( version ) );
+    QFileInfo f( file );
+    return QString( "%1/%2 (edit conflict, %3 v%4).json" ).arg( f.path(), f.baseName(), username, QString::number( version ) );
 }
 
 bool CoreUtils::hasProjectFileExtension( const QString filePath )
 {
-  return filePath.contains( ".qgs", Qt::CaseInsensitive ) || filePath.contains( ".qgz", Qt::CaseInsensitive );
+    return filePath.contains( ".qgs", Qt::CaseInsensitive ) || filePath.contains( ".qgz", Qt::CaseInsensitive );
 }
 
 bool CoreUtils::isValidName( const QString &name )
 {
-  static QRegularExpression reForbiddenmNames( R"([@#$%^&*\(\)\{\}\[\]\\\/\|\+=<>~\?:;,`\'\"]|^[\s^\.].*$|^CON$|^PRN$|^AUX$|^NUL$|^COM\d$|^LPT\d|^support$|^helpdesk$|^merginmaps$|^lutraconsulting$|^mergin$|^lutra$|^input$|^sales$|^admin$)", QRegularExpression::CaseInsensitiveOption );
-  QRegularExpressionMatch matchForbiddenNames = reForbiddenmNames.match( name );
-  return !matchForbiddenNames.hasMatch();
+    static QRegularExpression reForbiddenmNames( R"([@#$%^&*\(\)\{\}\[\]\\\/\|\+=<>~\?:;,`\'\"]|^[\s^\.].*$|^CON$|^PRN$|^AUX$|^NUL$|^COM\d$|^LPT\d|^support$|^helpdesk$|^merginmaps$|^lutraconsulting$|^mergin$|^lutra$|^input$|^sales$|^admin$)", QRegularExpression::CaseInsensitiveOption );
+    QRegularExpressionMatch matchForbiddenNames = reForbiddenmNames.match( name );
+    return !matchForbiddenNames.hasMatch();
 }
 
 QString CoreUtils::nameAbbr( const QString &name, const QString &email )
 {
-  if ( name.isEmpty() )
+    if ( name.isEmpty() )
+        return email.left( 2 ).toUpper();
+
+    static QRegularExpression re( R"([\r\n\t ]+)" );
+    QStringList list = name.split( re, Qt::SplitBehaviorFlags::SkipEmptyParts );
+
+    if ( list.size() > 1 )
+        return QString( "%1%2" ).arg( list.first()[0], list.last()[0] ).toUpper();
+
+    if ( email.isEmpty() )
+        return name.left( 2 ).toUpper();
+
     return email.left( 2 ).toUpper();
+}
 
-  static QRegularExpression re( R"([\r\n\t ]+)" );
-  QStringList list = name.split( re, Qt::SplitBehaviorFlags::SkipEmptyParts );
+double CoreUtils::getAvailableDeviceStorage()
+{
+    QString appDir = QCoreApplication::applicationDirPath();
+    QStorageInfo storageInfo(appDir);
 
-  if ( list.size() > 1 )
-    return QString( "%1%2" ).arg( list.first()[0], list.last()[0] ).toUpper();
+    if (storageInfo.isValid() && storageInfo.isReady()) {
+        return static_cast<qreal>(storageInfo.bytesAvailable());
+    }
 
-  if ( email.isEmpty() )
-    return name.left( 2 ).toUpper();
+    return 0.0;
+}
 
-  return email.left( 2 ).toUpper();
+double CoreUtils::getTotalDeviceStorage()
+{
+    QString appDir = QCoreApplication::applicationDirPath();
+    QStorageInfo storageInfo(appDir);
+
+    if (storageInfo.isValid() && storageInfo.isReady()) {
+        return static_cast<qreal>(storageInfo.bytesTotal());
+    }
+
+    return 0.0;
 }

--- a/core/coreutils.cpp
+++ b/core/coreutils.cpp
@@ -294,7 +294,7 @@ QString CoreUtils::getAvailableDeviceStorage()
     return bytesToHumanSize( storageInfo.bytesAvailable() );
   }
 
-  return "N/A"; //
+  return "N/A";
 }
 
 QString CoreUtils::getTotalDeviceStorage()

--- a/core/coreutils.h
+++ b/core/coreutils.h
@@ -20,7 +20,7 @@
 
 class CoreUtils
 {
-  public:
+public:
     explicit CoreUtils( ) = default;
     ~CoreUtils() = default;
 
@@ -109,7 +109,18 @@ class CoreUtils
     static QString deviceUuid();
 
     static const QString QSETTINGS_APP_GROUP_NAME;
-  private:
+
+    /**
+     * Returns available device storage
+    */
+    static double getAvailableDeviceStorage();
+
+    /**
+     * Returns total device storage
+    */
+    static double getTotalDeviceStorage();
+
+private:
     static QString sLogFile;
     static int CHECKSUM_CHUNK_SIZE;
 

--- a/core/coreutils.h
+++ b/core/coreutils.h
@@ -20,7 +20,7 @@
 
 class CoreUtils
 {
-public:
+  public:
     explicit CoreUtils( ) = default;
     ~CoreUtils() = default;
 
@@ -120,7 +120,7 @@ public:
     */
     static double getTotalDeviceStorage();
 
-private:
+  private:
     static QString sLogFile;
     static int CHECKSUM_CHUNK_SIZE;
 

--- a/core/coreutils.h
+++ b/core/coreutils.h
@@ -113,12 +113,17 @@ class CoreUtils
     /**
      * Returns available device storage
     */
-    static double getAvailableDeviceStorage();
+    static QString getAvailableDeviceStorage();
 
     /**
      * Returns total device storage
     */
-    static double getTotalDeviceStorage();
+    static QString getTotalDeviceStorage();
+
+    /**
+     * Converts bytes to human readable size (e.g. 1GB, 500MB)
+     */
+    static QString bytesToHumanSize( double bytes );
 
   private:
     static QString sLogFile;

--- a/core/merginapi.cpp
+++ b/core/merginapi.cpp
@@ -2415,7 +2415,7 @@ void MerginApi::startProjectPull( const QString &projectFullName )
   []( const DownloadQueueItem & a, const DownloadQueueItem & b ) { return a.size > b.size; }
   );
 
-  CoreUtils::log( "pull " + projectFullName, QStringLiteral( "%1 available device storage, %2 total device storage" )
+  CoreUtils::log( "pull " + projectFullName, QStringLiteral( "%1 of available device storage, %2 of total device storage" )
                   .arg( CoreUtils::getAvailableDeviceStorage() )
                   .arg( CoreUtils::getTotalDeviceStorage() ) );
 

--- a/core/merginapi.cpp
+++ b/core/merginapi.cpp
@@ -2415,6 +2415,10 @@ void MerginApi::startProjectPull( const QString &projectFullName )
   []( const DownloadQueueItem & a, const DownloadQueueItem & b ) { return a.size > b.size; }
   );
 
+  CoreUtils::log( "pull " + projectFullName, QStringLiteral( "%1 available device storage, %2 total device storage" )
+                  .arg( CoreUtils::getAvailableDeviceStorage() )
+                  .arg( CoreUtils::getTotalDeviceStorage() ) );
+
   CoreUtils::log( "pull " + projectFullName, QStringLiteral( "%1 update tasks, %2 items to download (total size %3 bytes)" )
                   .arg( transaction.pullTasks.count() )
                   .arg( transaction.downloadQueue.count() )


### PR DESCRIPTION
Available storage is now added to diagnostic logs at the start of syncing.

Download and upload information is already available and logged in:
https://github.com/MerginMaps/mobile/blob/33ff5a8da0b04a55a83056cced9a5ed9952a8a1b/core/merginapi.cpp#L2418

https://github.com/MerginMaps/mobile/blob/33ff5a8da0b04a55a83056cced9a5ed9952a8a1b/core/merginapi.cpp#L2746

Resolves #3522 