### PR TITLE
Fix not able to close drawer using system back button

### DIFF
--- a/app/qml/components/MMDrawer.qml
+++ b/app/qml/components/MMDrawer.qml
@@ -48,13 +48,6 @@ Drawer {
       height: parent.height / 2
       y: parent.height / 2
     }
-
-    Keys.onReleased: function( event ) {
-      if ( event.key === Qt.Key_Back || event.key === Qt.Key_Escape ) {
-        root.close()
-        event.accepted = true
-      }
-    }
   }
 
   contentItem: Column {
@@ -62,6 +55,14 @@ Drawer {
 
     anchors.fill: parent
     spacing: 0
+    focus : true
+
+    Keys.onReleased: function( event ) {
+      if ( event.key === Qt.Key_Back || event.key === Qt.Key_Escape ) {
+        root.close()
+        event.accepted = true
+      }
+    }
 
     MMListSpacer {
       id: topSpacer


### PR DESCRIPTION
This PR try to fix an error where in some case you couldn't close a drawer using the system back button

This happened because the control focus was not transferred correctly 

This bug was found during release testing and relate to #3525