### PR TITLE
Fix testDownloadProjectSpecChars

### DIFF
--- a/app/test/testmerginapi.cpp
+++ b/app/test/testmerginapi.cpp
@@ -241,7 +241,7 @@ void TestMerginApi::testDownloadProjectSpecChars()
   // Add special characters in the project file name
   QFile projectFile( projectDir + "/project.qgs" );
   QVERIFY( projectFile.exists() );
-  QString specChars( "+?%@&" );
+  QString specChars( "._- " );
   QString newProjectFileName = QString( "%1.qgs" ).arg( specChars );
   QVERIFY( projectFile.rename( projectDir + "/" + newProjectFileName ) );
 

--- a/app/test/testmerginapi.cpp
+++ b/app/test/testmerginapi.cpp
@@ -241,7 +241,7 @@ void TestMerginApi::testDownloadProjectSpecChars()
   // Add special characters in the project file name
   QFile projectFile( projectDir + "/project.qgs" );
   QVERIFY( projectFile.exists() );
-  QString specChars( "._- " );
+  QString specChars( "_-. " ); // can't start with dot or space
   QString newProjectFileName = QString( "%1.qgs" ).arg( specChars );
   QVERIFY( projectFile.rename( projectDir + "/" + newProjectFileName ) );
 


### PR DESCRIPTION
Changes in special characters in `testDownloadProjectSpecChars` reflecting server modifications. Newly supported characters: `_-. `. 