### PR TITLE
Adding Loaders to Highlights in Recording Tools

### DIFF
--- a/app/qml/map/MMRecordingTools.qml
+++ b/app/qml/map/MMRecordingTools.qml
@@ -111,96 +111,29 @@ Item {
   }
 
   Loader {
-    active: __inputUtils.geometryFromLayer( __activeLayer.vectorLayer ) === "linestring" ||
-            __inputUtils.geometryFromLayer( __activeLayer.vectorLayer ) === "polygon"
+    active: __inputUtils.isLineLayer( __activeLayer.vectorLayer ) ||
+            __inputUtils.isPolygonLayer( __activeLayer.vectorLayer )
 
     sourceComponent: handlesHighlightComponent
   }
 
   Loader {
-    active: __inputUtils.geometryFromLayer( __activeLayer.vectorLayer ) === "linestring" ||
-            __inputUtils.geometryFromLayer( __activeLayer.vectorLayer ) === "polygon"
+    active: __inputUtils.isLineLayer( __activeLayer.vectorLayer ) ||
+            __inputUtils.isPolygonLayer( __activeLayer.vectorLayer )
 
     sourceComponent: guidelineHighlightComponent
   }
 
   Loader {
-    active: __inputUtils.geometryFromLayer( __activeLayer.vectorLayer ) === "linestring" ||
-            __inputUtils.geometryFromLayer( __activeLayer.vectorLayer ) === "polygon"
+    active: __inputUtils.isLineLayer( __activeLayer.vectorLayer ) ||
+            __inputUtils.isPolygonLayer( __activeLayer.vectorLayer )
 
     sourceComponent: midSegmentsHighlightComponent
   }
 
   Loader {
-    active: __inputUtils.geometryFromLayer( __activeLayer.vectorLayer ) !== "point"
+    active: true
     sourceComponent: existingVerticesHighlightComponent
-  }
-
-  Component {
-    id:  handlesHighlightComponent
-
-    MMHighlight {
-      id: handlesHighlight
-
-      height: root.map.height
-      width: root.map.width
-
-      mapSettings: root.map.mapSettings
-      geometry: __inputUtils.transformGeometryToMapWithLayer( mapTool.handles, __activeLayer.vectorLayer, root.map.mapSettings )
-      lineStrokeStyle: ShapePath.DashLine
-      lineWidth: MMHighlight.LineWidths.Narrow
-    }
-  }
-
-  Component {
-    id: guidelineHighlightComponent
-
-    MMHighlight {
-      id: guideline
-
-      height: root.map.height
-      width: root.map.width
-
-      lineWidth: MMHighlight.LineWidths.Narrow
-      lineStrokeStyle: ShapePath.DashLine
-
-      mapSettings: root.map.mapSettings
-      geometry: guidelineController.guidelineGeometry
-    }
-  }
-
-  Component {
-    id: midSegmentsHighlightComponent
-
-    MMHighlight {
-      id: midSegmentsHighlight
-
-      height: root.map.height
-      width: root.map.width
-
-      mapSettings: root.map.mapSettings
-      geometry: __inputUtils.transformGeometryToMapWithLayer( mapTool.midPoints, __activeLayer.vectorLayer, root.map.mapSettings )
-
-      markerType: MMHighlight.MarkerTypes.Circle
-      markerBorderColor: __style.grapeColor
-    }
-  }
-
-  Component {
-    id: existingVerticesHighlightComponent
-
-    MMHighlight {
-      id: existingVerticesHighlight
-
-      height: root.map.height
-      width: root.map.width
-
-      mapSettings: root.map.mapSettings
-      geometry: __inputUtils.transformGeometryToMapWithLayer( mapTool.existingVertices, __activeLayer.vectorLayer, root.map.mapSettings )
-
-      markerType: MMHighlight.MarkerTypes.Circle
-      markerSize: MMHighlight.MarkerSizes.Bigger
-    }
   }
 
   // Duplicate position marker to be painted on the top of highlights
@@ -343,6 +276,73 @@ Item {
         return pointToolbarButtons
       }
       return polygonToolbarButtons
+    }
+  }
+
+  Component {
+    id:  handlesHighlightComponent
+
+    MMHighlight {
+      id: handlesHighlight
+
+      height: root.map.height
+      width: root.map.width
+
+      mapSettings: root.map.mapSettings
+      geometry: __inputUtils.transformGeometryToMapWithLayer( mapTool.handles, __activeLayer.vectorLayer, root.map.mapSettings )
+      lineStrokeStyle: ShapePath.DashLine
+      lineWidth: MMHighlight.LineWidths.Narrow
+    }
+  }
+
+  Component {
+    id: guidelineHighlightComponent
+
+    MMHighlight {
+      id: guideline
+
+      height: root.map.height
+      width: root.map.width
+
+      lineWidth: MMHighlight.LineWidths.Narrow
+      lineStrokeStyle: ShapePath.DashLine
+
+      mapSettings: root.map.mapSettings
+      geometry: guidelineController.guidelineGeometry
+    }
+  }
+
+  Component {
+    id: midSegmentsHighlightComponent
+
+    MMHighlight {
+      id: midSegmentsHighlight
+
+      height: root.map.height
+      width: root.map.width
+
+      mapSettings: root.map.mapSettings
+      geometry: __inputUtils.transformGeometryToMapWithLayer( mapTool.midPoints, __activeLayer.vectorLayer, root.map.mapSettings )
+
+      markerType: MMHighlight.MarkerTypes.Circle
+      markerBorderColor: __style.grapeColor
+    }
+  }
+
+  Component {
+    id: existingVerticesHighlightComponent
+
+    MMHighlight {
+      id: existingVerticesHighlight
+
+      height: root.map.height
+      width: root.map.width
+
+      mapSettings: root.map.mapSettings
+      geometry: __inputUtils.transformGeometryToMapWithLayer( mapTool.existingVertices, __activeLayer.vectorLayer, root.map.mapSettings )
+
+      markerType: MMHighlight.MarkerTypes.Circle
+      markerSize: MMHighlight.MarkerSizes.Bigger
     }
   }
 

--- a/app/qml/map/MMRecordingTools.qml
+++ b/app/qml/map/MMRecordingTools.qml
@@ -131,11 +131,6 @@ Item {
     sourceComponent: midSegmentsHighlightComponent
   }
 
-  Loader {
-    active: true
-    sourceComponent: existingVerticesHighlightComponent
-  }
-
   // Duplicate position marker to be painted on the top of highlights
   MMPositionMarker {
     xPos: positionMarkerComponent.xPos
@@ -159,6 +154,19 @@ Item {
     qgsProject: __activeProject.qgsProject
     mapSettings: root.map.mapSettings
     shouldUseSnapping: !mapTool.isUsingPosition
+  }
+
+  MMHighlight {
+    id: existingVerticesHighlight
+
+    height: root.map.height
+    width: root.map.width
+
+    mapSettings: root.map.mapSettings
+    geometry: __inputUtils.transformGeometryToMapWithLayer( mapTool.existingVertices, __activeLayer.vectorLayer, root.map.mapSettings )
+
+    markerType: MMHighlight.MarkerTypes.Circle
+    markerSize: MMHighlight.MarkerSizes.Bigger
   }
 
   MMToolbar {
@@ -326,23 +334,6 @@ Item {
 
       markerType: MMHighlight.MarkerTypes.Circle
       markerBorderColor: __style.grapeColor
-    }
-  }
-
-  Component {
-    id: existingVerticesHighlightComponent
-
-    MMHighlight {
-      id: existingVerticesHighlight
-
-      height: root.map.height
-      width: root.map.width
-
-      mapSettings: root.map.mapSettings
-      geometry: __inputUtils.transformGeometryToMapWithLayer( mapTool.existingVertices, __activeLayer.vectorLayer, root.map.mapSettings )
-
-      markerType: MMHighlight.MarkerTypes.Circle
-      markerSize: MMHighlight.MarkerSizes.Bigger
     }
   }
 

--- a/app/qml/map/MMRecordingTools.qml
+++ b/app/qml/map/MMRecordingTools.qml
@@ -132,7 +132,7 @@ Item {
   }
 
   Loader {
-    active: __inputUtils.geometryFromLayer( __activeLayer.vectorLayer ) === "point"
+    active: __inputUtils.geometryFromLayer( __activeLayer.vectorLayer ) !== "point"
     sourceComponent: existingVerticesHighlightComponent
   }
 

--- a/app/qml/map/MMRecordingTools.qml
+++ b/app/qml/map/MMRecordingTools.qml
@@ -110,56 +110,91 @@ Item {
     lineBorderWidth: 0
   }
 
-  MMHighlight {
-    id: handlesHighlight
-
-    height: root.map.height
-    width: root.map.width
-
-    mapSettings: root.map.mapSettings
-    geometry: __inputUtils.transformGeometryToMapWithLayer( mapTool.handles, __activeLayer.vectorLayer, root.map.mapSettings )
-
-    lineStrokeStyle: ShapePath.DashLine
-    lineWidth: MMHighlight.LineWidths.Narrow
+  Loader {
+    active: __inputUtils.geometryFromLayer( __activeLayer.vectorLayer ) === "linestring" || __inputUtils.geometryFromLayer( __activeLayer.vectorLayer ) === "polygon"
+    sourceComponent: handlesHighlightComponent
   }
 
-  MMHighlight {
-    id: guideline
-
-    height: root.map.height
-    width: root.map.width
-
-    lineWidth: MMHighlight.LineWidths.Narrow
-    lineStrokeStyle: ShapePath.DashLine
-
-    mapSettings: root.map.mapSettings
-    geometry: guidelineController.guidelineGeometry
+  Loader {
+    active: __inputUtils.geometryFromLayer( __activeLayer.vectorLayer ) === "linestring" || __inputUtils.geometryFromLayer( __activeLayer.vectorLayer ) === "polygon"
+    sourceComponent: guidelineHighlightComponent
   }
 
-  MMHighlight {
-    id: midSegmentsHighlight
-
-    height: root.map.height
-    width: root.map.width
-
-    mapSettings: root.map.mapSettings
-    geometry: __inputUtils.transformGeometryToMapWithLayer( mapTool.midPoints, __activeLayer.vectorLayer, root.map.mapSettings )
-
-    markerType: MMHighlight.MarkerTypes.Circle
-    markerBorderColor: __style.grapeColor
+  Loader {
+    active: __inputUtils.geometryFromLayer( __activeLayer.vectorLayer ) === "linestring" || __inputUtils.geometryFromLayer( __activeLayer.vectorLayer ) === "polygon"
+    sourceComponent: midSegmentsHighlightComponent
   }
 
-  MMHighlight {
-    id: existingVerticesHighlight
+  Loader {
+    active: __inputUtils.geometryFromLayer( __activeLayer.vectorLayer ) === "point"
+    sourceComponent: existingVerticesHighlightComponent
+  }
 
-    height: root.map.height
-    width: root.map.width
+  Component {
+    id:  handlesHighlightComponent
 
-    mapSettings: root.map.mapSettings
-    geometry: __inputUtils.transformGeometryToMapWithLayer( mapTool.existingVertices, __activeLayer.vectorLayer, root.map.mapSettings )
+    MMHighlight {
+      id: handlesHighlight
 
-    markerType: MMHighlight.MarkerTypes.Circle
-    markerSize: MMHighlight.MarkerSizes.Bigger
+      height: root.map.height
+      width: root.map.width
+
+      mapSettings: root.map.mapSettings
+      geometry: __inputUtils.transformGeometryToMapWithLayer( mapTool.handles, __activeLayer.vectorLayer, root.map.mapSettings )
+      lineStrokeStyle: ShapePath.DashLine
+      lineWidth: MMHighlight.LineWidths.Narrow
+    }
+  }
+
+  Component {
+    id: guidelineHighlightComponent
+
+    MMHighlight {
+      id: guideline
+
+      height: root.map.height
+      width: root.map.width
+
+      lineWidth: MMHighlight.LineWidths.Narrow
+      lineStrokeStyle: ShapePath.DashLine
+
+      mapSettings: root.map.mapSettings
+      geometry: guidelineController.guidelineGeometry
+    }
+  }
+
+  Component {
+    id: midSegmentsHighlightComponent
+
+    MMHighlight {
+      id: midSegmentsHighlight
+
+      height: root.map.height
+      width: root.map.width
+
+      mapSettings: root.map.mapSettings
+      geometry: __inputUtils.transformGeometryToMapWithLayer( mapTool.midPoints, __activeLayer.vectorLayer, root.map.mapSettings )
+
+      markerType: MMHighlight.MarkerTypes.Circle
+      markerBorderColor: __style.grapeColor
+    }
+  }
+
+  Component {
+    id: existingVerticesHighlightComponent
+
+    MMHighlight {
+      id: existingVerticesHighlight
+
+      height: root.map.height
+      width: root.map.width
+
+      mapSettings: root.map.mapSettings
+      geometry: __inputUtils.transformGeometryToMapWithLayer( mapTool.existingVertices, __activeLayer.vectorLayer, root.map.mapSettings )
+
+      markerType: MMHighlight.MarkerTypes.Circle
+      markerSize: MMHighlight.MarkerSizes.Bigger
+    }
   }
 
   // Duplicate position marker to be painted on the top of highlights

--- a/app/qml/map/MMRecordingTools.qml
+++ b/app/qml/map/MMRecordingTools.qml
@@ -111,17 +111,23 @@ Item {
   }
 
   Loader {
-    active: __inputUtils.geometryFromLayer( __activeLayer.vectorLayer ) === "linestring" || __inputUtils.geometryFromLayer( __activeLayer.vectorLayer ) === "polygon"
+    active: __inputUtils.geometryFromLayer( __activeLayer.vectorLayer ) === "linestring" ||
+            __inputUtils.geometryFromLayer( __activeLayer.vectorLayer ) === "polygon"
+
     sourceComponent: handlesHighlightComponent
   }
 
   Loader {
-    active: __inputUtils.geometryFromLayer( __activeLayer.vectorLayer ) === "linestring" || __inputUtils.geometryFromLayer( __activeLayer.vectorLayer ) === "polygon"
+    active: __inputUtils.geometryFromLayer( __activeLayer.vectorLayer ) === "linestring" ||
+            __inputUtils.geometryFromLayer( __activeLayer.vectorLayer ) === "polygon"
+
     sourceComponent: guidelineHighlightComponent
   }
 
   Loader {
-    active: __inputUtils.geometryFromLayer( __activeLayer.vectorLayer ) === "linestring" || __inputUtils.geometryFromLayer( __activeLayer.vectorLayer ) === "polygon"
+    active: __inputUtils.geometryFromLayer( __activeLayer.vectorLayer ) === "linestring" ||
+            __inputUtils.geometryFromLayer( __activeLayer.vectorLayer ) === "polygon"
+
     sourceComponent: midSegmentsHighlightComponent
   }
 


### PR DESCRIPTION
In `MMRecordingTools`, `MMHighlights` are loaded only when they match the layer's geometry, improving performance by eliminating the need to load unnecessary components.

https://github.com/user-attachments/assets/f8cbac6d-de6b-4bfe-a71a-933513a3146b

Partially Resolves #[2980](https://github.com/MerginMaps/mobile/issues/2980)