### PR TITLE
Avoid running autotests in multiple workflows at once

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -32,7 +32,7 @@ jobs:
     if: ( github.repository == 'MerginMaps/mobile' ) && (!contains(github.event.head_commit.message, 'Translate '))
     runs-on: ubuntu-22.04
     concurrency: 
-      group: mobileapp-autotests # Avoid running autotests at the same time across multiple workflows, because the same user is used
+      group: mobileapp-autotests-linux # Avoid running autotests at the same time across multiple linux workflows, because the same user is used
     steps:
       - name: Checkout Input
         uses: actions/checkout@v3

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -22,6 +22,7 @@ env:
   CMAKE_VERSION: '3.29.0'
   CACHE_VERSION: 0
       
+# Execute only the latest CI run on a branch
 concurrency:
   group: ci-${{github.ref}}-linux
   cancel-in-progress: true
@@ -30,6 +31,8 @@ jobs:
   linux_build:
     if: ( github.repository == 'MerginMaps/mobile' ) && (!contains(github.event.head_commit.message, 'Translate '))
     runs-on: ubuntu-22.04
+    concurrency: 
+      group: mobileapp-autotests # Avoid running autotests at the same time across multiple workflows, because the same user is used
     steps:
       - name: Checkout Input
         uses: actions/checkout@v3

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -32,7 +32,7 @@ jobs:
     if: ( github.repository == 'MerginMaps/mobile' ) && (!contains(github.event.head_commit.message, 'Translate '))
     runs-on: ubuntu-22.04
     concurrency: 
-      group: mobileapp-autotests-linux # Avoid running autotests at the same time across multiple linux workflows, because the same user is used
+      group: mobileapp-autotests-linux # Avoid running autotests at the same time across multiple linux workflows
     steps:
       - name: Checkout Input
         uses: actions/checkout@v3

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -33,7 +33,7 @@ jobs:
     if: ( github.repository == 'MerginMaps/mobile' ) && (!contains(github.event.head_commit.message, 'Translate '))
     runs-on: macos-13
     concurrency: 
-      group: mobileapp-autotests-macos # Avoid running autotests at the same time across multiple macos workflows, because the same user is used
+      group: mobileapp-autotests-macos # Avoid running autotests at the same time across multiple macos workflows
     steps:
       - name: Checkout Input
         uses: actions/checkout@v3

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -33,7 +33,7 @@ jobs:
     if: ( github.repository == 'MerginMaps/mobile' ) && (!contains(github.event.head_commit.message, 'Translate '))
     runs-on: macos-13
     concurrency: 
-      group: mobileapp-autotests # Avoid running autotests at the same time across multiple workflows, because the same user is used
+      group: mobileapp-autotests-macos # Avoid running autotests at the same time across multiple macos workflows, because the same user is used
     steps:
       - name: Checkout Input
         uses: actions/checkout@v3

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -23,6 +23,7 @@ env:
   CMAKE_VERSION: '3.29.0'
   XC_VERSION: ${{ '15.2' }}
 
+# Execute only the latest CI run on a branch
 concurrency:
   group: ci-${{github.ref}}-macos
   cancel-in-progress: true
@@ -31,6 +32,8 @@ jobs:
   macos_build:
     if: ( github.repository == 'MerginMaps/mobile' ) && (!contains(github.event.head_commit.message, 'Translate '))
     runs-on: macos-13
+    concurrency: 
+      group: mobileapp-autotests # Avoid running autotests at the same time across multiple workflows, because the same user is used
     steps:
       - name: Checkout Input
         uses: actions/checkout@v3


### PR DESCRIPTION
This PR adds concurrency for autotests so that two Linux or macOS tests do not run simultaneously. GitHub will keep at most one job running and one in a queue (pending). If someone else requests a third run, their run will be cancelled.

It helps to avoid overwriting data between two simultaneous runs. 
> Note: One macOS and one Linux workflow can run at the same time, because they use different users