### PR TITLE
Eliding project's name to the left

### DIFF
--- a/app/qml/project/components/MMProjectDelegate.qml
+++ b/app/qml/project/components/MMProjectDelegate.qml
@@ -101,6 +101,8 @@ Control {
               if ( root.state === "Error" ) return __style.darkGreyColor
               return __style.nightColor
             }
+
+            elide: Text.ElideLeft
           }
 
           Row {


### PR DESCRIPTION
Eliding project names to the left to better distinguish between them, prioritizing project names over the workspace name.

Resolves #3536 