### PR TITLE
Remove deprecated reference to writernames

### DIFF
--- a/core/merginprojectmetadata.cpp
+++ b/core/merginprojectmetadata.cpp
@@ -100,16 +100,6 @@ MerginProjectMetadata MerginProjectMetadata::fromJson( const QByteArray &data )
   project.name = docObj.value( QStringLiteral( "name" ) ).toString();
   project.projectNamespace = docObj.value( QStringLiteral( "namespace" ) ).toString();
 
-  QJsonValue access = docObj.value( QStringLiteral( "access" ) );
-  if ( access.isObject() )
-  {
-    QJsonArray writersnames = access.toObject().value( "writersnames" ).toArray();
-    for ( QJsonValueRef tag : writersnames )
-    {
-      project.writersnames.append( tag.toString() );
-    }
-  }
-
   QString versionStr = docObj.value( QStringLiteral( "version" ) ).toString();
   if ( versionStr.isEmpty() )
   {

--- a/core/merginprojectmetadata.h
+++ b/core/merginprojectmetadata.h
@@ -59,7 +59,6 @@ struct MerginProjectMetadata
 {
   QString name;
   QString projectNamespace;
-  QList<QString> writersnames;
   int version = -1;
   QList<MerginFile> files;
   QString projectId; //!< unique project ID (only available in API that supports project IDs)


### PR DESCRIPTION
Luckily, it was read as an optional key so there is no need to keep the server compatible :) 