### PR TITLE
Fix invalid layer in value relation field

### DIFF
--- a/app/featuresmodel.cpp
+++ b/app/featuresmodel.cpp
@@ -158,7 +158,7 @@ int FeaturesModel::rowCount( const QModelIndex &parent ) const
 
 QVariant FeaturesModel::featureTitle( const FeatureLayerPair &featurePair ) const
 {
-  if ( !featurePair.layer() || !featurePair.layer()->isValid() ) 
+  if ( !featurePair.layer() || !featurePair.layer()->isValid() )
   {
     CoreUtils::log( QStringLiteral( "Features Model" ), QStringLiteral( "Received invalid feature layer pair!" ) );
     return tr( "Unknown title" );

--- a/app/featuresmodel.cpp
+++ b/app/featuresmodel.cpp
@@ -158,6 +158,12 @@ int FeaturesModel::rowCount( const QModelIndex &parent ) const
 
 QVariant FeaturesModel::featureTitle( const FeatureLayerPair &featurePair ) const
 {
+  if ( !featurePair.layer() || !featurePair.layer()->isValid() ) 
+  {
+    CoreUtils::log( QStringLiteral( "Features Model" ), QStringLiteral( "Received invalid feature layer pair!" ) );
+    return tr( "Unknown title" );
+  }
+
   QString title;
 
   QgsExpressionContext context( QgsExpressionContextUtils::globalProjectLayerScopes( featurePair.layer() ) );


### PR DESCRIPTION
It seems there is some edge-case scenario where a referenced layer in the value relation field is not available (probably a missing layer or some other project misconfiguration ... I could not reproduce it with my projects)

Logs are indicating that `mTitleField` is empty, thus we continue to `FeaturesModel::FeatureTitle` with `pair->layer()` as nullptr. See https://github.com/MerginMaps/mobile/blob/dd05acc2fbc4a55e65715b799810e37368cf83b0/app/valuerelationfeaturesmodel.cpp#L87-L96

See bug report logs for more details -> Fixes #3535 