### PR TITLE
Fixing crashes related to MerginApi::parseVersion 

### DIFF
--- a/app/test/testmerginapi.cpp
+++ b/app/test/testmerginapi.cpp
@@ -2931,7 +2931,7 @@ void TestMerginApi::testParseVersion()
   QCOMPARE( major, 1 );
   QCOMPARE( minor, 2 );
 
-  // Invalid version string with spaces in the last argument
+  // Valid version string with spaces in the last argument
   QVERIFY( mApi->parseVersion( "1.2. 3", major, minor ) );
 
   // Invalid version string with only minor version (should fail)

--- a/app/test/testmerginapi.cpp
+++ b/app/test/testmerginapi.cpp
@@ -2931,8 +2931,8 @@ void TestMerginApi::testParseVersion()
   QCOMPARE( major, 1 );
   QCOMPARE( minor, 2 );
 
-  // Invalid version string with spaces (should fail)
-  QVERIFY( !mApi->parseVersion( "1.2. 3", major, minor ) );
+  // Invalid version string with spaces in the last argument
+  QVERIFY( mApi->parseVersion( "1.2. 3", major, minor ) );
 
   // Invalid version string with only minor version (should fail)
   QVERIFY( !mApi->parseVersion( ".2.3", major, minor ) );

--- a/app/test/testmerginapi.cpp
+++ b/app/test/testmerginapi.cpp
@@ -2893,3 +2893,44 @@ void TestMerginApi::testRegistration()
   QCOMPARE( spy.count(), 1 );
   QCOMPARE( spy.takeFirst().at( 1 ).toInt(), RegistrationError::RegistrationErrorType::TOC );
 }
+
+void TestMerginApi::testParseVersion()
+{
+  int major, minor;
+
+  // Valid version string
+  QVERIFY( mApi->parseVersion( "1.2", major, minor ) );
+  QCOMPARE( major, 1 );
+  QCOMPARE( minor, 2 );
+
+  // Valid version string with larger numbers
+  QVERIFY( mApi->parseVersion( "10.20", major, minor ) );
+  QCOMPARE( major, 10 );
+  QCOMPARE( minor, 20 );
+
+  // Invalid version string (missing minor version)
+  QVERIFY( !mApi->parseVersion( "1.", major, minor ) );
+
+  // Invalid version string (non-numeric characters)
+  QVERIFY( !mApi->parseVersion( "a.b", major, minor ) );
+
+  // Invalid version string (additional characters)
+  QVERIFY( !mApi->parseVersion( "1.2.3", major, minor ) );
+
+  // Empty version string
+  QVERIFY( !mApi->parseVersion( "", major, minor ) );
+
+  // Null version string
+  QVERIFY( !mApi->parseVersion( QString(), major, minor ) );
+
+  // Valid version string with leading zeros
+  QVERIFY( mApi->parseVersion( "01.02", major, minor ) );
+  QCOMPARE( major, 1 );
+  QCOMPARE( minor, 2 );
+
+  // Valid version string with spaces (should fail)
+  QVERIFY( !mApi->parseVersion( "1. 2", major, minor ) );
+
+  // Valid version string with only minor version (should fail)
+  QVERIFY( !mApi->parseVersion( ".2", major, minor ) );
+}

--- a/app/test/testmerginapi.cpp
+++ b/app/test/testmerginapi.cpp
@@ -2899,23 +2899,26 @@ void TestMerginApi::testParseVersion()
   int major, minor;
 
   // Valid version string
-  QVERIFY( mApi->parseVersion( "1.2", major, minor ) );
+  QVERIFY( mApi->parseVersion( "1.2.3", major, minor ) );
   QCOMPARE( major, 1 );
   QCOMPARE( minor, 2 );
 
   // Valid version string with larger numbers
-  QVERIFY( mApi->parseVersion( "10.20", major, minor ) );
+  QVERIFY( mApi->parseVersion( "10.20.30", major, minor ) );
   QCOMPARE( major, 10 );
   QCOMPARE( minor, 20 );
 
+  // Invalid version string (missing patch version)
+  QVERIFY( !mApi->parseVersion( "1.2", major, minor ) );
+
   // Invalid version string (missing minor version)
-  QVERIFY( !mApi->parseVersion( "1.", major, minor ) );
+  QVERIFY( !mApi->parseVersion( "1..3", major, minor ) );
 
   // Invalid version string (non-numeric characters)
-  QVERIFY( !mApi->parseVersion( "a.b", major, minor ) );
+  QVERIFY( !mApi->parseVersion( "a.b.c", major, minor ) );
 
   // Invalid version string (additional characters)
-  QVERIFY( !mApi->parseVersion( "1.2.3", major, minor ) );
+  QVERIFY( !mApi->parseVersion( "1.2.3.4", major, minor ) );
 
   // Empty version string
   QVERIFY( !mApi->parseVersion( "", major, minor ) );
@@ -2924,13 +2927,18 @@ void TestMerginApi::testParseVersion()
   QVERIFY( !mApi->parseVersion( QString(), major, minor ) );
 
   // Valid version string with leading zeros
-  QVERIFY( mApi->parseVersion( "01.02", major, minor ) );
+  QVERIFY( mApi->parseVersion( "01.02.03", major, minor ) );
   QCOMPARE( major, 1 );
   QCOMPARE( minor, 2 );
 
-  // Valid version string with spaces (should fail)
-  QVERIFY( !mApi->parseVersion( "1. 2", major, minor ) );
+  // Invalid version string with spaces (should fail)
+  QVERIFY( !mApi->parseVersion( "1.2. 3", major, minor ) );
 
-  // Valid version string with only minor version (should fail)
-  QVERIFY( !mApi->parseVersion( ".2", major, minor ) );
+  // Invalid version string with only minor version (should fail)
+  QVERIFY( !mApi->parseVersion( ".2.3", major, minor ) );
+
+  // Valid version string in expected format
+  QVERIFY( mApi->parseVersion( "2024.4.3", major, minor ) );
+  QCOMPARE( major, 2024 );
+  QCOMPARE( minor, 4 );
 }

--- a/app/test/testmerginapi.h
+++ b/app/test/testmerginapi.h
@@ -94,6 +94,8 @@ class TestMerginApi: public QObject
 
     void testRegistration();
 
+    void testParseVersion();
+
   private:
     MerginApi *mApi = nullptr;
 

--- a/core/merginapi.cpp
+++ b/core/merginapi.cpp
@@ -1595,7 +1595,7 @@ bool MerginApi::parseVersion( const QString &version, int &major, int &minor )
     return false;
 
   QRegularExpression re;
-  re.setPattern( QStringLiteral( R"((?<major>\d+)\.(?<minor>\d+))" ) );
+  re.setPattern( QStringLiteral( R"(^\s*(?<major>\d+)\.(?<minor>\d+)\s*$)" ) );
   QRegularExpressionMatch match = re.match( version );
 
   if ( match.hasMatch() )

--- a/core/merginapi.cpp
+++ b/core/merginapi.cpp
@@ -1591,13 +1591,22 @@ ProjectDiff MerginApi::localProjectChanges( const QString &projectDir )
 
 bool MerginApi::parseVersion( const QString &version, int &major, int &minor )
 {
+  if ( version.isNull() || version.isEmpty() )
+    return false;
+
   QRegularExpression re;
-  re.setPattern( QStringLiteral( "(?<major>\\d+)[.](?<minor>\\d+)" ) );
+  re.setPattern( QStringLiteral( R"((?<major>\d+)\.(?<minor>\d+))" ) );
   QRegularExpressionMatch match = re.match( version );
+
   if ( match.hasMatch() )
   {
-    major = match.captured( "major" ).toInt();
-    minor = match.captured( "minor" ).toInt();
+    bool majorOk, minorOk;
+    major = match.captured( "major" ).toInt( &majorOk );
+    minor = match.captured( "minor" ).toInt( &minorOk );
+
+    if ( !majorOk || !minorOk )
+      return false;
+
     return true;
   }
 

--- a/core/merginapi.cpp
+++ b/core/merginapi.cpp
@@ -1595,7 +1595,7 @@ bool MerginApi::parseVersion( const QString &version, int &major, int &minor )
     return false;
 
   QRegularExpression re;
-  re.setPattern( QStringLiteral( R"(^\s*(?<major>\d+)\.(?<minor>\d+)\s*$)" ) );
+  re.setPattern( QStringLiteral( R"(^\s*(?<major>\d+)\.(?<minor>\d+)\.\d+\s*$)" ) );
   QRegularExpressionMatch match = re.match( version );
 
   if ( match.hasMatch() )

--- a/core/merginapi.cpp
+++ b/core/merginapi.cpp
@@ -1594,23 +1594,19 @@ bool MerginApi::parseVersion( const QString &version, int &major, int &minor )
   if ( version.isNull() || version.isEmpty() )
     return false;
 
-  QRegularExpression re;
-  re.setPattern( QStringLiteral( R"(^\s*(?<major>\d+)\.(?<minor>\d+)\.\d+\s*$)" ) );
-  QRegularExpressionMatch match = re.match( version );
+  QStringList versionParts = version.split( '.' );
 
-  if ( match.hasMatch() )
-  {
-    bool majorOk, minorOk;
-    major = match.captured( "major" ).toInt( &majorOk );
-    minor = match.captured( "minor" ).toInt( &minorOk );
+  if ( versionParts.size() != 3 )
+    return false;
 
-    if ( !majorOk || !minorOk )
-      return false;
+  bool majorOk, minorOk;
+  major = versionParts[0].toInt( &majorOk );
+  minor = versionParts[1].toInt( &minorOk );
 
-    return true;
-  }
+  if ( !majorOk || !minorOk )
+    return false;
 
-  return false;
+  return true;
 }
 
 bool MerginApi::hasLocalProjectChanges( const QString &projectDir )


### PR DESCRIPTION
MerginApi::parseVersion would cause app to crash, as indicated by crash report. Fix includes additional checks to ensure valid inputs and conversions, aiming to preventing crashes.

Resolves #3541 