### PR TITLE
Fix dangling pointer in LayersProxyModel

### DIFF
--- a/app/qml/map/MMMapController.qml
+++ b/app/qml/map/MMMapController.qml
@@ -853,10 +853,6 @@ Item {
       Connections {
         target: __activeProject
 
-        function onProjectWillBeReloaded() {
-          recordingLayersModel.model.reset()
-        }
-
         function onProjectReloaded( qgsProject ) {
           recordingLayersModel.qgsProject = __activeProject.qgsProject
         }

--- a/app/qml/map/MMMapController.qml
+++ b/app/qml/map/MMMapController.qml
@@ -857,7 +857,7 @@ Item {
           recordingLayersModel.model.reset()
         }
 
-        function onProjectReloaded(qgsProject) {
+        function onProjectReloaded( qgsProject ) {
           recordingLayersModel.qgsProject = __activeProject.qgsProject
         }
       }

--- a/app/qml/map/MMMapController.qml
+++ b/app/qml/map/MMMapController.qml
@@ -849,6 +849,18 @@ Item {
         linkText: qsTr( "See how to enable digitizing in your project." )
         link: __inputHelp.howToEnableDigitizingLink
       }
+
+      Connections {
+        target: __activeProject
+
+        function onProjectWillBeReloaded() {
+          recordingLayersModel.model.reset()
+        }
+
+        function onProjectReloaded(qgsProject) {
+          recordingLayersModel.qgsProject = __activeProject.qgsProject
+        }
+      }
     }
   }
 


### PR DESCRIPTION
`LayersProxyModel` previously did not reset its `mQgsProject` reference upon a project change, resulting in dangling pointers. To address this, the solution involves connecting to `projectChanged` signal emitted by `ActiveLayer` and resetting `mQgsProject` accordingly.