### PR TITLE
Fixing text wrapping in MMToolbar

### DIFF
--- a/app/qml/components/private/MMToolbarShortButton.qml
+++ b/app/qml/components/private/MMToolbarShortButton.qml
@@ -72,14 +72,17 @@ Item {
     Text {
       id: text
 
+      width: parent.width
       text: root.text
       color: root.useDisabledVisual ? root.iconColorDisabled : root.iconColor
-      font: __style.t4
+      font: lineCount === 1 ? __style.t4 : __style.t5
       anchors.horizontalCenter: parent.horizontalCenter
       anchors.top: icon.bottom
       anchors.topMargin: root.buttonSpacing
       horizontalAlignment: Text.AlignHCenter
-      elide: Text.ElideMiddle
+      elide: Text.ElideRight
+      wrapMode: Text.Wrap
+      maximumLineCount: 2
     }
 
     MouseArea {


### PR DESCRIPTION
Text font for `MMToolbarShortButton` can change from t4 to t5 when the button text is too long and needs a better fit, resolvin text wrapping issue and also setting a maximum number of lines to 2, eliding it right after that.

| Portrait Before | Portrait After  |
|--------|--------|
|<img src="https://github.com/user-attachments/assets/b8c4905b-82d1-4403-b0e1-2ccc83f5e13c" width="150">| <img src="https://github.com/user-attachments/assets/5a15ef2c-7400-49ae-acfe-5f8b873904e7" width="150"> |

| Landscape Before| Landscape After |
|--------|--------|
|<img src="https://github.com/user-attachments/assets/ab733b93-ba52-4f7a-89cf-cdbf2652f90c" width="300">| <img src="https://github.com/user-attachments/assets/28efbc1d-9c3d-4f66-9b52-b40df811aa2a" width="300"> |

Fixes #3547 
