### PR TITLE
Fix uneccessary confirmation dialog when reopenning a form

### DIFF
--- a/app/qml/form/MMFormStackController.qml
+++ b/app/qml/form/MMFormStackController.qml
@@ -258,7 +258,7 @@ Item {
       if ( formsStack.depth > 1 ) {
         formsStack.pop()
       }
-      else{
+      else {
         formsStack.clear()
       }
 


### PR DESCRIPTION
Previously we kept the left most form component in the stackview for performance but it prevent the call to `recalculateDerivedItems` and the appropriate `HasAnyChanges` signal

This PR solve the issue by destroying the last form component and rebuild it each time a form is open


May partially solves #3671 