### PR TITLE
Fix CI tests

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -154,7 +154,7 @@ jobs:
 
       - name: run tests
         env:
-          TEST_MERGIN_URL: https://test.dev.merginmaps.com/
+          TEST_MERGIN_URL: https://app.dev.merginmaps.com/
           TEST_API_USERNAME: test_mobileapp
           TEST_API_PASSWORD: ${{ secrets.TEST_API_PASSWORD }}
           QT_QPA_PLATFORM: "offscreen"

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -153,7 +153,7 @@ jobs:
 
       - name: run tests
         env:
-          TEST_MERGIN_URL: https://test.dev.merginmaps.com/
+          TEST_MERGIN_URL: https://app.dev.merginmaps.com/
           TEST_API_USERNAME: test_mobileapp2
           TEST_API_PASSWORD: ${{ secrets.TEST_API_PASSWORD }}
         run: |

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -418,14 +418,14 @@ nmake
 # 8. Auto Testing
 
 You need to add cmake define `-DENABLE_TESTING=TRUE` on your cmake configure line.
-Also you need to open Passbolt and check for password for user `test_mobileapp_dev` on `test.dev.merginmaps.com`, 
+Also you need to open Passbolt and check for password for user `test_mobileapp_dev` on `app.dev.merginmaps.com`, 
 or you need some user with unlimited projects limit. First workspace from list is taken.
 
 ! Note that the same user cannot run tests in paraller ! 
 
 now you need to set environment variables: 
 ```
-TEST_MERGIN_URL=https://test.dev.merginmaps.com/
+TEST_MERGIN_URL=https://app.dev.merginmaps.com/
 TEST_API_USERNAME=test_mobileapp_dev
 TEST_API_PASSWORD=<your_password>
 ```

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -418,15 +418,15 @@ nmake
 # 8. Auto Testing
 
 You need to add cmake define `-DENABLE_TESTING=TRUE` on your cmake configure line.
-Also you need to open Passbolt and check for password for user `test_mobileapp_dev` on `app.dev.merginmaps.com`, 
+Also you need to open Passbolt and check for password for user `test_mobileapp` on `app.dev.merginmaps.com`, 
 or you need some user with unlimited projects limit. First workspace from list is taken.
 
-! Note that the same user cannot run tests in paraller ! 
+! Note that the same user cannot run tests in paraller ! This user is used for CI, consider creating your own account for local development !
 
 now you need to set environment variables: 
 ```
 TEST_MERGIN_URL=https://app.dev.merginmaps.com/
-TEST_API_USERNAME=test_mobileapp_dev
+TEST_API_USERNAME=test_mobileapp
 TEST_API_PASSWORD=<your_password>
 ```
 


### PR DESCRIPTION
We dropped test.dev server env. I updated credentials for app.dev. See https://github.com/MerginMaps/python-api-client/commit/621c5ffe2bbfc3103894ee6f63b26a88ea963551