### PR TITLE
Fix inconsistent UI/UX for read-only non-spatial layers

### DIFF
--- a/app/qml/layers/MMFeaturesListPage.qml
+++ b/app/qml/layers/MMFeaturesListPage.qml
@@ -83,20 +83,6 @@ MMComponents.MMPage {
       anchors.centerIn: parent
       running: featuresModel.fetchingResults
     }
-
-    MMComponents.MMButton {
-      id: addButton
-
-      width: parent.width
-      anchors.bottom: parent.bottom
-      anchors.bottomMargin: root.hasToolbar ? __style.margin20 : ( __style.safeAreaBottom + __style.margin8 )
-
-      visible: __inputUtils.isNoGeometryLayer( root.selectedLayer )
-
-      text: qsTr("Add feature")
-
-      onClicked: root.addFeatureClicked( root.selectedLayer )
-    }
   }
 
   Component.onCompleted: {

--- a/app/qml/layers/MMFeaturesListPage.qml
+++ b/app/qml/layers/MMFeaturesListPage.qml
@@ -21,7 +21,7 @@ MMComponents.MMPage {
 
   property var selectedLayer: null
   property bool hasToolbar: false
-  property bool layerIsReadOnly: featuresModel.layer?.readOnly ?? false
+  property bool layerIsReadOnly: selectedLayer?.readOnly ?? false
 
   signal featureClicked( var featurePair )
   signal addFeatureClicked( var toLayer )

--- a/app/qml/layers/MMFeaturesListPage.qml
+++ b/app/qml/layers/MMFeaturesListPage.qml
@@ -21,6 +21,7 @@ MMComponents.MMPage {
 
   property var selectedLayer: null
   property bool hasToolbar: false
+  property bool layerIsReadOnly: featuresModel.layer?.readOnly ?? false
 
   signal featureClicked( var featurePair )
   signal addFeatureClicked( var toLayer )
@@ -82,6 +83,20 @@ MMComponents.MMPage {
     MMComponents.MMBusyIndicator {
       anchors.centerIn: parent
       running: featuresModel.fetchingResults
+    }
+
+    MMComponents.MMButton {
+      id: addButton
+
+      width: parent.width
+      anchors.bottom: parent.bottom
+      anchors.bottomMargin: root.hasToolbar ? __style.margin20 : ( __style.safeAreaBottom + __style.margin8 )
+
+      visible: __inputUtils.isNoGeometryLayer( root.selectedLayer ) && !root.layerIsReadOnly
+
+      text: qsTr("Add feature")
+
+      onClicked: root.addFeatureClicked( root.selectedLayer )
     }
   }
 


### PR DESCRIPTION
Added `layerIsReadOnly` property as a condition for visibility of `Add Feature` button. If a layer is non-spatial and not read-only, the button will be visible.

| Read-only | Editable |
|--------|--------|
|<img src="https://github.com/user-attachments/assets/2340fd2d-1341-44dd-a5fb-1c9615d4a8ef" width="300">| <img src="https://github.com/user-attachments/assets/21fe116d-910e-40d8-b8c3-10adcbd1a45d" width="300"> |

Fix #3633 