### PR TITLE
Adjusting MMProjectLoadingPage text to respect safe area

### DIFF
--- a/app/qml/project/MMProjectLoadingPage.qml
+++ b/app/qml/project/MMProjectLoadingPage.qml
@@ -32,7 +32,7 @@ Item {
   Text {
     text: qsTr("Opening project ...")
     anchors.bottom: root.bottom
-    anchors.bottomMargin: __style.safeAreaBottom + __style.safeAreaLeft + __style.safeAreaRight
+    anchors.bottomMargin: __style.safeAreaBottom + 32 * __dp
     anchors.horizontalCenter: parent.horizontalCenter
     font: __style.t1
     color: __style.forestColor

--- a/app/qml/project/MMProjectLoadingPage.qml
+++ b/app/qml/project/MMProjectLoadingPage.qml
@@ -32,7 +32,7 @@ Item {
   Text {
     text: qsTr("Opening project ...")
     anchors.bottom: root.bottom
-    anchors.bottomMargin: 32 * __dp
+    anchors.bottomMargin: __style.safeAreaBottom + __style.safeAreaLeft + __style.safeAreaRight
     anchors.horizontalCenter: parent.horizontalCenter
     font: __style.t1
     color: __style.forestColor


### PR DESCRIPTION
Before:
<img src="https://github.com/user-attachments/assets/8eebb69a-d06d-4a88-8473-198565f9b2f9" width="200"> 

After
| Landscape | Portrait |
|--------|--------|
|<img src="https://github.com/user-attachments/assets/6ed5e920-4e6f-45ec-b0b1-38d7dc42248b" width="300">| <img src="https://github.com/user-attachments/assets/42340a4c-6e33-4115-9c44-6a661b2e7e98" width="200"> |
