### PR TITLE
Remove username and password repetition from sign up flow

### DIFF
--- a/app/qml/account/MMAccountController.qml
+++ b/app/qml/account/MMAccountController.qml
@@ -152,16 +152,14 @@ Item {
         stackView.popOnePageOrClose()
       }
 
-      onSignUpClicked: function ( username, email, password, passwordConfirm, tocAccept, newsletterSubscribe ) {
+      onSignUpClicked: function ( email, password, tocAccept, newsletterSubscribe ) {
         if ( __merginApi.serverType !== MM.MerginServerType.SAAS ) {
           return; //should not happen
         }
         else {
           stackView.pending = true
-          __merginApi.registerUser( username,
-                                   email,
+          __merginApi.registerUser( email,
                                    password,
-                                   passwordConfirm,
                                    tocAccept )
 
           postRegisterData.wantNewsletter = newsletterSubscribe

--- a/app/qml/account/MMSignUpPage.qml
+++ b/app/qml/account/MMSignUpPage.qml
@@ -33,10 +33,8 @@ MMPage {
 
   signal signInClicked
   signal signUpClicked(
-    string username,
     string email,
     string password,
-    string passwordConfirm,
     bool tocAccept,
     bool newsletterSubscribe
   )
@@ -67,15 +65,6 @@ MMPage {
       }
 
       MMTextInput {
-        id: username
-
-        width: parent.width
-
-        title: qsTr( "Username" )
-        textField.inputMethodHints: Qt.ImhNoAutoUppercase
-      }
-
-      MMTextInput {
         id: email
 
         width: parent.width
@@ -90,14 +79,6 @@ MMPage {
         width: parent.width
 
         title: qsTr( "Password" )
-      }
-
-      MMPasswordInput {
-        id: passwordConfirm
-
-        width: parent.width
-
-        title: qsTr( "Confirm password" )
       }
 
       MMCheckBox {
@@ -126,10 +107,8 @@ MMPage {
 
         onClicked: {
           root.signUpClicked(
-                username.text,
                 email.text,
                 password.text,
-                passwordConfirm.text,
                 tocCheck.checked,
                 newsletterCheck.checked
                 )
@@ -160,27 +139,17 @@ MMPage {
   function showErrorMessage( msg, field ) {
 
     // clear previous error messages
-    username.errorMsg = ""
     email.errorMsg = ""
     password.errorMsg = ""
-    passwordConfirm.errorMsg = ""
     tocCheck.hasError = false
 
-    if( field === MM.RegistrationError.USERNAME ) {
-      username.errorMsg = msg
-      username.focus = true
-    }
-    else if( field === MM.RegistrationError.EMAIL ) {
+    if( field === MM.RegistrationError.EMAIL ) {
       email.errorMsg = msg
       email.focus = true
     }
     else if( field === MM.RegistrationError.PASSWORD ) {
       password.errorMsg = msg
       password.focus = true
-    }
-    else if( field === MM.RegistrationError.CONFIRM_PASSWORD ) {
-      passwordConfirm.errorMsg = msg
-      passwordConfirm.focus = true
     }
     else if( field === MM.RegistrationError.TOC ) {
        tocCheck.hasError = true

--- a/app/test/testmerginapi.cpp
+++ b/app/test/testmerginapi.cpp
@@ -2460,10 +2460,11 @@ void TestMerginApi::testCreateWorkspace()
   QSKIP( "testCreateWorkspace requires USE_MM_SERVER_API_KEY" );
 #endif
   // we need to register new user for tests and assign its credentials to env vars
+  QString username = TestUtils::generateUsername();
   QString password = TestUtils::generatePassword();
   QString email = TestUtils::generateEmail();
 
-  qDebug() << "REGISTERING NEW TEST USER:" << email;
+  qDebug() << "REGISTERING NEW TEST USER WITH EMAIL:" << email;
 
   QSignalSpy spy( mApi,  &MerginApi::registrationSucceeded );
   QSignalSpy spy2( mApi,  &MerginApi::registrationFailed );
@@ -2482,11 +2483,11 @@ void TestMerginApi::testCreateWorkspace()
 
   // we also need to create a workspace for this user
   QSignalSpy wsSpy( mApi, &MerginApi::workspaceCreated );
-  mApi->createWorkspace( email );
+  mApi->createWorkspace( username );
   QVERIFY( wsSpy.wait( TestUtils::LONG_REPLY ) );
-  QCOMPARE( wsSpy.takeFirst().at( 0 ), email );
+  QCOMPARE( wsSpy.takeFirst().at( 0 ), username );
 
-  qDebug() << "CREATED NEW WORKSPACE:" << email;
+  qDebug() << "CREATED NEW WORKSPACE:" << username;
 
   // call userInfo to set active workspace
   QSignalSpy infoSpy( mApi, &MerginApi::userInfoReplyFinished );

--- a/app/test/testmerginapi.cpp
+++ b/app/test/testmerginapi.cpp
@@ -2854,17 +2854,14 @@ void TestMerginApi::testServerError()
 
 void TestMerginApi::testRegistration()
 {
-  QString username = "?";
   QString email = "broken@email";
   QString password = "pwd";
-  QString confirm_password = password;
 
   // do not want to be authorized
   mApi->clearAuth();
 
   // wrong email test
   QSignalSpy spy( mApi, &MerginApi::registrationFailed );
-  username = "username";
   mApi->registerUser( email, password, true );
   QCOMPARE( spy.count(), 1 );
   QCOMPARE( spy.takeFirst().at( 1 ).toInt(), RegistrationError::RegistrationErrorType::EMAIL );
@@ -2876,7 +2873,7 @@ void TestMerginApi::testRegistration()
   QCOMPARE( spy.takeFirst().at( 1 ).toInt(), RegistrationError::RegistrationErrorType::PASSWORD );
 
   // unchecked TOC test
-  confirm_password = "Lutra123:)";
+  password = "Lutra123:)";
   mApi->registerUser( email, password, false );
   QCOMPARE( spy.count(), 1 );
   QCOMPARE( spy.takeFirst().at( 1 ).toInt(), RegistrationError::RegistrationErrorType::TOC );

--- a/app/test/testmerginapi.cpp
+++ b/app/test/testmerginapi.cpp
@@ -2426,10 +2426,9 @@ void TestMerginApi::testRegisterAndDelete()
   QString password = mApi->userAuth()->password();
 
   QString quiteRandom = CoreUtils::uuidWithoutBraces( QUuid::createUuid() ).right( 15 ).replace( "-", "" );
-  QString username = "test_" + quiteRandom;
-  QString email = username + "@nonexistant.email.com";
+  QString email = "test_" + quiteRandom + "@nonexistant.email.com";
 
-  qDebug() << "username:" << username;
+  qDebug() << "email:" << email;
   // do not want to be authorized
   mApi->clearAuth();
 
@@ -2443,9 +2442,8 @@ void TestMerginApi::testRegisterAndDelete()
     QVERIFY( false );
   }
 
-
   QSignalSpy spyAuth( mApi->userAuth(),  &MerginUserAuth::authChanged );
-  mApi->authorize( username, password );
+  mApi->authorize( email, password );
   QVERIFY( spyAuth.wait( TestUtils::LONG_REPLY * 5 ) );
 
   // now delete user
@@ -2462,11 +2460,10 @@ void TestMerginApi::testCreateWorkspace()
   QSKIP( "testCreateWorkspace requires USE_MM_SERVER_API_KEY" );
 #endif
   // we need to register new user for tests and assign its credentials to env vars
-  QString username = TestUtils::generateUsername();
   QString password = TestUtils::generatePassword();
   QString email = TestUtils::generateEmail();
 
-  qDebug() << "REGISTERING NEW TEST USER:" << username;
+  qDebug() << "REGISTERING NEW TEST USER:" << email;
 
   QSignalSpy spy( mApi,  &MerginApi::registrationSucceeded );
   QSignalSpy spy2( mApi,  &MerginApi::registrationFailed );
@@ -2479,17 +2476,17 @@ void TestMerginApi::testCreateWorkspace()
   }
 
   QSignalSpy authSpy( mApi, &MerginApi::authChanged );
-  mApi->authorize( username, password );
+  mApi->authorize( email, password );
   QVERIFY( authSpy.wait( TestUtils::LONG_REPLY ) );
   QVERIFY( !authSpy.isEmpty() );
 
   // we also need to create a workspace for this user
   QSignalSpy wsSpy( mApi, &MerginApi::workspaceCreated );
-  mApi->createWorkspace( username );
+  mApi->createWorkspace( email );
   QVERIFY( wsSpy.wait( TestUtils::LONG_REPLY ) );
-  QCOMPARE( wsSpy.takeFirst().at( 0 ), username );
+  QCOMPARE( wsSpy.takeFirst().at( 0 ), email );
 
-  qDebug() << "CREATED NEW WORKSPACE:" << username;
+  qDebug() << "CREATED NEW WORKSPACE:" << email;
 
   // call userInfo to set active workspace
   QSignalSpy infoSpy( mApi, &MerginApi::userInfoReplyFinished );

--- a/app/test/testmerginapi.cpp
+++ b/app/test/testmerginapi.cpp
@@ -2862,33 +2862,22 @@ void TestMerginApi::testRegistration()
   // do not want to be authorized
   mApi->clearAuth();
 
-  // wrong username test
-  QSignalSpy spy( mApi, &MerginApi::registrationFailed );
-  mApi->registerUser( username, email, password, confirm_password, true );
-  QCOMPARE( spy.count(), 1 );
-  QCOMPARE( spy.takeFirst().at( 1 ).toInt(), RegistrationError::RegistrationErrorType::USERNAME );
-
   // wrong email test
+  QSignalSpy spy( mApi, &MerginApi::registrationFailed );
   username = "username";
-  mApi->registerUser( username, email, password, confirm_password, true );
+  mApi->registerUser( email, password, true );
   QCOMPARE( spy.count(), 1 );
   QCOMPARE( spy.takeFirst().at( 1 ).toInt(), RegistrationError::RegistrationErrorType::EMAIL );
 
   // wrong password test
   email = "username@email.com";
-  mApi->registerUser( username, email, password, confirm_password, true );
+  mApi->registerUser( email, password, true );
   QCOMPARE( spy.count(), 1 );
   QCOMPARE( spy.takeFirst().at( 1 ).toInt(), RegistrationError::RegistrationErrorType::PASSWORD );
 
-  // wrong confirm password test
-  password = "Lutra123:)";
-  mApi->registerUser( username, email, password, confirm_password, true );
-  QCOMPARE( spy.count(), 1 );
-  QCOMPARE( spy.takeFirst().at( 1 ).toInt(), RegistrationError::RegistrationErrorType::CONFIRM_PASSWORD );
-
   // unchecked TOC test
   confirm_password = "Lutra123:)";
-  mApi->registerUser( username, email, password, confirm_password, false );
+  mApi->registerUser( email, password, false );
   QCOMPARE( spy.count(), 1 );
   QCOMPARE( spy.takeFirst().at( 1 ).toInt(), RegistrationError::RegistrationErrorType::TOC );
 }

--- a/app/test/testmerginapi.cpp
+++ b/app/test/testmerginapi.cpp
@@ -2435,7 +2435,7 @@ void TestMerginApi::testRegisterAndDelete()
 
   QSignalSpy spy( mApi,  &MerginApi::registrationSucceeded );
   QSignalSpy spy2( mApi,  &MerginApi::registrationFailed );
-  mApi->registerUser( username, email, password, password, true );
+  mApi->registerUser( email, password, true );
   bool success = spy.wait( TestUtils::LONG_REPLY );
   if ( !success )
   {
@@ -2470,7 +2470,7 @@ void TestMerginApi::testCreateWorkspace()
 
   QSignalSpy spy( mApi,  &MerginApi::registrationSucceeded );
   QSignalSpy spy2( mApi,  &MerginApi::registrationFailed );
-  mApi->registerUser( username, email, password, password, true );
+  mApi->registerUser( email, password, true );
   bool success = spy.wait( TestUtils::LONG_REPLY );
   if ( !success )
   {

--- a/core/merginapi.h
+++ b/core/merginapi.h
@@ -324,10 +324,8 @@ class MerginApi: public QObject
     * \param acceptedTOC Whether user accepted Terms and Conditions
     */
     Q_INVOKABLE void registerUser(
-      const QString &username,
       const QString &email,
       const QString &password,
-      const QString &confirmPassword,
       bool acceptedTOC
     );
 
@@ -700,7 +698,7 @@ class MerginApi: public QObject
     void createProjectFinished();
     void deleteProjectFinished( bool informUser = true );
     void authorizeFinished();
-    void registrationFinished( const QString &username = QStringLiteral(), const QString &password = QStringLiteral() );
+    void registrationFinished( const QString &login = QStringLiteral(), const QString &password = QStringLiteral() );
     void postRegistrationFinished();
     void pingMerginReplyFinished();
     void deleteAccountFinished();

--- a/core/merginerrortypes.h
+++ b/core/merginerrortypes.h
@@ -19,10 +19,8 @@ class RegistrationError
     enum RegistrationErrorType
     {
       OTHER = 0,
-      USERNAME,
       EMAIL,
       PASSWORD,
-      CONFIRM_PASSWORD,
       TOC
     };
     Q_ENUM( RegistrationErrorType )

--- a/gallery/qml/pages/OnboardingPage.qml
+++ b/gallery/qml/pages/OnboardingPage.qml
@@ -158,10 +158,6 @@ Page {
 
       tocString: "Please read our Terms and Conditions"
 
-      onSignInClicked: console.log("Sign in clicked")
-      onSignUpClicked: function(email, password, tocAccept, newsletterSubscribe) {
-        console.log("Sign up clicked: " +  email + ";" + password + ";" + tocAccept + ";" + newsletterSubscribe)
-      }
       onBackClicked: stackview.pop()
     }
   }

--- a/gallery/qml/pages/OnboardingPage.qml
+++ b/gallery/qml/pages/OnboardingPage.qml
@@ -159,8 +159,8 @@ Page {
       tocString: "Please read our Terms and Conditions"
 
       onSignInClicked: console.log("Sign in clicked")
-      onSignUpClicked: function(username, email, password, passwordConfirm, tocAccept, newsletterSubscribe) {
-        console.log("Sign up clicked: " + username + ";" +  email + ";" + password + ";" + passwordConfirm + ";" + tocAccept + ";" + newsletterSubscribe)
+      onSignUpClicked: function(email, password, tocAccept, newsletterSubscribe) {
+        console.log("Sign up clicked: " +  email + ";" + password + ";" + tocAccept + ";" + newsletterSubscribe)
       }
       onBackClicked: stackview.pop()
     }


### PR DESCRIPTION
Remove `username` and `password confirm` in the Sign up and user registration flow. 

Resolves #3702