### PR TITLE
Online image preview support

### DIFF
--- a/app/icons/RemoteImageLoadError.svg
+++ b/app/icons/RemoteImageLoadError.svg
@@ -1,0 +1,5 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M7 14L10.2059 10.8807L13.8627 13.0312L15.4314 11.5156" stroke="#004C45" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M21 11.4375V17C21 19.2091 19.2091 21 17 21H12H7C4.79087 21 3 19.2091 3 17V9.75L3 7C3 4.79086 4.79086 3 7 3H12" stroke="#004C45" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M16 8H16.0054M16.0054 5.5C17.3861 5.5 18.5054 6.61929 18.5054 8M16 3C18.7614 3 21 5.23858 21 8" stroke="#004C45" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/app/icons/icons.qrc
+++ b/app/icons/icons.qrc
@@ -99,5 +99,6 @@
         <file>Student.svg</file>
         <file>Measure.svg</file>
         <file>CloseShape.svg</file>
+        <file>RemoteImageLoadError.svg</file>
     </qresource>
 </RCC>

--- a/app/inpututils.cpp
+++ b/app/inpututils.cpp
@@ -2293,8 +2293,3 @@ bool InputUtils::isValidUrl( const QString &link )
   QUrl url( link );
   return url.isValid();
 }
-
-bool InputUtils::isLocalFile( const QString &filePath )
-{
-  return filePath.startsWith( QStringLiteral( "file://" ) );
-}

--- a/app/inpututils.cpp
+++ b/app/inpututils.cpp
@@ -2289,8 +2289,4 @@ bool InputUtils::isValidUrl( const QString &link )
 {
   QUrl url( link );
   return url.isValid();
-
-  // should we check for https scheme?
-  // ( url.scheme().toLower() == QStringLiteral( "http" ) ||
-  // url.scheme().toLower() == QStringLiteral( "https" ) );
 }

--- a/app/inpututils.cpp
+++ b/app/inpututils.cpp
@@ -2288,6 +2288,9 @@ QgsMapLayer *InputUtils::mapLayerFromName( const QString &layerName, QgsProject 
 bool InputUtils::isValidUrl( const QString &link )
 {
   QUrl url( link );
-  return url.isValid() && ( url.scheme().toLower() == QStringLiteral( "http" ) ||
-                            url.scheme().toLower() == QStringLiteral( "https" ) );
+  return url.isValid();
+
+  // should we check for https scheme?
+  // ( url.scheme().toLower() == QStringLiteral( "http" ) ||
+  // url.scheme().toLower() == QStringLiteral( "https" ) );
 }

--- a/app/inpututils.cpp
+++ b/app/inpututils.cpp
@@ -2284,3 +2284,10 @@ QgsMapLayer *InputUtils::mapLayerFromName( const QString &layerName, QgsProject 
 
   return nullptr;
 }
+
+bool InputUtils::isValidUrl( const QString &link )
+{
+  QUrl url( link );
+  return url.isValid() && ( url.scheme().toLower() == QStringLiteral( "http" ) ||
+                            url.scheme().toLower() == QStringLiteral( "https" ) );
+}

--- a/app/inpututils.cpp
+++ b/app/inpututils.cpp
@@ -2287,6 +2287,9 @@ QgsMapLayer *InputUtils::mapLayerFromName( const QString &layerName, QgsProject 
 
 bool InputUtils::isValidUrl( const QString &link )
 {
+  if ( link.isEmpty() )
+    return false;
+
   QUrl url( link );
   return url.isValid();
 }

--- a/app/inpututils.cpp
+++ b/app/inpututils.cpp
@@ -2293,3 +2293,8 @@ bool InputUtils::isValidUrl( const QString &link )
   QUrl url( link );
   return url.isValid();
 }
+
+bool InputUtils::isLocalFile( const QString &filePath )
+{
+  return filePath.startsWith( QStringLiteral( "file://" ) );
+}

--- a/app/inpututils.h
+++ b/app/inpututils.h
@@ -620,11 +620,6 @@ class InputUtils: public QObject
      */
     Q_INVOKABLE static bool isValidUrl( const QString &link );
 
-    /**
-     * Checks whether the given file path starts with "file://"
-     */
-    Q_INVOKABLE static bool isLocalFile( const QString &filePath );
-
   public slots:
     void onQgsLogMessageReceived( const QString &message, const QString &tag, Qgis::MessageLevel level );
 

--- a/app/inpututils.h
+++ b/app/inpututils.h
@@ -615,6 +615,11 @@ class InputUtils: public QObject
      */
     static QgsMapLayer *mapLayerFromName( const QString &layerName, QgsProject *project );
 
+    /**
+     * Checks if the given string is a valid URL with "http" and "https" schemes
+     */
+    Q_INVOKABLE static bool isValidUrl( const QString &link );
+
   public slots:
     void onQgsLogMessageReceived( const QString &message, const QString &tag, Qgis::MessageLevel level );
 

--- a/app/inpututils.h
+++ b/app/inpututils.h
@@ -620,6 +620,11 @@ class InputUtils: public QObject
      */
     Q_INVOKABLE static bool isValidUrl( const QString &link );
 
+    /**
+     * Checks whether the given file path starts with "file://"
+     */
+    Q_INVOKABLE static bool isLocalFile( const QString &filePath );
+
   public slots:
     void onQgsLogMessageReceived( const QString &message, const QString &tag, Qgis::MessageLevel level );
 

--- a/app/inpututils.h
+++ b/app/inpututils.h
@@ -616,7 +616,7 @@ class InputUtils: public QObject
     static QgsMapLayer *mapLayerFromName( const QString &layerName, QgsProject *project );
 
     /**
-     * Checks if the given string is a valid URL with "http" and "https" schemes
+     * Checks if the given string is a valid URL
      */
     Q_INVOKABLE static bool isValidUrl( const QString &link );
 

--- a/app/mmstyle.h
+++ b/app/mmstyle.h
@@ -426,6 +426,7 @@ class MMStyle: public QObject
     QUrl moreIcon() const {return QUrl( "qrc:/More.svg" );}
     QUrl moreVerticalIcon() const {return QUrl( "qrc:/MoreVertical.svg" );}
     QUrl morePhotosIcon() const {return QUrl( "qrc:/MorePhotos.svg" );}
+    QUrl remoteImageLoadErrorIcon() const {return QUrl( "qrc:/RemoteImageLoadError.svg" );}
     QUrl mouthIcon() const {return QUrl( "qrc:/Mouth.svg" );}
     QUrl measurementToolIcon() const {return QUrl( "qrc:/Measure.svg" );}
     QUrl closeShapeIcon() const {return QUrl( "qrc:/CloseShape.svg" );}

--- a/app/mmstyle.h
+++ b/app/mmstyle.h
@@ -130,6 +130,7 @@ class MMStyle: public QObject
     Q_PROPERTY( QUrl moreIcon READ moreIcon CONSTANT )
     Q_PROPERTY( QUrl moreVerticalIcon READ moreVerticalIcon CONSTANT )
     Q_PROPERTY( QUrl morePhotosIcon READ morePhotosIcon CONSTANT )
+    Q_PROPERTY( QUrl remoteImageLoadErrorIcon READ remoteImageLoadErrorIcon CONSTANT )
     Q_PROPERTY( QUrl mouthIcon READ mouthIcon CONSTANT )
     Q_PROPERTY( QUrl naturalResourcesIcon READ naturalResourcesIcon CONSTANT )
     Q_PROPERTY( QUrl nextIcon READ nextIcon CONSTANT )
@@ -231,7 +232,6 @@ class MMStyle: public QObject
     Q_PROPERTY( QUrl crosshairForegroundImage READ crosshairForegroundImage CONSTANT )
     Q_PROPERTY( QUrl crosshairPlusImage READ crosshairPlusImage CONSTANT )
     Q_PROPERTY( QUrl noWorkspaceImage READ noWorkspaceImage CONSTANT )
-
 
     /*
      * Pixel sizes used across the app

--- a/app/qml/components/MMPhoto.qml
+++ b/app/qml/components/MMPhoto.qml
@@ -10,6 +10,8 @@
 import QtQuick
 import QtQuick.Controls
 import Qt5Compat.GraphicalEffects
+
+import "../components" as MMComponents
 import "."
 
 Image {
@@ -39,22 +41,28 @@ Image {
     }
   }
 
-  Rectangle {
-    anchors.fill: parent
-    color: __style.polarColor
-    z: -1
+  // Rectangle {
+  //   anchors.fill: parent
+  //   color: __style.polarColor
+  //   z: -1
 
-    MMIcon {
-      anchors.centerIn: parent
-      source: __style.morePhotosIcon
-      color: __style.mediumGreenColor
-      size: __style.icon32
-    }
-  }
+  //   MMIcon {
+  //     anchors.centerIn: parent
+  //     source: __style.morePhotosIcon
+  //     color: __style.mediumGreenColor
+  //     size: __style.icon32
+  //   }
+  // }
 
   MMSingleClickMouseArea {
     anchors.fill: parent
     onSingleClicked: root.clicked(root.photoUrl)
+  }
+
+  MMComponents.MMBusyIndicator {
+    id: busyIndicator
+    anchors.centerIn: parent
+    visible: root.photoUrl.status === Image.Loading
   }
 
   onStatusChanged: {

--- a/app/qml/components/MMPhoto.qml
+++ b/app/qml/components/MMPhoto.qml
@@ -18,6 +18,7 @@ Image {
   id: root
 
   property url photoUrl
+  property bool isLocalFile: true
 
   signal clicked( var path )
 
@@ -49,7 +50,7 @@ Image {
 
     MMIcon {
       anchors.centerIn: parent
-      source: ( root.photoUrl && __inputUtils.isLocalFile( root.photoUrl ) ) ? __style.morePhotosIcon : __style.remoteImageLoadErrorIcon
+      source: root.photoUrl && root.isLocalFile ? __style.morePhotosIcon : __style.remoteImageLoadErrorIcon
       color: __style.mediumGreenColor
       size: __style.icon32
     }

--- a/app/qml/components/MMPhoto.qml
+++ b/app/qml/components/MMPhoto.qml
@@ -49,7 +49,7 @@ Image {
 
     MMIcon {
       anchors.centerIn: parent
-      source: ( root.photoUrl && root.photoUrl.startsWith( "file://" ) ) ? __style.morePhotosIcon : __style.morePhotosIcon //__style.loadingImageErrorIcon
+      source: ( root.photoUrl && __inputUtils.isLocalFile( root.photoUrl ) ) ? __style.morePhotosIcon : __style.remoteImageLoadErrorIcon
       color: __style.mediumGreenColor
       size: __style.icon32
     }

--- a/app/qml/components/MMPhoto.qml
+++ b/app/qml/components/MMPhoto.qml
@@ -68,7 +68,6 @@ Image {
 
   onStatusChanged: {
     if (status === Image.Error) {
-      __notificationModel.addError( "Could not load the image. The file may not exist, could be invalid, or the URL might be incorrect: " + root.photoUrl );
       console.error("MMPhoto: Error loading image: " + root.photoUrl);
     }
   }

--- a/app/qml/components/MMPhoto.qml
+++ b/app/qml/components/MMPhoto.qml
@@ -68,6 +68,7 @@ Image {
 
   onStatusChanged: {
     if (status === Image.Error) {
+      __notificationModel.addError( "Could not load the image. The file may not exist, could be invalid, or the URL might be incorrect: " + root.photoUrl );
       console.error("MMPhoto: Error loading image: " + root.photoUrl);
     }
   }

--- a/app/qml/components/MMPhoto.qml
+++ b/app/qml/components/MMPhoto.qml
@@ -49,7 +49,7 @@ Image {
 
     MMIcon {
       anchors.centerIn: parent
-      source: __style.morePhotosIcon
+      source: ( root.photoUrl && root.photoUrl.startsWith( "file://" ) ) ? __style.morePhotosIcon : __style.morePhotosIcon //__style.loadingImageErrorIcon
       color: __style.mediumGreenColor
       size: __style.icon32
     }

--- a/app/qml/components/MMPhoto.qml
+++ b/app/qml/components/MMPhoto.qml
@@ -41,18 +41,19 @@ Image {
     }
   }
 
-  // Rectangle {
-  //   anchors.fill: parent
-  //   color: __style.polarColor
-  //   z: -1
+  Rectangle {
+    anchors.fill: parent
+    color: __style.polarColor
+    z: -1
+    visible: root.status === Image.Error // if image has transparent background, we would still see it
 
-  //   MMIcon {
-  //     anchors.centerIn: parent
-  //     source: __style.morePhotosIcon
-  //     color: __style.mediumGreenColor
-  //     size: __style.icon32
-  //   }
-  // }
+    MMIcon {
+      anchors.centerIn: parent
+      source: __style.morePhotosIcon
+      color: __style.mediumGreenColor
+      size: __style.icon32
+    }
+  }
 
   MMSingleClickMouseArea {
     anchors.fill: parent
@@ -62,7 +63,7 @@ Image {
   MMComponents.MMBusyIndicator {
     id: busyIndicator
     anchors.centerIn: parent
-    visible: root.photoUrl.status === Image.Loading
+    visible: root.status === Image.Loading
   }
 
   onStatusChanged: {

--- a/app/qml/form/editors/MMFormPhotoEditor.qml
+++ b/app/qml/form/editors/MMFormPhotoEditor.qml
@@ -131,6 +131,7 @@ MMFormPhotoViewer {
     function resetValueAndClose() {
       root.editorValueChanged( "", true )
 
+      errorMsg = ""
       imagePath = ""
       close()
     }

--- a/app/qml/form/editors/MMFormPhotoEditor.qml
+++ b/app/qml/form/editors/MMFormPhotoEditor.qml
@@ -87,11 +87,11 @@ MMFormPhotoViewer {
   hasCheckbox: _fieldRememberValueSupported
   checkboxChecked: _fieldRememberValueState
 
-  photoUrl: internal.absoluteImagePath
+  photoUrl: internal.resolvedImageSource
   hasCameraCapability: __androidUtils.isAndroid || __iosUtils.isIos
 
-  on_FieldValueChanged: internal.setAbsoluteImagePath()
-  on_FieldValueIsNullChanged: internal.setAbsoluteImagePath()
+  on_FieldValueChanged: internal.setImageSource()
+  on_FieldValueIsNullChanged: internal.setImageSource()
 
   onCapturePhotoClicked: internal.capturePhoto()
   onChooseFromGalleryClicked: internal.chooseFromGallery()
@@ -199,18 +199,19 @@ MMFormPhotoViewer {
                                             targetDir
                                             )
 
-    property string absoluteImagePath
+    property string resolvedImageSource
 
     property string imageSourceToDelete // used to postpone image deletion to when the form is saved
 
     //
-    // Sets path of the assigned photo to the absoluteImagePath.
-    //  - absoluteImagePath is the actual path on the device and is used by QML Image to show the image
+    // Sets path or url of the assigned photo to the resolvedImageSource.
+    //  - resolvedImageSource is the actual path on the device or a remote url,
+    //  - and is used by QML Image to show the image
     //
-    function setAbsoluteImagePath() {
+    function setImageSource() {
       if ( !root._fieldValue || root._fieldValueIsNull ) {
         root.photoState = "notSet"
-        absoluteImagePath = ""
+        resolvedImageSource = ""
         return
       }
 
@@ -218,15 +219,15 @@ MMFormPhotoViewer {
 
       if ( __inputUtils.fileExists( absolutePath ) ) {
         root.photoState = "valid"
-        absoluteImagePath = "file://" + absolutePath
+        resolvedImageSource = "file://" + absolutePath
       }
       else if ( __inputUtils.isValidUrl( absolutePath ) ) {
           root.photoState = "valid";
-          absoluteImagePath = absolutePath;
+          resolvedImageSource = absolutePath;
       }
       else {
         root.photoState = "notAvailable"
-        absoluteImagePath = ""
+        resolvedImageSource = ""
       }
     }
 

--- a/app/qml/form/editors/MMFormPhotoEditor.qml
+++ b/app/qml/form/editors/MMFormPhotoEditor.qml
@@ -208,15 +208,21 @@ MMFormPhotoViewer {
     //  - absoluteImagePath is the actual path on the device and is used by QML Image to show the image
     //
     function setAbsoluteImagePath() {
-      let absolutePath = __inputUtils.getAbsolutePath( root._fieldValue, internal.prefixToRelativePath )
-
       if ( !root._fieldValue || root._fieldValueIsNull ) {
         root.photoState = "notSet"
         absoluteImagePath = ""
+        return
       }
-      else if ( root._fieldValue && __inputUtils.fileExists( absolutePath ) ) {
+
+      let absolutePath = __inputUtils.getAbsolutePath( root._fieldValue, internal.prefixToRelativePath )
+
+      if ( __inputUtils.fileExists( absolutePath ) ) {
         root.photoState = "valid"
         absoluteImagePath = "file://" + absolutePath
+      }
+      else if ( __inputUtils.isValidUrl( absolutePath ) ) {
+          root.photoState = "valid";
+          absoluteImagePath = absolutePath;
       }
       else {
         root.photoState = "notAvailable"

--- a/app/qml/form/editors/MMFormPhotoViewer.qml
+++ b/app/qml/form/editors/MMFormPhotoViewer.qml
@@ -69,11 +69,14 @@ MMPrivateComponents.MMBaseInput {
       visible: photoStateGroup.state !== "notSet"
 
       photoUrl: root.photoUrl
+      isLocalFile: String( root.photoUrl ).startsWith( "file://" )
+
       fillMode: Image.PreserveAspectCrop
 
       onStatusChanged: {
       if ( status === Image.Error ) {
-          root.errorMsg = "Unable to load the image. It may be missing or invalid, the URL might be incorrect, or there may be no network connection: " + root.photoUrl;
+          __inputUtils.log( "Image Loading", "Could not load the image. It may be missing or invalid, the URL might be incorrect, or there may be no network connection: " + root.photoUrl )
+          root.errorMsg = "Could not load the image."
         }
       }
 

--- a/app/qml/form/editors/MMFormPhotoViewer.qml
+++ b/app/qml/form/editors/MMFormPhotoViewer.qml
@@ -71,6 +71,12 @@ MMPrivateComponents.MMBaseInput {
       photoUrl: root.photoUrl
       fillMode: Image.PreserveAspectCrop
 
+      onStatusChanged: {
+      if ( status === Image.Error ) {
+          root.errorMsg = "Unable to load the image. It may be missing or invalid, the URL might be incorrect, or there may be no network connection: " + root.photoUrl;
+        }
+      }
+
       MouseArea {
         anchors.fill: parent
         onClicked: {

--- a/app/qml/form/editors/MMFormPhotoViewer.qml
+++ b/app/qml/form/editors/MMFormPhotoViewer.qml
@@ -76,7 +76,6 @@ MMPrivateComponents.MMBaseInput {
       onStatusChanged: {
       if ( status === Image.Error ) {
           __inputUtils.log( "Image Loading", "Could not load the image. It may be missing or invalid, the URL might be incorrect, or there may be no network connection: " + root.photoUrl )
-          root.errorMsg = "Could not load the image."
         }
       }
 

--- a/app/qml/form/editors/MMFormPhotoViewer.qml
+++ b/app/qml/form/editors/MMFormPhotoViewer.qml
@@ -24,7 +24,7 @@ import "../components/photo" as MMPhotoComponents
 MMPrivateComponents.MMBaseInput {
   id: root
 
-  property url photoUrl: ""
+  property string photoUrl: ""
   property bool hasCameraCapability: true
 
   property var photoComponent: photo
@@ -69,7 +69,7 @@ MMPrivateComponents.MMBaseInput {
       visible: photoStateGroup.state !== "notSet"
 
       photoUrl: root.photoUrl
-      isLocalFile: String( root.photoUrl ).startsWith( "file://" )
+      isLocalFile: root.photoUrl.startsWith( "file://" )
 
       fillMode: Image.PreserveAspectCrop
 

--- a/app/test/testutils.cpp
+++ b/app/test/testutils.cpp
@@ -340,3 +340,21 @@ void TestUtils::testIsValidUrl()
   QVERIFY( !InputUtils::isValidUrl( "http://exa mple.com" ) );
   QVERIFY( !InputUtils::isValidUrl( "" ) ); // empty url is considered valid by QUrl but not by us
 }
+
+void TestUtils::testIsLocalFile()
+{
+  // file starting with "file://"
+  QCOMPARE( InputUtils::isLocalFile( "file://C:/path/to/file.txt" ), true );
+
+  // HTTP URL should return false
+  QCOMPARE( InputUtils::isLocalFile( "http://example.com/file.txt" ), false );
+
+  // relative file path should return false
+  QCOMPARE( InputUtils::isLocalFile( "/path/to/file.txt" ), false );
+
+  // empty string returns false
+  QCOMPARE( InputUtils::isLocalFile( "" ), false );
+
+  // ("FILE://") should return false due to case sensitivity
+  QCOMPARE( InputUtils::isLocalFile( "FILE://C:/path/to/file.txt" ), false );
+}

--- a/app/test/testutils.cpp
+++ b/app/test/testutils.cpp
@@ -340,21 +340,3 @@ void TestUtils::testIsValidUrl()
   QVERIFY( !InputUtils::isValidUrl( "http://exa mple.com" ) );
   QVERIFY( !InputUtils::isValidUrl( "" ) ); // empty url is considered valid by QUrl but not by us
 }
-
-void TestUtils::testIsLocalFile()
-{
-  // file starting with "file://"
-  QCOMPARE( InputUtils::isLocalFile( "file://C:/path/to/file.txt" ), true );
-
-  // HTTP URL should return false
-  QCOMPARE( InputUtils::isLocalFile( "http://example.com/file.txt" ), false );
-
-  // relative file path should return false
-  QCOMPARE( InputUtils::isLocalFile( "/path/to/file.txt" ), false );
-
-  // empty string returns false
-  QCOMPARE( InputUtils::isLocalFile( "" ), false );
-
-  // ("FILE://") should return false due to case sensitivity
-  QCOMPARE( InputUtils::isLocalFile( "FILE://C:/path/to/file.txt" ), false );
-}

--- a/app/test/testutils.cpp
+++ b/app/test/testutils.cpp
@@ -332,11 +332,11 @@ void TestUtils::testIsValidUrl()
   QVERIFY( InputUtils::isValidUrl( "https://example.com/path?query=1" ) );
   QVERIFY( InputUtils::isValidUrl( "ftp://ftp.example.com/resource" ) );
   QVERIFY( InputUtils::isValidUrl( "www.example.com" ) );
-  QVERIFY( InputUtils::isValidUrl( "" ) ); // empty url is considered valid by QUrl
 
   // invalid urls
   QVERIFY( !InputUtils::isValidUrl( "htp://www.example.com" ) );
   QVERIFY( !InputUtils::isValidUrl( "http//missingcolon.com" ) );
   QVERIFY( !InputUtils::isValidUrl( "://example.com" ) );
   QVERIFY( !InputUtils::isValidUrl( "http://exa mple.com" ) );
+  QVERIFY( !InputUtils::isValidUrl( "" ) ); // empty url is considered valid by QUrl but not by us
 }

--- a/app/test/testutils.cpp
+++ b/app/test/testutils.cpp
@@ -324,3 +324,19 @@ void TestUtils::testMapLayerFromName()
 
   delete project;
 }
+
+void TestUtils::testIsValidUrl()
+{
+  // valid urls
+  QVERIFY( InputUtils::isValidUrl( "http://www.example.com" ) );
+  QVERIFY( InputUtils::isValidUrl( "https://example.com/path?query=1" ) );
+  QVERIFY( InputUtils::isValidUrl( "ftp://ftp.example.com/resource" ) );
+  QVERIFY( InputUtils::isValidUrl( "www.example.com" ) );
+  QVERIFY( InputUtils::isValidUrl( "" ) ); // empty url is considered valid by QUrl
+
+  // invalid urls
+  QVERIFY( !InputUtils::isValidUrl( "htp://www.example.com" ) );
+  QVERIFY( !InputUtils::isValidUrl( "http//missingcolon.com" ) );
+  QVERIFY( !InputUtils::isValidUrl( "://example.com" ) );
+  QVERIFY( !InputUtils::isValidUrl( "http://exa mple.com" ) );
+}

--- a/app/test/testutils.h
+++ b/app/test/testutils.h
@@ -63,6 +63,7 @@ namespace TestUtils
   void testRecordingAllowed();
   void testMapLayerFromName();
   void testIsValidUrl();
+  void testIsLocalFile();
 }
 
 #define COMPARENEAR(actual, expected, epsilon) \

--- a/app/test/testutils.h
+++ b/app/test/testutils.h
@@ -62,6 +62,7 @@ namespace TestUtils
   void testIsPositionTrackingLayer();
   void testRecordingAllowed();
   void testMapLayerFromName();
+  void testIsValidUrl();
 }
 
 #define COMPARENEAR(actual, expected, epsilon) \

--- a/app/test/testutils.h
+++ b/app/test/testutils.h
@@ -63,7 +63,6 @@ namespace TestUtils
   void testRecordingAllowed();
   void testMapLayerFromName();
   void testIsValidUrl();
-  void testIsLocalFile();
 }
 
 #define COMPARENEAR(actual, expected, epsilon) \

--- a/gallery/qml/pages/IconsPage.qml
+++ b/gallery/qml/pages/IconsPage.qml
@@ -74,6 +74,7 @@ ScrollView {
             GalleryComponents.IconLine { name: "moreIcon"; source: __style.moreIcon; showRect: checkboxBorder.checked; invertColors: checkboxColor.checked }
             GalleryComponents.IconLine { name: "moreVerticalIcon"; source: __style.moreVerticalIcon; showRect: checkboxBorder.checked; invertColors: checkboxColor.checked }
             GalleryComponents.IconLine { name: "morePhotosIcon"; source: __style.morePhotosIcon; showRect: checkboxBorder.checked; invertColors: checkboxColor.checked }
+            GalleryComponents.IconLine { name: "remoteImageLoadErrorIcon"; source: __style.remoteImageLoadErrorIcon; showRect: checkboxBorder.checked; invertColors: checkboxColor.checked }
             GalleryComponents.IconLine { name: "plusIcon"; source: __style.plusIcon; showRect: checkboxBorder.checked; invertColors: checkboxColor.checked }
             GalleryComponents.IconLine { name: "positionTrackingIcon"; source: __style.positionTrackingIcon; showRect: checkboxBorder.checked; invertColors: checkboxColor.checked }
             GalleryComponents.IconLine { name: "measurementToolIcon"; source: __style.measurementToolIcon; showRect: checkboxBorder.checked; invertColors: checkboxColor.checked }


### PR DESCRIPTION
When loading a photo, we now also verify if it's a url. If the url is valid, we consider it a valid image and proceed to load it. Since some urls might take longer to load, which is beyond our control, a `MMBusyIndicator` has been added to `MMPhoto` to enhance user experience in cases where loading images from urls might take a while.


https://github.com/user-attachments/assets/810a6e98-955f-4b70-b66a-2bc64040d051

| Remote image loading with error |
|--------|
<img src="https://github.com/user-attachments/assets/a2d92c51-cbb1-4f7a-9c60-1a177ee58caa" width="300"> |


Resolves #2718