### PR TITLE
Renaming "Mergin Maps" occurrences

### DIFF
--- a/app/qml/account/MMAcceptInvitationPage.qml
+++ b/app/qml/account/MMAcceptInvitationPage.qml
@@ -59,7 +59,7 @@ MMPage {
 
             image: __style.positiveMMSymbolImage
             title: qsTr("You have been invited to a workspace")
-            description: qsTr("It is better to work together, join the workspace and explore the app!")
+            description: qsTr("Join the workspace and explore together!")
           }
 
           MMText {

--- a/app/qml/account/MMAcceptInvitationPage.qml
+++ b/app/qml/account/MMAcceptInvitationPage.qml
@@ -59,7 +59,7 @@ MMPage {
 
             image: __style.positiveMMSymbolImage
             title: qsTr("You have been invited to a workspace")
-            description: qsTr("It is better to work together, join the workspace and explore Mergin Maps!")
+            description: qsTr("It is better to work together, join the workspace and explore the app!")
           }
 
           MMText {

--- a/app/qml/account/MMAccountController.qml
+++ b/app/qml/account/MMAccountController.qml
@@ -135,7 +135,7 @@ Item {
 
       objectName: "signUpPanel"
       tocString: __inputUtils.htmlLink(
-          qsTr("I accept the Mergin Maps %1Terms and Conditions%3 and %2Privacy Policy%3"),
+          qsTr("I accept the %1Terms and Conditions%3 and %2Privacy Policy%3"),
           __style.forestColor,
           __inputHelp.merginTermsLink,
           __inputHelp.privacyPolicyLink

--- a/app/qml/account/MMCreateWorkspacePage.qml
+++ b/app/qml/account/MMCreateWorkspacePage.qml
@@ -108,7 +108,7 @@ MMPage {
       // hide the bubble on small screens
       visible: root.height + scrollBarBottomSpacer.height - dynamicContent.height - root.pageHeader.height - 2 * height > 0
 
-      title: qsTr( "Tip from us" )
+      title: qsTr( "A tip from us" )
       description: qsTr( "A good candidate for a workspace name is the name of your team or organisation" )
 
       imageSource: __style.bubbleImage

--- a/app/qml/account/MMCreateWorkspacePage.qml
+++ b/app/qml/account/MMCreateWorkspacePage.qml
@@ -108,7 +108,7 @@ MMPage {
       // hide the bubble on small screens
       visible: root.height + scrollBarBottomSpacer.height - dynamicContent.height - root.pageHeader.height - 2 * height > 0
 
-      title: qsTr( "Tip from Mergin Maps" )
+      title: qsTr( "Tip from us" )
       description: qsTr( "A good candidate for a workspace name is the name of your team or organisation" )
 
       imageSource: __style.bubbleImage

--- a/app/qml/dialogs/MMCloseAccountDialog.qml
+++ b/app/qml/dialogs/MMCloseAccountDialog.qml
@@ -37,7 +37,7 @@ MMDrawer {
         image: __style.closeAccountImage
 
         title: qsTr("Do you really wish to close your account?")
-        description: qsTr("This action will delete your Mergin Maps account. If you are a workspace owner, you need to transfer the ownership to somebody else or close the workspace.")
+        description: qsTr("This action will delete your account. If you are a workspace owner, you need to transfer the ownership to somebody else or close the workspace.")
       }
 
       MMText {

--- a/app/qml/dialogs/MMMissingAuthDialog.qml
+++ b/app/qml/dialogs/MMMissingAuthDialog.qml
@@ -18,7 +18,7 @@ MMDrawerDialog {
 
   imageSource: __style.signInImage
   title: qsTr( "Sign in to your account" )
-  description: qsTr( "You need to be signed in to your Mergin Maps account in order to synchronise the project." )
+  description: qsTr( "You need to be signed in to your account in order to synchronise the project." )
   primaryButton.text: qsTr( "Yes, I want to sign in" )
   secondaryButton.text: qsTr( "No, thanks" )
 

--- a/app/qml/dialogs/MMPositionTrackingDialog.qml
+++ b/app/qml/dialogs/MMPositionTrackingDialog.qml
@@ -22,7 +22,7 @@ MMComponents.MMDrawerDialog {
 
   title: qsTr("Position tracking")
   imageSource: root.trackingActive ? __style.positionTrackingRunningImage : __style.positionTrackingStartImage
-  description: root.trackingActive ? qsTr( "Mergin Maps can track your position on this project." ) : qsTr( "Track your routes even with your screen off. Your records are stored in a separate layer. Finalised tracks are synced like any other feature." )
+  description: root.trackingActive ? qsTr( "The app can track your position on this project." ) : qsTr( "Track your routes even with your screen off. Your records are stored in a separate layer. Finalised tracks are synced like any other feature." )
   primaryButton.text: root.trackingActive ? qsTr( "Stop tracking" ) : qsTr( "Start tracking" )
   primaryButton.type: root.trackingActive ? MMComponents.MMButton.Secondary : MMComponents.MMButton.Primary
 

--- a/app/qml/dialogs/MMWelcomeToNewDesignDialog.qml
+++ b/app/qml/dialogs/MMWelcomeToNewDesignDialog.qml
@@ -18,7 +18,7 @@ MMDrawerDialog {
 
   imageSource: __style.positiveMMSymbolImage
   title: qsTr( "New Look & Feel" )
-  description: qsTr( "We've been busy making Mergin Maps even better! This update brings a fresh look and improved navigation, making it faster to find what you need. Take a look around!" )
+  description: qsTr( "We've been busy making the app even better! This update brings a fresh look and improved navigation, making it faster to find what you need. Take a look around!" )
   primaryButton.text: qsTr("Let's start!")
 
   onPrimaryButtonClicked: {

--- a/app/qml/gps/MMPositionProviderPage.qml
+++ b/app/qml/gps/MMPositionProviderPage.qml
@@ -147,7 +147,7 @@ MMComponents.MMPage {
       description: qsTr( "This function is not available on iOS. " +
                         "Your hardware vendor may provide a custom " +
                         "app that connects to the receiver and sets position. " +
-                        "Mergin Maps will still think it is the internal GPS of " +
+                        "The app will still think it is the internal GPS of " +
                         "your phone/tablet." )
       link: __inputHelp.howToConnectGPSLink
     }

--- a/app/qml/project/MMProjectHomeTab.qml
+++ b/app/qml/project/MMProjectHomeTab.qml
@@ -61,7 +61,7 @@ Item {
       topMargin: root.spacing
     }
     title: qsTr("Your attention is required")
-    description: qsTr("Click here to visit Mergin Maps dashboard")
+    description: qsTr("Click here to access the dashboard")
     imageSource: __style.warnLogoImage
 
     color: __style.nightColor

--- a/app/qml/project/MMProjectList.qml
+++ b/app/qml/project/MMProjectList.qml
@@ -234,7 +234,7 @@ Item {
     }
 
     image: __style.positiveMMSymbolImage
-    title: qsTr( "Get started with the app")
+    title: qsTr( "Let's get started")
     description: qsTr( "First step is to create your brand new project." )
   }
 

--- a/app/qml/project/MMProjectList.qml
+++ b/app/qml/project/MMProjectList.qml
@@ -234,7 +234,7 @@ Item {
     }
 
     image: __style.positiveMMSymbolImage
-    title: qsTr( "Get started with Mergin Maps")
+    title: qsTr( "Get started with the app")
     description: qsTr( "First step is to create your brand new project." )
   }
 

--- a/app/qml/settings/MMAboutPage.qml
+++ b/app/qml/settings/MMAboutPage.qml
@@ -18,7 +18,7 @@ MMPage {
 
   signal visitWebsiteClicked()
 
-  pageHeader.title: qsTr( "About the App" )
+  pageHeader.title: qsTr( "About" )
 
   pageContent: ScrollView {
 

--- a/app/qml/settings/MMAboutPage.qml
+++ b/app/qml/settings/MMAboutPage.qml
@@ -18,7 +18,7 @@ MMPage {
 
   signal visitWebsiteClicked()
 
-  pageHeader.title: qsTr( "About Mergin Maps" )
+  pageHeader.title: qsTr( "About the App" )
 
   pageContent: ScrollView {
 

--- a/gallery/qml/pages/MiscPage.qml
+++ b/gallery/qml/pages/MiscPage.qml
@@ -234,7 +234,7 @@ ScrollView {
 
         MMInfoBox {
           width: page.width - 64
-          title: "Tip from Mergin Maps"
+          title: "Tip from us"
           description: "A good candidate for a workspace name is the name of your team or organisation"
           imageSource: __style.bubbleImage
         }

--- a/gallery/qml/pages/MiscPage.qml
+++ b/gallery/qml/pages/MiscPage.qml
@@ -234,7 +234,7 @@ ScrollView {
 
         MMInfoBox {
           width: page.width - 64
-          title: "Tip from us"
+          title: "A tip from us"
           description: "A good candidate for a workspace name is the name of your team or organisation"
           imageSource: __style.bubbleImage
         }


### PR DESCRIPTION
To enhance maintainability, reusability and other key attributes, we have replaced occurrences of `Mergin Maps` in notifications and tool/action descriptions within the app with more generic terms.