### PR TITLE
Retry failed download requests implementation

### DIFF
--- a/app/test/testmerginapi.cpp
+++ b/app/test/testmerginapi.cpp
@@ -2687,7 +2687,7 @@ void TestMerginApi::deleteRemoteProjectNow( MerginApi *api, const QString &proje
   QUrl url( api->mApiRoot + QStringLiteral( "/v2/projects/%1" ).arg( projectId ) );
   request.setUrl( url );
   qDebug() << "Trying to delete project " << projectName << ", id: " << projectId << " (" << url << ")";
-  QNetworkReply *r = api->mManager.deleteResource( request );
+  QNetworkReply *r = api->mManager->deleteResource( request );
   QSignalSpy spy( r, &QNetworkReply::finished );
   spy.wait( TestUtils::SHORT_REPLY );
 

--- a/app/test/testmerginapi.cpp
+++ b/app/test/testmerginapi.cpp
@@ -2965,12 +2965,12 @@ void TestMerginApi::testDownloadWithNetworkError()
     mApi->setNetworkManager( failingManager );
 
     // Create signal spies
-    QSignalSpy startSpy( mApi, &MerginApi::downloadItemsStarted );
+    QSignalSpy startSpy( mApi, &MerginApi::pullFilesStarted );
     QSignalSpy retrySpy( mApi, &MerginApi::downloadItemRetried );
     QSignalSpy finishSpy( mApi, &MerginApi::syncProjectFinished );
 
     // Trigger the current network error when download starts
-    connect( mApi, &MerginApi::downloadItemsStarted, this, [this, failingManager, networkError]()
+    connect( mApi, &MerginApi::pullFilesStarted, this, [this, failingManager, networkError]()
     {
       failingManager->setShouldFail( true, networkError );
     } );
@@ -3002,7 +3002,7 @@ void TestMerginApi::testDownloadWithNetworkError()
     QVERIFY( !localProject.isValid() );
 
     // Disconnect all signals
-    disconnect( mApi, &MerginApi::downloadItemsStarted, this, nullptr );
+    disconnect( mApi, &MerginApi::pullFilesStarted, this, nullptr );
 
     // Clean up
     mApi->setNetworkManager( originalManager );
@@ -3023,7 +3023,7 @@ void TestMerginApi::testDownloadWithNetworkErrorRecovery()
   mApi->setNetworkManager( failingManager );
 
   // Create signal spies
-  QSignalSpy startSpy( mApi, &MerginApi::downloadItemsStarted );
+  QSignalSpy startSpy( mApi, &MerginApi::pullFilesStarted );
   QSignalSpy retrySpy( mApi, &MerginApi::downloadItemRetried );
   QSignalSpy finishSpy( mApi, &MerginApi::syncProjectFinished );
 
@@ -3038,13 +3038,13 @@ void TestMerginApi::testDownloadWithNetworkErrorRecovery()
     if ( retryCount == 2 )
     {
       failingManager->setShouldFail( false );
-      disconnect( mApi, &MerginApi::downloadItemsStarted, nullptr, nullptr );
+      disconnect( mApi, &MerginApi::pullFilesStarted, nullptr, nullptr );
       disconnect( mApi, &MerginApi::downloadItemRetried, nullptr, nullptr );
     }
   } );
 
   // Trigger network error when download starts
-  connect( mApi, &MerginApi::downloadItemsStarted, this, [failingManager, networkError]()
+  connect( mApi, &MerginApi::pullFilesStarted, this, [failingManager, networkError]()
   {
     failingManager->setShouldFail( true, networkError );
   } );

--- a/app/test/testmerginapi.cpp
+++ b/app/test/testmerginapi.cpp
@@ -2982,7 +2982,7 @@ void TestMerginApi::testDownloadWithNetworkError()
   QVERIFY( retrySpy.count() > 0 );
   QCOMPARE( finishSpy.count(), 1 );
 
-  // Verify that 5 (MAX_RETRY_COUNT) retry attempts were made
+  // Verify that transaction.MAX_RETRY_COUNT retry attempts were made
   int maxRetries = TransactionStatus::MAX_RETRY_COUNT;
   QCOMPARE( retrySpy.count(), maxRetries );
 

--- a/app/test/testmerginapi.cpp
+++ b/app/test/testmerginapi.cpp
@@ -2971,6 +2971,8 @@ void TestMerginApi::testDownloadWithNetworkError()
 
   disconnect( mApi, &MerginApi::downloadItemsStarted, this, nullptr );
 
+  failingManager->setShouldFail( false );
+
   // Second attempt - TemporaryNetworkFailureError
   connect( mApi, &MerginApi::downloadItemsStarted, this, [this, failingManager]()
   {

--- a/app/test/testmerginapi.cpp
+++ b/app/test/testmerginapi.cpp
@@ -2994,6 +2994,9 @@ void TestMerginApi::testDownloadWithNetworkError()
   LocalProject localProject = mApi->localProjectsManager().projectFromMerginName( mWorkspaceName, projectName );
   QVERIFY( !localProject.isValid() );
 
+  // Disconnect all signals
+  disconnect( mApi, &MerginApi::downloadItemsStarted, this, nullptr );
+
   // Restore the original manager
   QNetworkAccessManager *originalManager = new QNetworkAccessManager( this );
   mApi->setNetworkManager( originalManager );

--- a/app/test/testmerginapi.cpp
+++ b/app/test/testmerginapi.cpp
@@ -2945,34 +2945,34 @@ void TestMerginApi::testParseVersion()
 
 void TestMerginApi::testDownloadWithNetworkError()
 {
-    QString projectName = "testDownloadWithNetworkError";
-    QString projectNamespace = mWorkspaceName;
+  QString projectName = "testDownloadWithNetworkError";
+  QString projectNamespace = mWorkspaceName;
 
-    // Create a test project on server
-    createRemoteProject( mApiExtra, projectNamespace, projectName, mTestDataPath + "/" + TEST_PROJECT_NAME + "/" );
+  // Create a test project on server
+  createRemoteProject( mApiExtra, projectNamespace, projectName, mTestDataPath + "/" + TEST_PROJECT_NAME + "/" );
 
-    // Create mock network manager
-    MockNetworkManager *mockManager = new MockNetworkManager( mApi );
-    mApi->setNetworkManager( mockManager );
+  // Create mock network manager
+  MockNetworkManager *mockManager = new MockNetworkManager( mApi );
+  mApi->setNetworkManager( mockManager );
 
-    // Track retry signals
-    QSignalSpy retrySpy( mApi, &MerginApi::downloadItemRetried );
+  // Track retry signals
+  QSignalSpy retrySpy( mApi, &MerginApi::downloadItemRetried );
 
-    // Start download and make network fail after project info
-    mApi->pullProject( projectNamespace, projectName );
+  // Start download and make network fail after project info
+  mApi->pullProject( projectNamespace, projectName );
 
-    QSignalSpy pullStartedSpy( mApi, &MerginApi::pullFilesStarted );
-    QVERIFY( pullStartedSpy.wait( TestUtils::SHORT_REPLY ) );
-    mockManager->setShouldFail( true );
+  QSignalSpy pullStartedSpy( mApi, &MerginApi::pullFilesStarted );
+  QVERIFY( pullStartedSpy.wait( TestUtils::SHORT_REPLY ) );
+  mockManager->setShouldFail( true );
 
-    // Wait for sync to finish
-    QSignalSpy syncFinishedSpy( mApi, &MerginApi::syncProjectFinished );
-    QVERIFY( syncFinishedSpy.wait( TestUtils::LONG_REPLY ) );
+  // Wait for sync to finish
+  QSignalSpy syncFinishedSpy( mApi, &MerginApi::syncProjectFinished );
+  QVERIFY( syncFinishedSpy.wait( TestUtils::LONG_REPLY ) );
 
-    // Verify we got retry signals
-    QVERIFY( retrySpy.count() > 0 );
+  // Verify we got retry signals
+  QVERIFY( retrySpy.count() > 0 );
 
-    // Cleanup
-    mApi->setNetworkManager( new QNetworkAccessManager( mApi ) );
-    deleteRemoteProjectNow( mApi, projectNamespace, projectName );
+  // Cleanup
+  mApi->setNetworkManager( new QNetworkAccessManager( mApi ) );
+  deleteRemoteProjectNow( mApi, projectNamespace, projectName );
 }

--- a/app/test/testmerginapi.cpp
+++ b/app/test/testmerginapi.cpp
@@ -2945,29 +2945,29 @@ void TestMerginApi::testParseVersion()
 
 void TestMerginApi::testDownloadWithNetworkError()
 {
-  MockNetworkManager *mockManager = new MockNetworkManager( mApi );
-  mApi->setNetworkManager( mockManager );
+  // MockNetworkManager *mockManager = new MockNetworkManager( mApi );
+  // mApi->setNetworkManager( mockManager );
 
-  QString projectName = "testDownloadWithNetworkError";
-  QString projectNamespace = mWorkspaceName;
-  createRemoteProject( mApiExtra, projectNamespace, projectName, mTestDataPath + "/" + TEST_PROJECT_NAME + "/" );
+  // QString projectName = "testDownloadWithNetworkError";
+  // QString projectNamespace = mWorkspaceName;
+  // createRemoteProject( mApiExtra, projectNamespace, projectName, mTestDataPath + "/" + TEST_PROJECT_NAME + "/" );
 
-  mockManager->setShouldFail( true );
+  // mockManager->setShouldFail( true );
 
-  QSignalSpy spy( mApi, &MerginApi::syncProjectFinished );
-  QSignalSpy errorSpy( mApi, &MerginApi::networkErrorOccurred );
+  // QSignalSpy spy( mApi, &MerginApi::syncProjectFinished );
+  // QSignalSpy errorSpy( mApi, &MerginApi::networkErrorOccurred );
 
-  mApi->pullProject( projectNamespace, projectName );
+  // mApi->pullProject( projectNamespace, projectName );
 
-  QVERIFY( spy.wait( TestUtils::LONG_REPLY * 5 ) );
+  // QVERIFY( spy.wait( TestUtils::LONG_REPLY * 5 ) );
 
-  QCOMPARE( spy.count(), 1 );
-  QList<QVariant> arguments = spy.takeFirst();
-  QVERIFY( !arguments.at( 1 ).toBool() );
+  // QCOMPARE( spy.count(), 1 );
+  // QList<QVariant> arguments = spy.takeFirst();
+  // QVERIFY( !arguments.at( 1 ).toBool() );
 
-  QCOMPARE( errorSpy.count(), 1 );
+  // QCOMPARE( errorSpy.count(), 1 );
 
-  mApi->setNetworkManager( new QNetworkAccessManager( mApi ) );
+  // mApi->setNetworkManager( new QNetworkAccessManager( mApi ) );
 
-  deleteRemoteProjectNow( mApi, projectNamespace, projectName );
+  // deleteRemoteProjectNow( mApi, projectNamespace, projectName );
 }

--- a/app/test/testmerginapi.h
+++ b/app/test/testmerginapi.h
@@ -26,7 +26,7 @@ class MockReply : public QNetworkReply
   public:
     explicit MockReply( QObject *parent = nullptr ) : QNetworkReply( parent )
     {
-      QNetworkReply::setError( QNetworkReply::ConnectionRefusedError, "Mock network failure" );
+      QNetworkReply::setError( QNetworkReply::UnknownNetworkError, "Mock network failure" );
       QMetaObject::invokeMethod( this, "finished", Qt::QueuedConnection );
     }
 

--- a/app/test/testmerginapi.h
+++ b/app/test/testmerginapi.h
@@ -26,7 +26,7 @@ class MockReply : public QNetworkReply
   public:
     explicit MockReply( QObject *parent = nullptr ) : QNetworkReply( parent )
     {
-      QNetworkReply::setError( QNetworkReply::UnknownNetworkError, "Mock network failure" );
+      QNetworkReply::setError( QNetworkReply::TimeoutError, "Mock network failure" );
       QMetaObject::invokeMethod( this, "finished", Qt::QueuedConnection );
     }
 
@@ -45,6 +45,15 @@ class MockNetworkManager : public QNetworkAccessManager
 
     void setShouldFail( bool shouldFail ) { mShouldFail = shouldFail; }
     bool shouldFail() const { return mShouldFail; }
+
+    QNetworkReply *get( const QNetworkRequest &request )
+    {
+      if ( mShouldFail )
+      {
+        return new MockReply( this );
+      }
+      return QNetworkAccessManager::get( request );
+    }
 
     QNetworkReply *post( const QNetworkRequest &request, const QByteArray &data )
     {

--- a/app/test/testmerginapi.h
+++ b/app/test/testmerginapi.h
@@ -108,6 +108,7 @@ class TestMerginApi: public QObject
     void testListProjectsByName();
     void testDownloadProject();
     void testDownloadWithNetworkError();
+    void testDownloadWithNetworkErrorRecovery();
     void testDownloadProjectSpecChars();
     void testCancelDownloadProject();
     void testCreateProjectTwice();

--- a/core/merginapi.cpp
+++ b/core/merginapi.cpp
@@ -3972,6 +3972,9 @@ bool MerginApi::isRetryableNetworkError( QNetworkReply *reply )
 
 void MerginApi::setNetworkManager( QNetworkAccessManager *manager )
 {
+  if ( !manager )
+    return;
+
   if ( mManager == manager )
     return;
 

--- a/core/merginapi.cpp
+++ b/core/merginapi.cpp
@@ -427,7 +427,8 @@ void MerginApi::downloadItemReplyFinished( DownloadQueueItem item )
     transaction.retryCount++;
     transaction.downloadQueue.append( item );
 
-    CoreUtils::log( "pull " + projectFullName, QStringLiteral( "Retrying download (attempt %1 of 5)" ).arg( transaction.retryCount ) );
+    CoreUtils::log( "pull " + projectFullName, QStringLiteral( "Retrying download (attempt %1 of %2)" ).arg( transaction.retryCount )
+                    .arg( transaction.MAX_RETRY_COUNT ) );
 
     downloadNextItem( projectFullName );
 
@@ -3228,8 +3229,8 @@ ProjectDiff MerginApi::compareProjectFiles(
   /*
   for ( MerginFile file : oldServerFilesMap )
   {
-  // R-D/L-D
-  // TODO: need to do anything?
+    // R-D/L-D
+    // TODO: need to do anything?
   }
   */
 

--- a/core/merginapi.cpp
+++ b/core/merginapi.cpp
@@ -2441,6 +2441,8 @@ void MerginApi::startProjectPull( const QString &projectFullName )
   }
   else
   {
+    emit downloadItemsStarted();
+
     while ( transaction.replyPullItems.count() < 5 && !transaction.downloadQueue.isEmpty() )
     {
       downloadNextItem( projectFullName );

--- a/core/merginapi.cpp
+++ b/core/merginapi.cpp
@@ -3960,17 +3960,18 @@ bool MerginApi::isRetryableNetworkError( QNetworkReply *reply )
   Q_ASSERT( reply );
 
   QNetworkReply::NetworkError err = reply->error();
-  int httpCode = reply->attribute( QNetworkRequest::HttpStatusCodeAttribute ).toInt();
 
   bool isRetryableError = ( err == QNetworkReply::TimeoutError ||
                             err == QNetworkReply::TemporaryNetworkFailureError ||
                             err == QNetworkReply::NetworkSessionFailedError ||
-                            err == QNetworkReply::UnknownNetworkError );
+                            err == QNetworkReply::UnknownNetworkError ||
+                            err == QNetworkReply::RemoteHostClosedError ||
+                            err == QNetworkReply::ProxyConnectionClosedError ||
+                            err == QNetworkReply::ProxyTimeoutError ||
+                            err == QNetworkReply::UnknownProxyError ||
+                            err == QNetworkReply::ServiceUnavailableError );
 
-  bool isRetryableHttpCode = ( httpCode == 500 || httpCode == 502 ||
-                               httpCode == 503 || httpCode == 504 );
-
-  return isRetryableError || isRetryableHttpCode;
+  return isRetryableError;
 }
 
 void MerginApi::setNetworkManager( QNetworkAccessManager *manager )

--- a/core/merginapi.cpp
+++ b/core/merginapi.cpp
@@ -430,6 +430,8 @@ void MerginApi::downloadItemReplyFinished( DownloadQueueItem item )
     CoreUtils::log( "pull " + projectFullName, QStringLiteral( "Retrying download (attempt %1 of 5)" ).arg( transaction.retryCount ) );
 
     downloadNextItem( projectFullName );
+
+    emit downloadItemRetried( projectFullName, transaction.retryCount );
     transaction.replyPullItems.remove( r );
     r->deleteLater();
   }

--- a/core/merginapi.cpp
+++ b/core/merginapi.cpp
@@ -2445,8 +2445,6 @@ void MerginApi::startProjectPull( const QString &projectFullName )
   }
   else
   {
-    emit downloadItemsStarted();
-
     while ( transaction.replyPullItems.count() < 5 && !transaction.downloadQueue.isEmpty() )
     {
       downloadNextItem( projectFullName );

--- a/core/merginapi.cpp
+++ b/core/merginapi.cpp
@@ -406,12 +406,15 @@ void MerginApi::downloadItemReplyFinished( DownloadQueueItem item )
     transaction.transferedSize += data.size();
     emit syncProjectStatusChanged( projectFullName, transaction.transferedSize / transaction.totalSize );
     transaction.replyPullItems.remove( r );
+
     r->deleteLater();
+
     if ( !transaction.downloadQueue.isEmpty() )
     {
       // one request finished, let's start another one
       downloadNextItem( projectFullName );
     }
+
     else if ( transaction.replyPullItems.isEmpty() )
     {
       // nothing else to download and all requests are finished, we're done
@@ -3978,10 +3981,7 @@ void MerginApi::setNetworkManager( QNetworkAccessManager *manager )
   if ( mManager == manager )
     return;
 
-  delete mManager;
   mManager = manager;
-  if ( mManager )
-    mManager->setParent( this );
 
   emit networkManagerChanged();
 }

--- a/core/merginapi.h
+++ b/core/merginapi.h
@@ -584,7 +584,6 @@ class MerginApi: public QObject
 
     /**
      * Sets the network manager to be used for Mergin API requests
-     * \param QNetworkAccessManager
      */
     void setNetworkManager( QNetworkAccessManager *manager );
 

--- a/core/merginapi.h
+++ b/core/merginapi.h
@@ -668,7 +668,6 @@ class MerginApi: public QObject
     void networkManagerChanged();
 
     void downloadItemRetried( const QString &projectFullName, int retryCount );
-    void downloadItemsStarted();
 
   private slots:
     void listProjectsReplyFinished( QString requestId );

--- a/core/merginapi.h
+++ b/core/merginapi.h
@@ -584,6 +584,7 @@ class MerginApi: public QObject
 
     /**
      * Sets the network manager to be used for Mergin API requests
+     * Function will return early if manager is null.
      */
     void setNetworkManager( QNetworkAccessManager *manager );
 

--- a/core/merginapi.h
+++ b/core/merginapi.h
@@ -667,6 +667,8 @@ class MerginApi: public QObject
     void serverWasUpgraded();
     void networkManagerChanged();
 
+    void downloadItemRetried( const QString &projectFullName, int retryCount );
+
   private slots:
     void listProjectsReplyFinished( QString requestId );
     void listProjectsByNameReplyFinished( QString requestId );

--- a/core/merginapi.h
+++ b/core/merginapi.h
@@ -668,6 +668,7 @@ class MerginApi: public QObject
     void networkManagerChanged();
 
     void downloadItemRetried( const QString &projectFullName, int retryCount );
+    void downloadItemsStarted();
 
   private slots:
     void listProjectsReplyFinished( QString requestId );

--- a/core/merginapi.h
+++ b/core/merginapi.h
@@ -109,7 +109,6 @@ struct DownloadQueueItem
   qint64 rangeTo = -1;       //!< what range of bytes to download (-1 if downloading the whole file)
   bool downloadDiff = false; //!< whether to download just the diff between the previous version and the current one
   QString tempFileName;      //!< relative filename of the temporary file where the downloaded content will be stored
-  int retryCount = 0;
 };
 
 
@@ -143,8 +142,6 @@ struct TransactionStatus
     Pull
   };
 
-  static const int MAX_RETRY_COUNT = 5;  //!< maximum number of retry attempts for failed network requests
-
   qreal totalSize = 0;     //!< total size (in bytes) of files to be pushed or pulled
   qint64 transferedSize = 0;  //!< size (in bytes) of amount of data transferred so far
   QString transactionUUID; //!< only for push. Initially dummy non-empty string, after server confirms a valid UUID, on finish/cancel it is empty
@@ -171,6 +168,7 @@ struct TransactionStatus
 
   // retry handling
   int retryCount = 0;  //!< current number of retry attempts for failed network requests
+  static const int MAX_RETRY_COUNT = 5;  //!< maximum number of retry attempts for failed network requests
 
   QString projectDir;
   QByteArray projectMetadata;  //!< metadata of the new project (not parsed)

--- a/core/merginapi.h
+++ b/core/merginapi.h
@@ -579,6 +579,17 @@ class MerginApi: public QObject
      */
     bool apiSupportsWorkspaces();
 
+    /**
+     * Returns the network manager used for Mergin API requests
+     */
+    QNetworkAccessManager *networkManager() const { return mManager; }
+
+    /**
+     * Sets the network manager to be used for Mergin API requests
+     * \param QNetworkAccessManager
+     */
+    void setNetworkManager( QNetworkAccessManager *manager );
+
   signals:
     void apiSupportsSubscriptionsChanged();
     void supportsSelectiveSyncChanged();
@@ -656,6 +667,7 @@ class MerginApi: public QObject
     void apiSupportsWorkspacesChanged();
 
     void serverWasUpgraded();
+    void networkManagerChanged();
 
   private slots:
     void listProjectsReplyFinished( QString requestId );
@@ -802,7 +814,7 @@ class MerginApi: public QObject
 
     bool projectFileHasBeenUpdated( const ProjectDiff &diff );
 
-    QNetworkAccessManager mManager;
+    QNetworkAccessManager *mManager = nullptr;
     QString mApiRoot;
     LocalProjectsManager &mLocalProjects;
     QString mDataDir; // dir with all projects


### PR DESCRIPTION
Implements a retry mechanism for failed downloads during project downloads, with a maximum of 5 retries per transaction. Individual file downloads now retry on network issues, being re-added to the download queue. Added a `downloadItemRetried` signal to track retry attempts. Added a getter/setter for the Mergin API's QNetworkAccessManager to support testing.

Retry system for downloads diagram:
![image](https://github.com/user-attachments/assets/03841210-c7ca-44c8-a7e5-49dbd43ac13d)

Transaction download queue replies handling:
![image](https://github.com/user-attachments/assets/9601a3e8-1dfa-40cf-9912-254307bc46fc)

Resolves #3644
