### PR TITLE
Handling XLSX and DOCX files in file viewing system for newer Android versions

### DIFF
--- a/cmake_templates/AndroidManifest.xml.in
+++ b/cmake_templates/AndroidManifest.xml.in
@@ -110,5 +110,15 @@
         <category android:name="android.intent.category.BROWSABLE" />
         <data android:scheme="https" />
     </intent>
+    <intent>
+        <action android:name="android.intent.action.VIEW" />
+        <category android:name="android.intent.category.DEFAULT" />
+        <data android:mimeType="application/vnd.openxmlformats-officedocument.wordprocessingml.document" />
+    </intent>
+    <intent>
+        <action android:name="android.intent.action.VIEW" />
+        <category android:name="android.intent.category.DEFAULT" />
+        <data android:mimeType="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet" />
+    </intent>
     </queries>
 </manifest>

--- a/cmake_templates/AndroidManifest.xml.in
+++ b/cmake_templates/AndroidManifest.xml.in
@@ -107,18 +107,7 @@
     </intent>
     <intent>
         <action android:name="android.intent.action.VIEW" />
-        <category android:name="android.intent.category.BROWSABLE" />
-        <data android:scheme="https" />
-    </intent>
-    <intent>
-        <action android:name="android.intent.action.VIEW" />
-        <category android:name="android.intent.category.DEFAULT" />
-        <data android:mimeType="application/vnd.openxmlformats-officedocument.wordprocessingml.document" />
-    </intent>
-    <intent>
-        <action android:name="android.intent.action.VIEW" />
-        <category android:name="android.intent.category.DEFAULT" />
-        <data android:mimeType="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet" />
+        <data android:mimeType="*/*" />
     </intent>
     </queries>
 </manifest>


### PR DESCRIPTION
Changes in `AndroidManifest.xml` to ensure that newer versions of Android can open more types of documents, such as XLSX, DOCX, and PNG, provided there is an application that can open these documents. See [reference.](https://stackoverflow.com/questions/11068648/launching-an-intent-for-file-and-mime-type)

