### PR TITLE
Fixing app freeze related to MMBaseSingleLineInput

### DIFF
--- a/app/qml/components/private/MMBaseSingleLineInput.qml
+++ b/app/qml/components/private/MMBaseSingleLineInput.qml
@@ -92,7 +92,7 @@ MMBaseInput {
     radius: __style.radius12
 
     RowLayout {
-      anchors .fill: parent
+      anchors.fill: parent
 
       spacing: __style.margin12
 

--- a/app/qml/form/MMFormPage.qml
+++ b/app/qml/form/MMFormPage.qml
@@ -338,7 +338,6 @@ Page {
         }
 
         function onOpenLinkedFeature( linkedFeature ) {
-          root.forceActiveFocus() //prevent app freeze as mentioned in issue #3538
           root.openLinkedFeature( linkedFeature )
         }
       }

--- a/app/qml/form/MMFormPage.qml
+++ b/app/qml/form/MMFormPage.qml
@@ -338,6 +338,7 @@ Page {
         }
 
         function onOpenLinkedFeature( linkedFeature ) {
+          root.forceActiveFocus() //prevent app freeze as mentioned in issue #3538
           root.openLinkedFeature( linkedFeature )
         }
       }

--- a/app/qml/form/editors/MMFormGalleryEditor.qml
+++ b/app/qml/form/editors/MMFormGalleryEditor.qml
@@ -91,9 +91,7 @@ MMPrivateComponents.MMBaseInput {
 
         MMComponents.MMSingleClickMouseArea {
           anchors.fill: parent
-          onSingleClicked: {
-            root.createLinkedFeature( root._fieldFeatureLayerPair, root._fieldAssociatedRelation )
-          }
+          onSingleClicked: root.createLinkedFeature( root._fieldFeatureLayerPair, root._fieldAssociatedRelation )
         }
       }
 


### PR DESCRIPTION
Small fix in `MMBaseSingleLineInput.qml` to prevent app freeze in the first method of reproducing issue.

Fixes (Partially) #3538 