### PR TITLE
Fix #2320 Split geometry visual problems

### DIFF
--- a/app/guidelinecontroller.h
+++ b/app/guidelinecontroller.h
@@ -100,7 +100,7 @@ class GuidelineController : public QObject
     QgsGeometry mRealGeometry;
     InputMapSettings *mMapSettings = nullptr; // not owned
     Vertex mActiveVertex;
-    bool mAllowed;
+    bool mAllowed = true;
     RecordingMapTool::InsertPolicy mInsertPolicy;
     int mActivePart = 0;
     int mActiveRing = 0;

--- a/app/qml/map/MMSplittingTools.qml
+++ b/app/qml/map/MMSplittingTools.qml
@@ -39,6 +39,8 @@ Item {
   MM.GuidelineController {
     id: guidelineController
 
+    allowed: true
+
     mapSettings: root.map.mapSettings
     crosshairPosition: crosshair.screenPoint
     realGeometry: __inputUtils.transformGeometryToMapWithLayer( mapTool.recordedGeometry, __activeLayer.vectorLayer, root.map.mapSettings )
@@ -50,7 +52,10 @@ Item {
     height: root.map.height
     width: root.map.width
 
+    markerColor: __style.deepOceanColor
     lineColor: __style.deepOceanColor
+    lineStrokeStyle: ShapePath.DashLine
+    lineWidth: MMHighlight.LineWidths.Narrow
 
     mapSettings: root.map.mapSettings
     geometry: guidelineController.guidelineGeometry
@@ -62,9 +67,7 @@ Item {
     height: map.height
     width: map.width
 
-    markerColor: __style.deepOceanColor
     lineColor: __style.deepOceanColor
-    lineStrokeStyle: ShapePath.DashLine
 
     mapSettings: root.map.mapSettings
     geometry: __inputUtils.transformGeometryToMapWithLayer( mapTool.recordedGeometry, __activeLayer.vectorLayer, root.map.mapSettings )

--- a/app/qml/map/MMSplittingTools.qml
+++ b/app/qml/map/MMSplittingTools.qml
@@ -39,8 +39,6 @@ Item {
   MM.GuidelineController {
     id: guidelineController
 
-    allowed: true
-
     mapSettings: root.map.mapSettings
     crosshairPosition: crosshair.screenPoint
     realGeometry: __inputUtils.transformGeometryToMapWithLayer( mapTool.recordedGeometry, __activeLayer.vectorLayer, root.map.mapSettings )
@@ -68,6 +66,7 @@ Item {
     width: map.width
 
     lineColor: __style.deepOceanColor
+    lineWidth: MMHighlight.LineWidths.Narrow
 
     mapSettings: root.map.mapSettings
     geometry: __inputUtils.transformGeometryToMapWithLayer( mapTool.recordedGeometry, __activeLayer.vectorLayer, root.map.mapSettings )

--- a/app/qml/map/MMSplittingTools.qml
+++ b/app/qml/map/MMSplittingTools.qml
@@ -65,6 +65,7 @@ Item {
     height: map.height
     width: map.width
 
+    markerColor: __style.deepOceanColor
     lineColor: __style.deepOceanColor
     lineWidth: MMHighlight.LineWidths.Narrow
 


### PR DESCRIPTION
This PR fix #2320 where the guideline from last point to cursor wasn't showing in the splitting tool

The root issue was that the `GuidelineController::buildGuideline` was cancelled at the beginning of the function, because of the `allowed` property. So I turned allowed to be always true for the splitting tool

I wanted to show clearly to the users that the actual splitting line were the one to the last point and not  to the cursor.
So I updated the visual to match the way it works when adding a new line geometry
Let me know if it's working for the user experience otherwise I will revert that part

<img src="https://github.com/user-attachments/assets/e206044f-d569-44c2-86a2-b1835ab78a66" height="650">




