### PR TITLE
Fix : Unsaved changes dialog not displayed when using back button

### DIFF
--- a/app/qml/form/MMFormPage.qml
+++ b/app/qml/form/MMFormPage.qml
@@ -80,7 +80,15 @@ Page {
 
   header: MMComponents.MMPageHeader {
 
-    onBackClicked: root.rollbackAndClose()
+    onBackClicked: {
+      if ( root.controller.hasAnyChanges )  {
+        saveChangesDialog.open()
+      }
+      else {
+        root.rollbackAndClose()
+      }
+    }
+
 
     title: {
       if ( root.state === "add" ) return qsTr( "New feature" )


### PR DESCRIPTION
When editing The Unsaved changes" dialog was not showing up if the cancelled using the header back arrow  instead of the system back button. Therefore user could lost their changes 

This PR solve the issue and display the dialog when editing or adding a new feature


solve #3525 