### PR TITLE
Hide position tracking button for readers

### DIFF
--- a/app/activeproject.cpp
+++ b/app/activeproject.cpp
@@ -535,7 +535,7 @@ bool ActiveProject::positionTrackingSupported() const
     return false;
   }
 
-  return mQgsProject->readBoolEntry( QStringLiteral( "Mergin" ), QStringLiteral( "PositionTracking/Enabled" ), false );
+  return mQgsProject->readBoolEntry( QStringLiteral( "Mergin" ), QStringLiteral( "PositionTracking/Enabled" ), false ) && userHasEditableRole();
 }
 
 bool ActiveProject::projectHasRecordingLayers() const
@@ -566,4 +566,9 @@ void ActiveProject::setProjectRole( const QString &role )
 
     emit projectRoleChanged();
   }
+}
+
+bool ActiveProject::userHasEditableRole() const
+{
+  return mProjectRole != "reader";
 }

--- a/app/activeproject.h
+++ b/app/activeproject.h
@@ -116,11 +116,17 @@ class ActiveProject: public QObject
 
     //! Returns true if the project has at least one layer that allows recording
     Q_INVOKABLE bool projectHasRecordingLayers() const;
+
     /**
      * Returns role/permission level of current user for this project
      */
     Q_INVOKABLE QString projectRole() const;
     void setProjectRole( const QString &role );
+
+    /**
+     * Returns true if user role is different than reader
+     */
+    Q_INVOKABLE bool userHasEditableRole() const;
 
   signals:
     void qgsProjectChanged();

--- a/app/qml/form/MMFormPage.qml
+++ b/app/qml/form/MMFormPage.qml
@@ -201,7 +201,7 @@ Page {
 
   footer: MMComponents.MMToolbar {
 
-    visible: !root.layerIsReadOnly && __activeProject.projectRole !== "reader"
+    visible: !root.layerIsReadOnly && __activeProject.userHasEditableRole
 
     ObjectModel {
       id: readStateButtons
@@ -231,7 +231,7 @@ Page {
         id: editGeometry
         text: qsTr( "Edit geometry" )
         iconSource: __style.editIcon
-        visible: root.layerIsSpatial && __activeProject.projectRole !== "reader"
+        visible: root.layerIsSpatial && __activeProject.userHasEditableRole
         onClicked: root.editGeometryRequested( root.controller.featureLayerPair )
       }
     }

--- a/app/qml/form/MMPreviewDrawer.qml
+++ b/app/qml/form/MMPreviewDrawer.qml
@@ -295,7 +295,7 @@ Item {
     property bool isHTMLType: root.controller.type === MM.AttributePreviewController.HTML
     property bool isEmptyType: root.controller.type === MM.AttributePreviewController.Empty
 
-    property bool showEditButton: !root.layerIsReadOnly && __activeProject.projectRole !== "reader"
+    property bool showEditButton: !root.layerIsReadOnly && __activeProject.userHasEditableRole
     property bool showStakeoutButton: __inputUtils.isPointLayerFeature( controller.featureLayerPair )
     property bool showButtons: showEditButton || showStakeoutButton
 

--- a/app/qml/form/components/MMFeaturesListPageDrawer.qml
+++ b/app/qml/form/components/MMFeaturesListPageDrawer.qml
@@ -103,7 +103,7 @@ Drawer {
         }
 
         text: qsTr( "Add feature" )
-        visible: __activeProject.projectRole !== "reader"
+        visible: __activeProject.userHasEditableRole
 
         onClicked: root.buttonClicked()
       }

--- a/app/qml/layers/MMFeaturesListPage.qml
+++ b/app/qml/layers/MMFeaturesListPage.qml
@@ -89,7 +89,7 @@ MMComponents.MMPage {
       anchors.bottom: parent.bottom
       anchors.bottomMargin: root.hasToolbar ? __style.margin20 : ( __style.safeAreaBottom + __style.margin8 )
 
-      visible: __inputUtils.isNoGeometryLayer( root.selectedLayer ) && !root.layerIsReadOnly && __activeProject.projectRole !== "reader"
+      visible: __inputUtils.isNoGeometryLayer( root.selectedLayer ) && !root.layerIsReadOnly && __activeProject.userHasEditableRole
 
       text: qsTr("Add feature")
 

--- a/app/qml/main.qml
+++ b/app/qml/main.qml
@@ -278,7 +278,7 @@ ApplicationWindow {
 
         text: qsTr("Add")
         iconSource: __style.addIcon
-        visible: __activeProject.projectRole !== "reader"
+        visible: __activeProject.userHasEditableRole
         onClicked: {
           if ( __activeProject.projectHasRecordingLayers() ) {
             stateManager.state = "map"
@@ -331,7 +331,7 @@ ApplicationWindow {
         text: qsTr("Position tracking")
         iconSource: __style.positionTrackingIcon
         active: map.isTrackingPosition
-        visible: __activeProject.positionTrackingSupported && __activeProject.projectRole !== "reader"
+        visible: __activeProject.positionTrackingSupported
 
         onClicked: {
           trackingPanelLoader.active = true
@@ -1019,7 +1019,7 @@ ApplicationWindow {
     }
 
     function onPositionTrackingSupportedChanged() {
-      positionTrackingButton.visible = __activeProject.positionTrackingSupported && __activeProject.projectRole !== "reader"
+      positionTrackingButton.visible = __activeProject.positionTrackingSupported
       mapToolbar.recalculate()
     }
   }

--- a/app/qml/main.qml
+++ b/app/qml/main.qml
@@ -331,7 +331,7 @@ ApplicationWindow {
         text: qsTr("Position tracking")
         iconSource: __style.positionTrackingIcon
         active: map.isTrackingPosition
-        visible: __activeProject.positionTrackingSupported
+        visible: __activeProject.positionTrackingSupported && __activeProject.projectRole !== "reader"
 
         onClicked: {
           trackingPanelLoader.active = true
@@ -1019,7 +1019,7 @@ ApplicationWindow {
     }
 
     function onPositionTrackingSupportedChanged() {
-      positionTrackingButton.visible = __activeProject.positionTrackingSupported
+      positionTrackingButton.visible = __activeProject.positionTrackingSupported && __activeProject.projectRole !== "reader"
       mapToolbar.recalculate()
     }
   }


### PR DESCRIPTION
Hide position tracking button for readers, completing https://github.com/MerginMaps/mobile/pull/3682.

Resolves #3719
