### PR TITLE
Fix incorrect missing authentication dialog trigger

### DIFF
--- a/core/merginapi.cpp
+++ b/core/merginapi.cpp
@@ -3966,7 +3966,7 @@ DownloadQueueItem::DownloadQueueItem( const QString &fp, qint64 s, int v, qint64
 
 void MerginApi::reloadProjectRole( const QString &projectFullName )
 {
-  if ( projectFullName.isEmpty() )
+  if ( projectFullName.isEmpty() || !isLoggedIn() )
   {
     return;
   }
@@ -4052,4 +4052,9 @@ void MerginApi::setNetworkManager( QNetworkAccessManager *manager )
   mManager = manager;
 
   emit networkManagerChanged();
+}
+
+bool MerginApi::isLoggedIn() const
+{
+  return mUserAuth->hasAuthData() && !mUserAuth->authToken().isEmpty();
 }

--- a/core/merginapi.cpp
+++ b/core/merginapi.cpp
@@ -1453,7 +1453,7 @@ bool MerginApi::validateAuth()
     return false;
   }
 
-  if ( mUserAuth->authToken().isEmpty() || mUserAuth->tokenExpiration() < QDateTime().currentDateTime().toUTC() )
+  if ( mUserAuth->authToken().isEmpty() || mUserAuth->tokenExpiration() < QDateTime().currentDateTimeUtc() )
   {
     authorize( mUserAuth->username(), mUserAuth->password() );
     CoreUtils::log( QStringLiteral( "MerginApi" ), QStringLiteral( "Requesting authorization because of missing or expired token." ) );
@@ -3966,12 +3966,10 @@ DownloadQueueItem::DownloadQueueItem( const QString &fp, qint64 s, int v, qint64
 
 void MerginApi::reloadProjectRole( const QString &projectFullName )
 {
-  if ( projectFullName.isEmpty() || !isLoggedIn() )
-  {
+  if ( projectFullName.isEmpty() )
     return;
-  }
 
-  QNetworkReply *reply = getProjectInfo( projectFullName );
+  QNetworkReply *reply = getProjectInfo( projectFullName, mUserAuth->isLoggedIn() ); //withAuth depends on whether user is logged in or not
   if ( !reply )
     return;
 
@@ -4052,9 +4050,4 @@ void MerginApi::setNetworkManager( QNetworkAccessManager *manager )
   mManager = manager;
 
   emit networkManagerChanged();
-}
-
-bool MerginApi::isLoggedIn() const
-{
-  return mUserAuth->hasAuthData() && !mUserAuth->authToken().isEmpty() && !( mUserAuth->tokenExpiration() < QDateTime().currentDateTime().toUTC() );
 }

--- a/core/merginapi.cpp
+++ b/core/merginapi.cpp
@@ -4056,5 +4056,5 @@ void MerginApi::setNetworkManager( QNetworkAccessManager *manager )
 
 bool MerginApi::isLoggedIn() const
 {
-  return mUserAuth->hasAuthData() && !mUserAuth->authToken().isEmpty();
+  return mUserAuth->hasAuthData() && !mUserAuth->authToken().isEmpty() && !( mUserAuth->tokenExpiration() < QDateTime().currentDateTime().toUTC() );
 }

--- a/core/merginapi.h
+++ b/core/merginapi.h
@@ -593,6 +593,11 @@ class MerginApi: public QObject
      */
     void setNetworkManager( QNetworkAccessManager *manager );
 
+    /**
+     * Returns whether user is currently logged in
+    */
+    Q_INVOKABLE bool isLoggedIn() const;
+
   signals:
     void apiSupportsSubscriptionsChanged();
     void supportsSelectiveSyncChanged();

--- a/core/merginapi.h
+++ b/core/merginapi.h
@@ -593,11 +593,6 @@ class MerginApi: public QObject
      */
     void setNetworkManager( QNetworkAccessManager *manager );
 
-    /**
-     * Returns whether user is currently logged in
-    */
-    Q_INVOKABLE bool isLoggedIn() const;
-
   signals:
     void apiSupportsSubscriptionsChanged();
     void supportsSelectiveSyncChanged();

--- a/core/merginuserauth.cpp
+++ b/core/merginuserauth.cpp
@@ -134,3 +134,8 @@ bool MerginUserAuth::hasValidToken() const
 {
   return !mAuthToken.isEmpty() && mTokenExpiration >= QDateTime().currentDateTimeUtc();
 }
+
+bool MerginUserAuth::isLoggedIn()
+{
+  return hasAuthData() && hasValidToken();
+}

--- a/core/merginuserauth.h
+++ b/core/merginuserauth.h
@@ -38,6 +38,11 @@ class MerginUserAuth: public QObject
     //! i.e. we should be good to do authenticated requests.
     Q_INVOKABLE bool hasValidToken() const;
 
+    /**
+     * Returns whether user is currently logged in
+    */
+    Q_INVOKABLE bool isLoggedIn();
+
     void clear();
 
     QString username() const;


### PR DESCRIPTION
In `reloadProjectRole`, we check if user is logged with new method `isLoggedIn` before proceeding, preventing `missingAuthorizationError` and `MMMissingAuthDialog` from popping up.