### PR TITLE
Fix permanently pending synchronization issue for projects with selective sync enabled

### DIFF
--- a/app/projectsmodel.cpp
+++ b/app/projectsmodel.cpp
@@ -95,7 +95,7 @@ QVariant ProjectsModel::data( const QModelIndex &index, int role ) const
         }
         else
         {
-          ProjectStatus::Status status = ProjectStatus::projectStatus( project );
+          ProjectStatus::Status status = ProjectStatus::projectStatus( project, mBackend->supportsSelectiveSync() );
 
           if ( status == ProjectStatus::NeedsSync )
           {
@@ -285,7 +285,7 @@ void ProjectsModel::mergeProjects( const MerginProjectsList &merginProjects, Mer
       if ( res != merginProjects.end() )
       {
         project.mergin = *res;
-        project.mergin.status = ProjectStatus::projectStatus( project );
+        project.mergin.status = ProjectStatus::projectStatus( project, mBackend->supportsSelectiveSync() );
       }
       else if ( project.local.hasMerginMetadata() )
       {
@@ -295,7 +295,7 @@ void ProjectsModel::mergeProjects( const MerginProjectsList &merginProjects, Mer
         // (listProjectsByName API limits response to max 50 projects)
         project.mergin.projectName = project.local.projectName;
         project.mergin.projectNamespace = project.local.projectNamespace;
-        project.mergin.status = ProjectStatus::projectStatus( project );
+        project.mergin.status = ProjectStatus::projectStatus( project, mBackend->supportsSelectiveSync() );
       }
 
       mProjects << project;
@@ -317,7 +317,7 @@ void ProjectsModel::mergeProjects( const MerginProjectsList &merginProjects, Mer
         Project project;
 
         MerginApi::extractProjectName( pendingProjectName, project.mergin.projectNamespace, project.mergin.projectName );
-        project.mergin.status = ProjectStatus::projectStatus( project );
+        project.mergin.status = ProjectStatus::projectStatus( project, mBackend->supportsSelectiveSync() );
 
         mProjects << project;
       }
@@ -340,7 +340,7 @@ void ProjectsModel::mergeProjects( const MerginProjectsList &merginProjects, Mer
       {
         project.local = *match;
       }
-      project.mergin.status = ProjectStatus::projectStatus( project );
+      project.mergin.status = ProjectStatus::projectStatus( project, mBackend->supportsSelectiveSync() );
 
       mProjects << project;
     }
@@ -429,7 +429,7 @@ void ProjectsModel::onProjectSyncFinished( const QString &projectFullName, bool 
     project.mergin.serverVersion = newVersion;
   }
 
-  project.mergin.status = ProjectStatus::projectStatus( project );
+  project.mergin.status = ProjectStatus::projectStatus( project, mBackend->supportsSelectiveSync() );
 
   QModelIndex changeIndex = index( ix );
   emit dataChanged( changeIndex, changeIndex, { ProjectSyncPending, ProjectSyncProgress, ProjectStatus } );
@@ -474,7 +474,7 @@ void ProjectsModel::onProjectAdded( const LocalProject &localProject )
     project.local = localProject;
     if ( project.isMergin() )
     {
-      project.mergin.status = ProjectStatus::projectStatus( project );
+      project.mergin.status = ProjectStatus::projectStatus( project, mBackend->supportsSelectiveSync() );
     }
 
     QModelIndex modelIx = index( ix );
@@ -510,7 +510,7 @@ void ProjectsModel::onAboutToRemoveProject( const LocalProject &localProject )
     {
       // just remove local part
       mProjects[ix].local = LocalProject();
-      mProjects[ix].mergin.status = ProjectStatus::projectStatus( mProjects[ix] );
+      mProjects[ix].mergin.status = ProjectStatus::projectStatus( mProjects[ix], mBackend->supportsSelectiveSync() );
 
       QModelIndex modelIx = index( ix );
       emit dataChanged( modelIx, modelIx );
@@ -531,7 +531,7 @@ void ProjectsModel::onProjectDataChanged( const LocalProject &localProject )
 
   if ( project.isMergin() )
   {
-    project.mergin.status = ProjectStatus::projectStatus( project );
+    project.mergin.status = ProjectStatus::projectStatus( project, mBackend->supportsSelectiveSync() );
   }
 
   QModelIndex editIndex = index( ix );

--- a/app/synchronizationmanager.cpp
+++ b/app/synchronizationmanager.cpp
@@ -83,7 +83,7 @@ void SynchronizationManager::syncProject( const LocalProject &project, SyncOptio
 
   bool syncHasStarted = false;
 
-  if ( ProjectStatus::hasLocalChanges( project ) )
+  if ( ProjectStatus::hasLocalChanges( project, mMerginApi->supportsSelectiveSync() ) )
   {
     syncHasStarted = mMerginApi->pushProject( project.projectNamespace, project.projectName );
   }

--- a/app/test/testmerginapi.cpp
+++ b/app/test/testmerginapi.cpp
@@ -764,7 +764,7 @@ void TestMerginApi::testPushNoChanges()
   QCOMPARE( project2.mergin.status, ProjectStatus::UpToDate );
 
   QCOMPARE( MerginApi::localProjectChanges( projectDir ), ProjectDiff() );
-  QVERIFY( !MerginApi::hasLocalProjectChanges( projectDir ) );
+  QVERIFY( !MerginApi::hasLocalProjectChanges( projectDir, mApi->supportsSelectiveSync() ) );
 }
 
 void TestMerginApi::testUpdateAddedFile()
@@ -1103,7 +1103,7 @@ void TestMerginApi::testDiffUpload()
   QVERIFY( QFileInfo::exists( projectDir + "/.mergin/base.gpkg" ) );
 
   QCOMPARE( MerginApi::localProjectChanges( projectDir ), ProjectDiff() );  // no local changes expected
-  QVERIFY( !MerginApi::hasLocalProjectChanges( projectDir ) );
+  QVERIFY( !MerginApi::hasLocalProjectChanges( projectDir, mApi->supportsSelectiveSync() ) );
 
   // replace gpkg with a new version with a modified geometry
   // but make sure time it gets a different timestamp or its checksum will be read from the cache
@@ -1115,7 +1115,7 @@ void TestMerginApi::testDiffUpload()
   ProjectDiff expectedDiff;
   expectedDiff.localUpdated = QSet<QString>() << "base.gpkg";
   QVERIFY2( diff == expectedDiff, diff.dump().toStdString().c_str() );
-  QVERIFY( MerginApi::hasLocalProjectChanges( projectDir ) );
+  QVERIFY( MerginApi::hasLocalProjectChanges( projectDir, mApi->supportsSelectiveSync() ) );
 
   GeodiffUtils::ChangesetSummary expectedSummary;
   expectedSummary["simple"] = GeodiffUtils::TableSummary( 0, 1, 0 );
@@ -1126,7 +1126,7 @@ void TestMerginApi::testDiffUpload()
   uploadRemoteProject( mApi, mWorkspaceName, projectName );
 
   QCOMPARE( MerginApi::localProjectChanges( projectDir ), ProjectDiff() );  // no local changes expected
-  QVERIFY( !MerginApi::hasLocalProjectChanges( projectDir ) );
+  QVERIFY( !MerginApi::hasLocalProjectChanges( projectDir, mApi->supportsSelectiveSync() ) );
 }
 
 void TestMerginApi::testDiffSubdirsUpload()
@@ -1142,7 +1142,7 @@ void TestMerginApi::testDiffSubdirsUpload()
   QVERIFY( QFileInfo::exists( projectDir + "/.mergin/" + base ) );
 
   QCOMPARE( MerginApi::localProjectChanges( projectDir ), ProjectDiff() );  // no local changes expected
-  QVERIFY( !MerginApi::hasLocalProjectChanges( projectDir ) );
+  QVERIFY( !MerginApi::hasLocalProjectChanges( projectDir, mApi->supportsSelectiveSync() ) );
 
   // replace gpkg with a new version with a modified geometry
   // but make sure time it gets a different timestamp or its checksum will be read from the cache
@@ -1154,7 +1154,7 @@ void TestMerginApi::testDiffSubdirsUpload()
   ProjectDiff expectedDiff;
   expectedDiff.localUpdated = QSet<QString>() << base ;
   QVERIFY2( diff == expectedDiff, diff.dump().toStdString().c_str() );
-  QVERIFY( MerginApi::hasLocalProjectChanges( projectDir ) );
+  QVERIFY( MerginApi::hasLocalProjectChanges( projectDir, mApi->supportsSelectiveSync() ) );
 
   GeodiffUtils::ChangesetSummary expectedSummary;
   expectedSummary["simple"] = GeodiffUtils::TableSummary( 0, 1, 0 );
@@ -1165,7 +1165,7 @@ void TestMerginApi::testDiffSubdirsUpload()
   uploadRemoteProject( mApi, mWorkspaceName, projectName );
 
   QCOMPARE( MerginApi::localProjectChanges( projectDir ), ProjectDiff() );  // no local changes expected
-  QVERIFY( !MerginApi::hasLocalProjectChanges( projectDir ) );
+  QVERIFY( !MerginApi::hasLocalProjectChanges( projectDir, mApi->supportsSelectiveSync() ) );
 }
 
 void TestMerginApi::testDiffUpdateBasic()
@@ -1183,7 +1183,7 @@ void TestMerginApi::testDiffUpdateBasic()
 
   QVERIFY( QFileInfo::exists( projectDir + "/.mergin/base.gpkg" ) );
   QCOMPARE( MerginApi::localProjectChanges( projectDir ), ProjectDiff() );  // no local changes expected
-  QVERIFY( !MerginApi::hasLocalProjectChanges( projectDir ) );
+  QVERIFY( !MerginApi::hasLocalProjectChanges( projectDir, mApi->supportsSelectiveSync() ) );
 
   QgsVectorLayer *vl0 = new QgsVectorLayer( projectDir + "/base.gpkg|layername=simple", "base", "ogr" );
   QVERIFY( vl0->isValid() );
@@ -1213,7 +1213,7 @@ void TestMerginApi::testDiffUpdateBasic()
   delete vl;
 
   QCOMPARE( MerginApi::localProjectChanges( projectDir ), ProjectDiff() );  // no local changes expected
-  QVERIFY( !MerginApi::hasLocalProjectChanges( projectDir ) );
+  QVERIFY( !MerginApi::hasLocalProjectChanges( projectDir, mApi->supportsSelectiveSync() ) );
 
   QVERIFY( !GeodiffUtils::hasPendingChanges( projectDir, "base.gpkg" ) );
 }
@@ -1233,7 +1233,7 @@ void TestMerginApi::testDiffUpdateWithRebase()
 
   QVERIFY( QFileInfo::exists( projectDir + "/.mergin/base.gpkg" ) );
   QCOMPARE( MerginApi::localProjectChanges( projectDir ), ProjectDiff() );  // no local changes expected
-  QVERIFY( !MerginApi::hasLocalProjectChanges( projectDir ) );
+  QVERIFY( !MerginApi::hasLocalProjectChanges( projectDir, mApi->supportsSelectiveSync() ) );
 
   //
   // download with mApiExtra + modify + upload
@@ -1267,7 +1267,7 @@ void TestMerginApi::testDiffUpdateWithRebase()
   ProjectDiff expectedDiff;
   expectedDiff.localUpdated = QSet<QString>() << "base.gpkg";
   QCOMPARE( diff, expectedDiff );
-  QVERIFY( MerginApi::hasLocalProjectChanges( projectDir ) );
+  QVERIFY( MerginApi::hasLocalProjectChanges( projectDir, mApi->supportsSelectiveSync() ) );
 
   // check that geodiff knows there was one added feature
   GeodiffUtils::ChangesetSummary expectedSummary;
@@ -1291,7 +1291,7 @@ void TestMerginApi::testDiffUpdateWithRebase()
   // like before the update - there should be locally modified base.gpkg with the changes we did
   QCOMPARE( MerginApi::localProjectChanges( projectDir ), expectedDiff );
   QCOMPARE( GeodiffUtils::parseChangesetSummary( changes ), expectedSummary );
-  QVERIFY( MerginApi::hasLocalProjectChanges( projectDir ) );
+  QVERIFY( MerginApi::hasLocalProjectChanges( projectDir, mApi->supportsSelectiveSync() ) );
 }
 
 void TestMerginApi::testDiffUpdateWithRebaseFailed()
@@ -1312,7 +1312,7 @@ void TestMerginApi::testDiffUpdateWithRebaseFailed()
 
   QVERIFY( QFileInfo::exists( projectDir + "/.mergin/base.gpkg" ) );
   QCOMPARE( MerginApi::localProjectChanges( projectDir ), ProjectDiff() );  // no local changes expected
-  QVERIFY( !MerginApi::hasLocalProjectChanges( projectDir ) );
+  QVERIFY( !MerginApi::hasLocalProjectChanges( projectDir, mApi->supportsSelectiveSync() ) );
 
   //
   // download with mApiExtra + modify + upload
@@ -1338,7 +1338,7 @@ void TestMerginApi::testDiffUpdateWithRebaseFailed()
   expectedDiff.localUpdated = QSet<QString>() << "base.gpkg";
   qDebug() << diff.dump();
   QCOMPARE( diff, expectedDiff );
-  QVERIFY( MerginApi::hasLocalProjectChanges( projectDir ) );
+  QVERIFY( MerginApi::hasLocalProjectChanges( projectDir, mApi->supportsSelectiveSync() ) );
 
   // check that geodiff knows there was one added feature
   QString changes = GeodiffUtils::diffableFilePendingChanges( projectDir, "base.gpkg", true );
@@ -1364,7 +1364,7 @@ void TestMerginApi::testDiffUpdateWithRebaseFailed()
   ProjectDiff expectedDiffFinal;
   expectedDiffFinal.localAdded = QSet<QString>() << conflictFilename;
   QCOMPARE( MerginApi::localProjectChanges( projectDir ), expectedDiffFinal );
-  QVERIFY( MerginApi::hasLocalProjectChanges( projectDir ) );
+  QVERIFY( MerginApi::hasLocalProjectChanges( projectDir, mApi->supportsSelectiveSync() ) );
 }
 
 void TestMerginApi::testUpdateWithDiffs()
@@ -1382,7 +1382,7 @@ void TestMerginApi::testUpdateWithDiffs()
 
   QVERIFY( QFileInfo::exists( projectDir + "/.mergin/base.gpkg" ) );
   QCOMPARE( MerginApi::localProjectChanges( projectDir ), ProjectDiff() );  // no local changes expected
-  QVERIFY( !MerginApi::hasLocalProjectChanges( projectDir ) );
+  QVERIFY( !MerginApi::hasLocalProjectChanges( projectDir, mApi->supportsSelectiveSync() ) );
 
   //
   // download with mApiExtra + modify + upload
@@ -1413,7 +1413,7 @@ void TestMerginApi::testUpdateWithDiffs()
   delete vl;
 
   QCOMPARE( MerginApi::localProjectChanges( projectDir ), ProjectDiff() );
-  QVERIFY( !MerginApi::hasLocalProjectChanges( projectDir ) );
+  QVERIFY( !MerginApi::hasLocalProjectChanges( projectDir, mApi->supportsSelectiveSync() ) );
   QVERIFY( !GeodiffUtils::hasPendingChanges( projectDir, "base.gpkg" ) );
 }
 
@@ -3198,12 +3198,18 @@ void TestMerginApi::testHasLocalChangesWithSelectiveSyncEnabled()
   oldServerFiles.append( serverExcluded );
   oldServerFiles.append( serverIncluded );
 
+  // retrieve config file we wrote
+  MerginConfig config = MerginConfig::fromFile( configPath );
+  QVERIFY( config.isValid );
+  QCOMPARE( config.selectiveSyncEnabled, true );
+  QCOMPARE( config.selectiveSyncDir, QString( "photos" ) ); // verify selective sync folder
+
   // first scenario => local files list exactly matches the non‑excluded server file
   // the excluded file ("photos/photo.jpg") is ignored, and no local changes should be detected
   QList<MerginFile> localFilesNoChange;
   localFilesNoChange.append( serverIncluded );
 
-  bool result = mApi->hasLocalChanges( oldServerFiles, localFilesNoChange, projectDir );
+  bool result = mApi->hasLocalChanges( oldServerFiles, localFilesNoChange, projectDir, config );
   QVERIFY( !result );
 
   // second scenario => local file list contains a modified version of non‑excluded file
@@ -3215,7 +3221,7 @@ void TestMerginApi::testHasLocalChangesWithSelectiveSyncEnabled()
     localFilesChanged.append( modifiedIncluded );
   }
 
-  result = mApi->hasLocalChanges( oldServerFiles, localFilesChanged, projectDir );
+  result = mApi->hasLocalChanges( oldServerFiles, localFilesChanged, projectDir, config );
   QVERIFY( result );
 }
 

--- a/app/test/testmerginapi.cpp
+++ b/app/test/testmerginapi.cpp
@@ -3255,7 +3255,7 @@ void TestMerginApi::testHasLocalProjectChanges()
   QVERIFY( !mApi->supportsSelectiveSync() );
 
   // expected results: no changes
-  QVERIFY( !MerginApi::hasLocalProjectChanges( projectDir, mApi->supportsSelectiveSync() ) );
+  QVERIFY( !mApi->hasLocalProjectChanges( projectDir, mApi->supportsSelectiveSync() ) );
 
   // 2: second scenario => metadata has files and no local files, selective sync not supported
   // add an entry to metadata file
@@ -3277,14 +3277,17 @@ void TestMerginApi::testHasLocalProjectChanges()
   writeFileContent( projectDir + "/" + MerginApi::sMetadataFile, doc.toJson() );
 
   // expected results: has changes
-  QVERIFY( MerginApi::hasLocalProjectChanges( projectDir, mApi->supportsSelectiveSync() ) );
+  QVERIFY( mApi->hasLocalProjectChanges( projectDir, mApi->supportsSelectiveSync() ) );
 
   // 3: third scenario => metadata files equals local files, selective sync supported
   writeFileContent( projectDir + "/test.txt", QByteArray( "test content" ) );
 
   // update checksum in metadata file to match local file
+  QFileInfo fileInfo( projectDir + "/test.txt" );
   QByteArray checksum = CoreUtils::calculateChecksum( projectDir + "/test.txt" );
   fileObj["checksum"] = QString( checksum );
+  fileObj["size"] = fileInfo.size();
+  fileObj["mtime"] = fileInfo.lastModified().toString( Qt::ISODateWithMs );
   filesArray = QJsonArray();
   filesArray.append( fileObj );
   obj["files"] = filesArray;
@@ -3295,12 +3298,12 @@ void TestMerginApi::testHasLocalProjectChanges()
   QVERIFY( mApi->supportsSelectiveSync() );
 
   // expected results: no changes
-  QVERIFY( !MerginApi::hasLocalProjectChanges( projectDir, mApi->supportsSelectiveSync() ) );
+  QVERIFY( !mApi->hasLocalProjectChanges( projectDir, mApi->supportsSelectiveSync() ) );
 
   // 4: fourth scenario => local files differs from metadata, selective sync supported
   writeFileContent( projectDir + "/test.txt", QByteArray( "modified content" ) );
   // expected results: has changes
-  QVERIFY( MerginApi::hasLocalProjectChanges( projectDir, mApi->supportsSelectiveSync() ) );
+  QVERIFY( mApi->hasLocalProjectChanges( projectDir, mApi->supportsSelectiveSync() ) );
 
   // clean up
   QDir( projectDir ).removeRecursively();

--- a/app/test/testmerginapi.h
+++ b/app/test/testmerginapi.h
@@ -150,6 +150,7 @@ class TestMerginApi: public QObject
     void testAutosyncFailure();
     void testUpdateProjectMetadataRole();
     void testMerginConfigFromFile();
+    void testHasLocalChangesWithSelectiveSyncEnabled();
 
     void testRegisterAndDelete();
     void testCreateWorkspace();

--- a/app/test/testmerginapi.h
+++ b/app/test/testmerginapi.h
@@ -155,6 +155,8 @@ class TestMerginApi: public QObject
     void testRegisterAndDelete();
     void testCreateWorkspace();
 
+    void testHasLocalProjectChanges();
+
     // mergin functions
     void testExcludeFromSync();
 

--- a/app/test/testmerginapi.h
+++ b/app/test/testmerginapi.h
@@ -149,6 +149,7 @@ class TestMerginApi: public QObject
     void testAutosync();
     void testAutosyncFailure();
     void testUpdateProjectMetadataRole();
+    void testMerginConfigFromFile();
 
     void testRegisterAndDelete();
     void testCreateWorkspace();

--- a/app/test/testmerginapi.h
+++ b/app/test/testmerginapi.h
@@ -151,11 +151,10 @@ class TestMerginApi: public QObject
     void testUpdateProjectMetadataRole();
     void testMerginConfigFromFile();
     void testHasLocalChangesWithSelectiveSyncEnabled();
+    void testHasLocalProjectChanges();
 
     void testRegisterAndDelete();
     void testCreateWorkspace();
-
-    void testHasLocalProjectChanges();
 
     // mergin functions
     void testExcludeFromSync();

--- a/core/merginapi.cpp
+++ b/core/merginapi.cpp
@@ -2994,14 +2994,23 @@ bool MerginApi::hasLocalChanges(
   const QString &projectDir
 )
 {
-  if ( localFiles.count() != oldServerFiles.count() )
+  MerginConfig config = MerginConfig::fromFile( projectDir + "/" + sMerginConfigFile );
+
+  QList<MerginFile> filteredOldServerFiles;
+  for ( const MerginFile &file : oldServerFiles )
+  {
+    if ( !excludeFromSync( file.path, config ) )
+      filteredOldServerFiles.append( file );
+  }
+
+  if ( localFiles.count() != filteredOldServerFiles.count() )
   {
     return true;
   }
 
   QHash<QString, MerginFile> oldServerFilesMap;
 
-  for ( const MerginFile &file : oldServerFiles )
+  for ( const MerginFile &file : filteredOldServerFiles )
   {
     oldServerFilesMap.insert( file.path, file );
   }

--- a/core/merginapi.cpp
+++ b/core/merginapi.cpp
@@ -3000,7 +3000,7 @@ bool MerginApi::hasLocalChanges(
 {
   QList<MerginFile> filteredOldServerFiles;
 
-  if ( config.isValid ) // if a config was set, support selective sync is supported
+  if ( config.isValid ) // if a config was set, selective sync is supported
   {
     for ( const MerginFile &file : oldServerFiles )
     {

--- a/core/merginapi.cpp
+++ b/core/merginapi.cpp
@@ -2998,29 +2998,29 @@ bool MerginApi::hasLocalChanges(
   const MerginConfig config
 )
 {
-  QList<MerginFile> filteredOldServerFiles;
+  QList<MerginFile> resolvedOldServerFiles;
 
   if ( config.isValid ) // if a config was set, selective sync is supported
   {
     for ( const MerginFile &file : oldServerFiles )
     {
       if ( !excludeFromSync( file.path, config ) )
-        filteredOldServerFiles.append( file );
+        resolvedOldServerFiles.append( file );
     }
   }
   else
   {
-    filteredOldServerFiles = oldServerFiles;
+    resolvedOldServerFiles = oldServerFiles;
   }
 
-  if ( localFiles.count() != filteredOldServerFiles.count() )
+  if ( localFiles.count() != resolvedOldServerFiles.count() )
   {
     return true;
   }
 
   QHash<QString, MerginFile> oldServerFilesMap;
 
-  for ( const MerginFile &file : filteredOldServerFiles )
+  for ( const MerginFile &file : resolvedOldServerFiles )
   {
     oldServerFilesMap.insert( file.path, file );
   }

--- a/core/merginapi.cpp
+++ b/core/merginapi.cpp
@@ -39,7 +39,6 @@ const QSet<QString> MerginApi::sIgnoreImageExtensions = QSet<QString>() << "jpg"
 const QSet<QString> MerginApi::sIgnoreFiles = QSet<QString>() << "mergin.json" << ".DS_Store";
 const int MerginApi::UPLOAD_CHUNK_SIZE = 10 * 1024 * 1024; // Should be the same as on Mergin server
 const QString MerginApi::sSyncCanceledMessage = QObject::tr( "Synchronisation canceled" );
-bool MerginApi::mSupportsSelectiveSync = true;
 
 MerginApi::MerginApi( LocalProjectsManager &localProjects, QObject *parent )
   : QObject( parent )
@@ -335,7 +334,7 @@ bool MerginApi::projectFileHasBeenUpdated( const ProjectDiff &diff )
   return false;
 }
 
-bool MerginApi::supportsSelectiveSync()
+bool MerginApi::supportsSelectiveSync() const
 {
   return mSupportsSelectiveSync;
 }
@@ -1617,13 +1616,13 @@ bool MerginApi::parseVersion( const QString &version, int &major, int &minor )
   return true;
 }
 
-bool MerginApi::hasLocalProjectChanges( const QString &projectDir, bool hasLocalProjectChanges )
+bool MerginApi::hasLocalProjectChanges( const QString &projectDir, bool supportsSelectiveSync )
 {
   MerginProjectMetadata projectMetadata = MerginProjectMetadata::fromCachedJson( projectDir + "/" + sMetadataFile );
   QList<MerginFile> localFiles = getLocalProjectFiles( projectDir + "/" );
 
   MerginConfig config;
-  if ( hasLocalProjectChanges )
+  if ( supportsSelectiveSync )
   {
     config = MerginConfig::fromFile( projectDir + "/" + sMerginConfigFile );
   }

--- a/core/merginapi.h
+++ b/core/merginapi.h
@@ -516,10 +516,10 @@ class MerginApi: public QObject
     */
     static bool extractProjectName( const QString &sourceString, QString &projectNamespace, QString &projectName );
 
-    bool supportsSelectiveSync() const;
+    static bool supportsSelectiveSync();
     void setSupportsSelectiveSync( bool supportsSelectiveSync );
 
-    /**
+    /**ss
      * Determine Mergin server type by querying /config endpoint.
      * Possible types are: saas, ce, ee and legacy
      */
@@ -858,7 +858,7 @@ class MerginApi: public QObject
     QEventLoop mAuthLoopEvent;
     MerginApiStatus::VersionStatus mApiVersionStatus = MerginApiStatus::VersionStatus::UNKNOWN;
     bool mApiSupportsSubscriptions = false;
-    bool mSupportsSelectiveSync = true;
+    static bool mSupportsSelectiveSync;
 
     static const int UPLOAD_CHUNK_SIZE;
     const int PROJECT_PER_PAGE = 50;

--- a/core/merginapi.h
+++ b/core/merginapi.h
@@ -517,10 +517,10 @@ class MerginApi: public QObject
     */
     static bool extractProjectName( const QString &sourceString, QString &projectNamespace, QString &projectName );
 
-    static bool supportsSelectiveSync();
+    bool supportsSelectiveSync() const;
     void setSupportsSelectiveSync( bool supportsSelectiveSync );
 
-    /**ss
+    /**
      * Determine Mergin server type by querying /config endpoint.
      * Possible types are: saas, ce, ee and legacy
      */
@@ -859,7 +859,7 @@ class MerginApi: public QObject
     QEventLoop mAuthLoopEvent;
     MerginApiStatus::VersionStatus mApiVersionStatus = MerginApiStatus::VersionStatus::UNKNOWN;
     bool mApiSupportsSubscriptions = false;
-    static bool mSupportsSelectiveSync;
+    bool mSupportsSelectiveSync = true;
 
     static const int UPLOAD_CHUNK_SIZE;
     const int PROJECT_PER_PAGE = 50;

--- a/core/merginapi.h
+++ b/core/merginapi.h
@@ -390,7 +390,7 @@ class MerginApi: public QObject
     QStringList projectDiffableFiles( const QString &projectFullName );
 
     static ProjectDiff localProjectChanges( const QString &projectDir );
-    static bool hasLocalProjectChanges( const QString &projectDir );
+    static bool hasLocalProjectChanges( const QString &projectDir, bool supportsSelectiveSync );
 
     /**
      * Parse major and minor version number from version string
@@ -475,7 +475,8 @@ class MerginApi: public QObject
     static bool hasLocalChanges(
       const QList<MerginFile> &oldServerFiles,
       const QList<MerginFile> &localFiles,
-      const QString &projectDir
+      const QString &projectDir,
+      const MerginConfig config
     );
 
     static QList<MerginFile> getLocalProjectFiles( const QString &projectPath );

--- a/core/project.cpp
+++ b/core/project.cpp
@@ -33,7 +33,7 @@ QString MerginProject::id() const
   return MerginApi::getFullProjectName( projectNamespace, projectName );
 }
 
-ProjectStatus::Status ProjectStatus::projectStatus( const Project &project )
+ProjectStatus::Status ProjectStatus::projectStatus( const Project &project, const bool supportsSelectiveSync )
 {
   if ( !project.isMergin() || !project.isLocal() ) // This is not a Mergin project or not downloaded project
     return ProjectStatus::NoVersion;
@@ -50,7 +50,7 @@ ProjectStatus::Status ProjectStatus::projectStatus( const Project &project )
     return ProjectStatus::NeedsSync;
   }
 
-  if ( ProjectStatus::hasLocalChanges( project.local ) )
+  if ( ProjectStatus::hasLocalChanges( project.local, supportsSelectiveSync ) )
   {
     return ProjectStatus::NeedsSync;
   }
@@ -58,7 +58,7 @@ ProjectStatus::Status ProjectStatus::projectStatus( const Project &project )
   return ProjectStatus::UpToDate;
 }
 
-bool ProjectStatus::hasLocalChanges( const LocalProject &project )
+bool ProjectStatus::hasLocalChanges( const LocalProject &project, bool supportsSelectiveSync )
 {
   QString metadataFilePath = project.projectDir + "/" + MerginApi::sMetadataFile;
 
@@ -68,5 +68,5 @@ bool ProjectStatus::hasLocalChanges( const LocalProject &project )
     return true;
   }
 
-  return MerginApi::hasLocalProjectChanges( project.projectDir );
+  return MerginApi::hasLocalProjectChanges( project.projectDir, supportsSelectiveSync );
 }

--- a/core/project.h
+++ b/core/project.h
@@ -30,9 +30,9 @@ namespace ProjectStatus
   Q_ENUM_NS( Status )
 
   //! Returns project state from ProjectStatus::Status enum for the project
-  Status projectStatus( const Project &project );
+  Status projectStatus( const Project &project, bool supportsSelectiveSync );
 
-  bool hasLocalChanges( const LocalProject &project );
+  bool hasLocalChanges( const LocalProject &project, bool supportsSelectiveSync );
 }
 
 /**


### PR DESCRIPTION
Files listed on the server are now filtered before retrieving local changes status, ensuring that files excluded by selective sync are not compared. This prevents a permanent pending sync status when selective sync is enabled.

Resolves #3129 