### PR TITLE
Fix FeaturesProxyModel sorting when model layer is set after setting the sourceModel

### DIFF
--- a/app/featuresmodel.cpp
+++ b/app/featuresmodel.cpp
@@ -363,6 +363,7 @@ void FeaturesModel::setLayer( QgsVectorLayer *newLayer )
     }
 
     mLayer = newLayer;
+    setupSorting();
     emit layerChanged( mLayer );
 
     if ( mLayer )

--- a/app/featuresproxymodel.cpp
+++ b/app/featuresproxymodel.cpp
@@ -45,5 +45,4 @@ void FeaturesProxyModel::setFeaturesSourceModel( FeaturesModel *sourceModel )
   setSourceModel( mModel );
   mModel->setupSorting();
   connect( mModel, &FeaturesModel::fetchingResultsChanged, this, [ = ]( bool pending ) { if ( !pending ) updateSorting(); } );
-  connect( mModel, &FeaturesModel::layerChanged, this, &FeaturesProxyModel::updateSorting );
 }

--- a/app/featuresproxymodel.cpp
+++ b/app/featuresproxymodel.cpp
@@ -45,4 +45,5 @@ void FeaturesProxyModel::setFeaturesSourceModel( FeaturesModel *sourceModel )
   setSourceModel( mModel );
   mModel->setupSorting();
   connect( mModel, &FeaturesModel::fetchingResultsChanged, this, [ = ]( bool pending ) { if ( !pending ) updateSorting(); } );
+  connect( mModel, &FeaturesModel::layerChanged, this, &FeaturesProxyModel::updateSorting );
 }

--- a/app/test/testmodels.cpp
+++ b/app/test/testmodels.cpp
@@ -75,10 +75,10 @@ void TestModels::testFeaturesProxyModel()
   conf.setSortExpression( QStringLiteral( "Name" ) );
   layer->setAttributeTableConfig( conf );
 
+  proxy.setFeaturesSourceModel( &model );
   model.setLayer( layer );
   model.reloadFeatures();
 
-  proxy.setFeaturesSourceModel( &model );
 
   spy.wait();
 


### PR DESCRIPTION
In _MMFeaturesListPage_, when `FeaturesProxyModel::setFeaturesSourceModel( &model );` is called, the model layer is not yet defined, 
This led to `FeaturesModel::sortingEnabled()` always returning `false` and no sorting taking place.

With this PR, when the model's layer is changed, `FeaturesModel::setupSorting()` is also called followed by `FeaturesProxyModel::updateSorting()`

Test was adjusted to handle this.

@tomasMizera do you think it would be better if `FeaturesModel::sortingEnabled()` would implicitly call `FeaturesModel::setupSorting()` first instead?

Fixes #3604