### PR TITLE
Optimize WFS layers handling on iOS

### DIFF
--- a/app/main.cpp
+++ b/app/main.cpp
@@ -460,6 +460,7 @@ int main( int argc, char *argv[] )
   qputenv( "QT_ANDROID_DISABLE_ACCESSIBILITY", "1" );
 #endif
 #ifdef Q_OS_IOS
+  // See issue #3561 -> WFS layers causing stress on iOS
   qputenv( "QGIS_USE_SHARED_MEMORY_KEEP_ALIVE", "1" );
   qDebug() <<  "Setting QGIS_USE_SHARED_MEMORY_KEEP_ALIVE environment variable TRUE";
 #endif

--- a/app/main.cpp
+++ b/app/main.cpp
@@ -459,6 +459,10 @@ int main( int argc, char *argv[] )
   // See issue #3431 -> disable Android accessibility features to prevent ANRs
   qputenv( "QT_ANDROID_DISABLE_ACCESSIBILITY", "1" );
 #endif
+#ifdef Q_OS_IOS
+  qputenv( "QGIS_USE_SHARED_MEMORY_KEEP_ALIVE", "1" );
+  qDebug() <<  "Setting QGIS_USE_SHARED_MEMORY_KEEP_ALIVE environment variable TRUE";
+#endif
 
   // AppSettings has to be initialized after QGIS app init (because of correct reading/writing QSettings).
   AppSettings as;


### PR DESCRIPTION
Setting `QGIS_USE_SHARED_MEMORY_KEEP_ALIVE` environment variable can significantly enhance performance and stability when working with large WFS layers by preventing frequent allocation and deallocation of shared memory, making projects smoother.

Before:

https://github.com/user-attachments/assets/6cdcdd80-1ea5-4aea-8503-d5ffefb06fde


After:


https://github.com/user-attachments/assets/fb84423c-faef-428c-8be0-b75ffb1b9322


Resolves #3558