### PR TITLE
Update build instructions on GNU/Ubuntu

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -143,7 +143,7 @@ Steps to build and run Input:
    cmake -G Ninja \
      -DCMAKE_PREFIX_PATH=~/Qt/6.6.3/gcc_64 \
      -DINPUT_SDK_PATH=~/input-sdk/x64-linux \
-     -DQGIS_QUICK_DATA_PATH=~/input/app/android/assets/qgis-data \
+     -DQGIS_QUICK_DATA_PATH=../app/android/assets/qgis-data \
      -DUSE_MM_SERVER_API_KEY=FALSE \
      ..
    ninja
@@ -152,7 +152,7 @@ Steps to build and run Input:
 5. Run Input
 
    ```
-   ./app/input
+   ./app/Input
    ```
 
 


### PR DESCRIPTION
Update build instructions on GNU/Ubuntu

* The path of `DQGIS_QUICK_DATA_PATH` was still using the former name of the MerginMaps mobile app
* And the output name was not capitalized correctly

Remarque: It's already the case but the build instructions assume you build from a `build` folder located in the root for exemple `mobile/build/`