### PR TITLE
Bump upload-artifact action to v4

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -266,7 +266,7 @@ jobs:
             ${{ github.workspace }}/merginmaps-${{ env.INPUT_VERSION_CODE }}.apk
 
       - name: Upload APK to Artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           path: ${{ github.workspace }}/merginmaps-${{ env.INPUT_VERSION_CODE }}.apk
           name: Mergin Maps ${{ env.INPUT_VERSION_CODE }} APK [v7 + v8a]
@@ -294,7 +294,7 @@ jobs:
 
       - name: Upload AAB to Artifacts
         if: ${{ github.ref_name == 'master' || github.ref_type == 'tag' }}
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           path: ${{ github.workspace }}/merginmaps-${{ env.INPUT_VERSION_CODE }}.aab
           name: Mergin Maps ${{ env.INPUT_VERSION_CODE }} AAB

--- a/.github/workflows/gallery.yml
+++ b/.github/workflows/gallery.yml
@@ -121,7 +121,7 @@ jobs:
           tar -czf ${{ github.workspace }}/merginmaps-gallery-${{ matrix.os }}.tar.gz .
           
       - name: Upload APK to Artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           path: ${{ github.workspace }}/merginmaps-gallery-${{ matrix.os }}.tar.gz
           name: Mergin Maps Gallery ${{ matrix.os }}

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -214,6 +214,6 @@ jobs:
           tar -c -z -f ${{ github.workspace }}/${INPUT_TAR} ./
 
       - name: Upload Sdk in Artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           path: ${{ github.workspace }}/${{ env.INPUT_TAR }}

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -197,6 +197,6 @@ jobs:
           tar -c -z -f ${{ github.workspace }}/${INPUT_TAR} "./Input.app"
 
       - name: Upload Sdk in Artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           path: ${{ github.workspace }}/${{ env.INPUT_TAR }}

--- a/.github/workflows/macos_arm64.yml
+++ b/.github/workflows/macos_arm64.yml
@@ -168,6 +168,6 @@ jobs:
           tar -c -z -f ${{ github.workspace }}/${INPUT_TAR} "./Input.app"
 
       - name: Upload Sdk in Artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           path: ${{ github.workspace }}/${{ env.INPUT_TAR }}

--- a/.github/workflows/win.yml
+++ b/.github/workflows/win.yml
@@ -199,7 +199,7 @@ jobs:
             xcopy C:\input-package\inputapp-win-x86_64.exe mergin-maps-input-win64-${{ steps.time.outputs.formattedTime }}-${{ github.run_number }}.exe* /Y
 
       - name: Upload Sdk in Artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           path: mergin-maps-input-win64-${{ steps.time.outputs.formattedTime }}-${{ github.run_number }}.exe
           if-no-files-found: error


### PR DESCRIPTION
This PR bump the upload-artifact action to v4 because previous version are deprecated at the end of the month

In the case of the mobile repository, the naive bump to v4 worked without change. and the artifacts content are similar on the few I checked (android, windows, linux, and the gallery app artifacts)