### PR TITLE
Fix wrong evaluation of unique constraint when creating child feature

### DIFF
--- a/app/attributes/attributecontroller.cpp
+++ b/app/attributes/attributecontroller.cpp
@@ -632,6 +632,15 @@ void AttributeController::acquireId()
     emit commitFailed();
   }
 
+  //
+  // We need to trigger the recalucation of the form because QgsVectorLayer::featureAdded
+  // is called before commit is finished. This can cause issues with evaluation of validations
+  // when old feature with FID_IS_NEW is not yet removed from the layer and the new feature
+  // with valid fid is already added (unique constraints are failing as it detects two features
+  // with the same values). We thus manually trigger the recalculation here.
+  //
+  recalculateDerivedItems();
+
   disconnect( mFeatureLayerPair.layer(), &QgsVectorLayer::featureAdded, this, &AttributeController::onFeatureAdded );
 }
 


### PR DESCRIPTION
There was an issue (probably for ages) that behaved like this:
 - have a layer (layer A) with a field that has unique constraint set
 - add relations between this layer and some other layer (layer B)
 - open a form of layer A to add a new feature, fill in details to the field with unique constraint (so that the validation passes - the value is unique)
 - click to add a new child feature 
   - validation is triggered when acquiring fid for the parent feature
   - unique constraint validation fails -> this is because we run the validation while `QgsVectorLayer::commit` is in progress (when `QgsVectorLayer::featureAdded` is called), but the old feature (with `FID_IS_NEW`) is not yet removed from the layer. Thus, QGIS detects that there are two features with the same value and returns a unique constraint violation.

Fixes issue from this video: https://drive.google.com/file/d/19V4TVvz3e1ocABdYkAMIvv42J25Ks_Vv/view?usp=sharing