### PR TITLE
Adding informational message on recording

### DIFF
--- a/app/qml/map/MMMapController.qml
+++ b/app/qml/map/MMMapController.qml
@@ -98,6 +98,8 @@ Item {
 
     switch ( state ) {
       case "record": {
+        root.showInfoTextMessage( qsTr( "Mark the geometry on the map and click record" ) )
+
         if ( __appSettings.autolockPosition ) { // center to GPS
           if ( gpsStateGroup.state === "unavailable" ) {
             __notificationModel.addError( "GPS currently unavailable." )


### PR DESCRIPTION
Following Figma, recording message `Mark the geometry on the map and click Record` has been added when recording mode is opened:

<img src="https://github.com/user-attachments/assets/c31af664-f6f4-4b9c-b2c8-5f4109f58851" width="220">