### PR TITLE
Fix TabBar issues with multiple tabs

### DIFF
--- a/app/mmstyle.h
+++ b/app/mmstyle.h
@@ -289,6 +289,7 @@ class MMStyle: public QObject
     Q_PROPERTY( double row24 READ number24 CONSTANT )
     Q_PROPERTY( double row36 READ number36 CONSTANT )
     Q_PROPERTY( double row40 READ number40 CONSTANT )
+    Q_PROPERTY( double row45 READ number45 CONSTANT )
     Q_PROPERTY( double row49 READ number49 CONSTANT )
     Q_PROPERTY( double row50 READ number50 CONSTANT )
     Q_PROPERTY( double row54 READ number54 CONSTANT )

--- a/app/qml/form/MMFormPage.qml
+++ b/app/qml/form/MMFormPage.qml
@@ -108,12 +108,15 @@ Page {
     MMFormComponents.MMFormTabBar {
       id: tabBar
 
+      Layout.topMargin: __style.margin10
+      Layout.bottomMargin: __style.margin10
       Layout.alignment: Qt.AlignHCenter
+      Layout.fillWidth: true
       Layout.maximumWidth: Math.min(__style.maxPageWidth, root.width)
 
-      visible: root.controller.hasTabs
+      model: root.controller.attributeTabProxyModel
 
-      tabButtonsModel: root.controller.attributeTabProxyModel
+      visible: root.controller.hasTabs
 
       onCurrentIndexChanged: formSwipe.setCurrentIndex( tabBar.currentIndex )
     }
@@ -128,7 +131,7 @@ Page {
 
       clip: true
 
-      onCurrentIndexChanged: tabBar.setCurrentIndex( formSwipe.currentIndex )
+      onCurrentIndexChanged: tabBar.currentIndex = formSwipe.currentIndex
 
       Repeater {
         id: swipeViewRepeater
@@ -161,7 +164,7 @@ Page {
             section {
               property: "Group"
               delegate: sectionDelegate
-              labelPositioning: ViewSection.CurrentLabelAtStart | ViewSection.InlineLabels
+              labelPositioning: ViewSection.InlineLabels
             }
 
             delegate: editorDelegate
@@ -220,22 +223,14 @@ Page {
   Component {
     id: sectionDelegate
 
-    Item {
-
-      property string sectionTitle: section
+    Rectangle {
 
       height: section ? childrenRect.height : 0
       width: ListView.view.width
 
-      // section bgnd
-      Rectangle {
-        anchors.fill: parent;
-        color: __style.lightGreenColor;
-      }
+      color: __style.lightGreenColor
 
       MMComponents.MMText {
-        id: sectionTitle
-
         text: section
         font: __style.h3
         color: __style.forestColor
@@ -274,7 +269,7 @@ Page {
         width: parent.width
 
         property var fieldValue: model.RawValue
-        property bool fieldValueIsNull: model.RawValueIsNull
+        property bool fieldValueIsNull: model.RawValueIsNull ?? true
 
         property var field: model.Field
         property var fieldIndex: model.FieldIndex

--- a/app/qml/form/components/MMFormTabBar.qml
+++ b/app/qml/form/components/MMFormTabBar.qml
@@ -9,65 +9,52 @@
 
 import QtQuick
 import QtQuick.Controls
+import "../../components" as MMComponents
 
-TabBar {
+MMComponents.MMListView {
   id: root
 
-  property alias tabButtonsModel: tabBarRepeater.model
+  implicitHeight: __style.row45
 
-  implicitHeight: 56 * __dp
-
-  spacing: 20 * __dp
-
-  leftPadding: internal.tabBarPadding
-  rightPadding: internal.tabBarPadding
+  spacing: 0
 
   clip: true
+  orientation: ListView.Horizontal
 
-  background: Rectangle {
-    color: __style.lightGreenColor
-  }
+  interactive: contentWidth > width
 
-  Repeater {
-    id: tabBarRepeater
+  header: MMComponents.MMListSpacer { width: __style.margin20 }
+  footer: MMComponents.MMListSpacer { width: __style.margin20 }
 
-    TabButton {
-      id: tabDelegate
+  delegate: Control {
+    id: tabDelegate
 
-      property bool isSelected: TabBar.index === root.currentIndex
+    property bool isSelected: ListView.isCurrentItem
 
-      height: 45 * __dp
-      width: contentItem.implicitWidth
+    height: __style.row45
+    width: contentItem.implicitWidth
 
-      anchors.verticalCenter: parent.verticalCenter
+    focusPolicy: Qt.NoFocus
 
-      focusPolicy: Qt.NoFocus
+    background: Rectangle {
+      visible: tabDelegate.isSelected
+      color: __style.grassColor
+      radius: __style.radius30
+    }
 
-      contentItem: Text {
-        text: model.Name
+    contentItem: MMComponents.MMText {
+      text: model.Name
 
-        leftPadding: __style.margin20
-        rightPadding: __style.margin20
+      font: __style.t4
 
-        font: __style.t4
-        color: __style.forestColor
+      leftPadding: __style.margin20
+      rightPadding: __style.margin20
+    }
 
-        verticalAlignment: Text.AlignVCenter
-        horizontalAlignment: Text.AlignHCenter
-      }
-
-      background: Rectangle {
-        radius: 30 * __dp
-        color: __style.grassColor
-
-        visible: tabDelegate.isSelected
-      }
+    MouseArea {
+      anchors.fill: parent
+      onClicked: root.currentIndex = index
     }
   }
-
-  QtObject {
-    id: internal
-
-    property real tabBarPadding: 20 * __dp
-  }
 }
+

--- a/gallery/qml/pages/FormPage.qml
+++ b/gallery/qml/pages/FormPage.qml
@@ -48,9 +48,10 @@ Page {
       id: tabBar
 
       Layout.alignment: Qt.AlignHCenter
+      Layout.fillWidth: true
       Layout.maximumWidth: Math.min(__style.maxPageWidth, root.width)
 
-      tabButtonsModel: ListModel {
+      model: ListModel {
         id: tabModel
 
         ListElement { Name: "Address of the object" }
@@ -73,7 +74,7 @@ Page {
 
       clip: true
 
-      onCurrentIndexChanged: tabBar.setCurrentIndex(formSwipe.currentIndex)
+      onCurrentIndexChanged: tabBar.currentIndex = formSwipe.currentIndex
 
       Repeater {
         model: tabModel


### PR DESCRIPTION
We kept having issues with TabBar when project had multiple tabs, for example:
![Screenshot 2024-07-25 at 13 37 46](https://github.com/user-attachments/assets/2c69ba65-b3bf-4750-a52a-b88a2536ac62)

Solution: use `ListView` instead of `TabBar` 🙃 

ListView is set to mimic the behaviour of TabBar (horizontal orientation), the same project now looks like this:
![Screenshot 2024-07-25 at 14 59 08](https://github.com/user-attachments/assets/d5f20716-75de-41b3-8172-29e58e2d8868)

There is a behavioural change for sections - I limited it to use only `ViewSection.InlineLabels`, because `CurrentLabelAtStart` was also producing some issues (see https://doc.qt.io/qt-6/qml-qtquick-listview.html#section-prop)