### PR TITLE
Fix Reuse last entered value tool and QGIS's reuseLastValue support 

### DIFF
--- a/app/attributes/attributecontroller.cpp
+++ b/app/attributes/attributecontroller.cpp
@@ -183,8 +183,6 @@ void AttributeController::setRememberAttributesController( RememberAttributesCon
   if ( mRememberAttributesController != rememberAttributes )
   {
     mRememberAttributesController = rememberAttributes;
-    if ( mRememberAttributesController && mFeatureLayerPair.layer() )
-      mRememberAttributesController->storeLayerFields( mFeatureLayerPair.layer() );
     emit rememberAttributesChanged();
   }
 }
@@ -514,10 +512,6 @@ void AttributeController::updateOnLayerChange()
 
     createTab( tab );
   }
-
-  if ( mRememberAttributesController )
-    mRememberAttributesController->storeLayerFields( layer );
-
 
   // 2) MODELS
   // for all other models, ownership is managed by Qt parent system

--- a/app/attributes/rememberattributescontroller.cpp
+++ b/app/attributes/rememberattributescontroller.cpp
@@ -100,29 +100,20 @@ bool RememberAttributesController::shouldRememberValue( const QgsVectorLayer *la
 
 bool RememberAttributesController::setShouldRememberValue( const QgsVectorLayer *layer, int fieldIndex, bool shouldRemember )
 {
-  if ( !rememberValuesAllowed() )
+  if ( !rememberValuesAllowed() || !layer || !mActiveProject )
     return false;
 
   QSettings settings;
   settings.beginGroup( CACHED_ATTRIBUTES_GROUP );
 
   QString fieldEnabledKey = QStringLiteral( "/%1/%2/%3/enabled" ).arg( mActiveProject->projectFullName() ).arg( layer->id() ).arg( fieldIndex );
-  bool fieldEnabled = settings.value( fieldEnabledKey, false ).toBool();
+  bool currentlyEnabled = settings.value( fieldEnabledKey, false ).toBool();
 
-  if ( layer && shouldRemember )
-  {
-    if ( !fieldEnabled )
-      settings.setValue( fieldEnabledKey, true );
-
-    settings.endGroup();
-    return true;
-  }
-
-  if ( fieldEnabled )
-    settings.setValue( fieldEnabledKey, false );
+  if ( currentlyEnabled != shouldRemember )
+    settings.setValue( fieldEnabledKey, shouldRemember );
 
   settings.endGroup();
-  return false;
+  return shouldRemember;
 }
 
 bool RememberAttributesController::rememberedValue(
@@ -130,6 +121,9 @@ bool RememberAttributesController::rememberedValue(
   int fieldIndex,
   QVariant &value ) const
 {
+  if ( !layer || !mActiveProject )
+    return false;
+
   QSettings settings;
   settings.beginGroup( CACHED_ATTRIBUTES_GROUP );
 

--- a/app/attributes/rememberattributescontroller.cpp
+++ b/app/attributes/rememberattributescontroller.cpp
@@ -18,8 +18,6 @@
 #include "qgsattributes.h"
 #include "featurelayerpair.h"
 
-QHash<QString, RememberAttributesController::RememberedValues> RememberAttributesController::sRememberedValues;
-
 RememberAttributesController::RememberAttributesController( QObject *parent )
   : QObject( parent )
 {
@@ -27,7 +25,7 @@ RememberAttributesController::RememberAttributesController( QObject *parent )
 
 void RememberAttributesController::reset()
 {
-  sRememberedValues.clear();
+  mRememberedValues.clear();
 }
 
 RememberAttributesController::~RememberAttributesController() = default;
@@ -48,10 +46,10 @@ void RememberAttributesController::setRememberValuesAllowed( bool rememberValues
 
 void RememberAttributesController::storeLayerFields( const QgsVectorLayer *layer )
 {
-  if ( layer && ( !sRememberedValues.contains( keyForLayer( layer ) ) ) )
+  if ( layer && ( !mRememberedValues.contains( layer->id() ) ) )
   {
-    sRememberedValues[keyForLayer( layer )] = RememberedValues();
-    sRememberedValues[keyForLayer( layer )].attributeFilter.fill( false, layer->fields().size() );
+    mRememberedValues[layer->id()] = RememberedValues();
+    mRememberedValues[layer->id()].attributeFilter.fill( false, layer->fields().size() );
   }
 }
 
@@ -59,7 +57,7 @@ void RememberAttributesController::storeFeature( const FeatureLayerPair &pair )
 {
   if ( pair.layer() )
     storeLayerFields( pair.layer() );
-  sRememberedValues[keyForLayer( pair.layer() )].feature = pair.feature();
+  mRememberedValues[pair.layer()->id()].feature = pair.feature();
 }
 
 bool RememberAttributesController::shouldRememberValue( const QgsVectorLayer *layer, int fieldIndex ) const
@@ -68,10 +66,10 @@ bool RememberAttributesController::shouldRememberValue( const QgsVectorLayer *la
   if ( !mRememberValuesAllowed )
     return false;
 
-  if ( !layer || !sRememberedValues.contains( keyForLayer( layer ) ) )
+  if ( !layer || !mRememberedValues.contains( layer->id() ) )
     return false;
 
-  const RememberedValues from = sRememberedValues[keyForLayer( layer )];
+  const RememberedValues from = mRememberedValues[layer->id()];
   if ( fieldIndex < 0 || fieldIndex >= from.attributeFilter.size() )
     // serious screw-up, mismatch between layer and stored layer?
     return false;
@@ -85,9 +83,9 @@ bool RememberAttributesController::setShouldRememberValue( const QgsVectorLayer 
   if ( !mRememberValuesAllowed )
     return false;
 
-  if ( layer && sRememberedValues.contains( keyForLayer( layer ) ) )
+  if ( layer && mRememberedValues.contains( layer->id() ) )
   {
-    RememberedValues &from = sRememberedValues[keyForLayer( layer )];
+    RememberedValues &from = mRememberedValues[layer->id()];
     if ( fieldIndex >= 0 && fieldIndex < from.attributeFilter.length() )
     {
       bool oldVal = from.attributeFilter[fieldIndex];
@@ -101,11 +99,6 @@ bool RememberAttributesController::setShouldRememberValue( const QgsVectorLayer 
   return false;
 }
 
-QString RememberAttributesController::keyForLayer( const QgsVectorLayer *layer ) const
-{
-  return QStringLiteral( "%1/%2" ).arg( mActiveProjectId, layer->id() );
-}
-
 bool RememberAttributesController::rememberedValue(
   const QgsVectorLayer *layer,
   int fieldIndex,
@@ -115,10 +108,10 @@ bool RememberAttributesController::rememberedValue(
   if ( !mRememberValuesAllowed )
     return false;
 
-  if ( !layer || !sRememberedValues.contains( keyForLayer( layer ) ) )
+  if ( !layer || !mRememberedValues.contains( layer->id() ) )
     return false;
 
-  const RememberedValues from = sRememberedValues[keyForLayer( layer )];
+  const RememberedValues from = mRememberedValues[layer->id()];
   if ( !from.feature.isValid() )
     return false;
 

--- a/app/attributes/rememberattributescontroller.cpp
+++ b/app/attributes/rememberattributescontroller.cpp
@@ -64,20 +64,14 @@ void RememberAttributesController::storeFeature( const FeatureLayerPair &pair )
   const QgsFields &fields = layer->fields();
   for ( int fieldIndex = 0; fieldIndex < fields.count(); fieldIndex++ )
   {
-    QString fieldEnabledKey = keyForField( "enabled", layer, fieldIndex );
-    bool fieldEnabled = settings.value( fieldEnabledKey, false ).toBool();
-    bool qgisReuseLastValue = layer->editFormConfig().reuseLastValue( ( fieldIndex ) );
-
-    if ( rememberValuesAllowed() ? fieldEnabled : qgisReuseLastValue ) //we want to keep QGIS's reuseLastValue independent when global switch off
-    {
-      QString fieldValueKey = keyForField( "value", layer, fieldIndex );
-      QVariant value = feature.attribute( fieldIndex );
-      settings.setValue( fieldValueKey, value );
-    }
+    QString fieldValueKey = keyForField( "value", layer, fieldIndex );
+    QVariant value = feature.attribute( fieldIndex );
+    settings.setValue( fieldValueKey, value );
   }
 
   settings.endGroup();
 }
+
 
 bool RememberAttributesController::shouldRememberValue( const QgsVectorLayer *layer, int fieldIndex ) const
 {

--- a/app/attributes/rememberattributescontroller.cpp
+++ b/app/attributes/rememberattributescontroller.cpp
@@ -44,7 +44,11 @@ void RememberAttributesController::storeFeature( const FeatureLayerPair &pair )
       // if key does not exist, default to invalid QVariant, meaning "unchecked"
       // if key value is valid, replace it with the new value from the feature
       if ( mSettings.value( fieldValueKey, QVariant() ).isValid() )
-        mSettings.setValue( fieldValueKey, feature.attribute( fieldIndex ) );
+      {
+        // if the feature has an empty value, we store an empty QString instead, since storing an invalid QVariant would mean "unchecked"
+        const QVariant valueToStore = feature.attribute( fieldIndex ).isValid() ? feature.attribute( fieldIndex ) : QString();
+        mSettings.setValue( fieldValueKey, valueToStore );
+      }
       // else do nothing, keep invalid value in settings, meaning "unchecked"
 
       continue;
@@ -53,7 +57,9 @@ void RememberAttributesController::storeFeature( const FeatureLayerPair &pair )
     // we still need to store the value when qgis says so, even if mRememberValuesAllowed is false
     if ( enabledInQgis( layer, fieldIndex ) )
     {
-      mSettings.setValue( fieldValueKey, feature.attribute( fieldIndex ) );
+      // if the feature has an empty value, we store an empty QString instead, since storing an invalid QVariant would mean "unchecked"
+      const QVariant valueToStore = feature.attribute( fieldIndex ).isValid() ? feature.attribute( fieldIndex ) : QString();
+      mSettings.setValue( fieldValueKey, valueToStore );
     }
     else
     {
@@ -64,7 +70,7 @@ void RememberAttributesController::storeFeature( const FeatureLayerPair &pair )
 }
 
 
-bool RememberAttributesController::shouldRememberValue( const QgsVectorLayer *layer, int fieldIndex ) const
+bool RememberAttributesController::shouldRememberValue( const QgsVectorLayer *layer, int fieldIndex )
 {
   if ( !mRememberValuesAllowed || !layer )
     return false;
@@ -80,6 +86,8 @@ bool RememberAttributesController::shouldRememberValue( const QgsVectorLayer *la
   }
   else if ( enabledInQgis( layer, fieldIndex ) )
   {
+    // Store a valid empty string, meaning "checked but no stored value yet"
+    mSettings.setValue( fieldValueKey, QString() );
     return true;
   }
 

--- a/app/attributes/rememberattributescontroller.cpp
+++ b/app/attributes/rememberattributescontroller.cpp
@@ -67,7 +67,12 @@ void RememberAttributesController::storeFeature( const FeatureLayerPair &pair )
     QString fieldEnabledKey = QStringLiteral( "/%1/%2/%3/enabled" ).arg( mActiveProject->projectFullName() ).arg( layer->id() ).arg( fieldIndex );
     bool fieldEnabled = settings.value( fieldEnabledKey, false ).toBool();
 
-    if ( fieldEnabled )
+    bool qgisReuse = layer->editFormConfig().reuseLastValue( ( fieldIndex ) );
+
+    bool con1 = (fieldEnabled && rememberValuesAllowed());
+    bool con2 = ( !rememberValuesAllowed() && qgisReuse);
+
+    if ( con1 || con2 )
     {
       QString fieldValueKey = QStringLiteral( "/%1/%2/%3/value" ).arg( mActiveProject->projectFullName() ).arg( layer->id() ).arg( fieldIndex );
       QVariant value = feature.attribute( fieldIndex );
@@ -80,7 +85,7 @@ void RememberAttributesController::storeFeature( const FeatureLayerPair &pair )
 
 bool RememberAttributesController::shouldRememberValue( const QgsVectorLayer *layer, int fieldIndex ) const
 {
-  // global switch off of the functionality
+  // // global switch off of the functionality
 
   if ( !rememberValuesAllowed() )
     return layer->editFormConfig().reuseLastValue( ( fieldIndex ) );
@@ -92,6 +97,7 @@ bool RememberAttributesController::shouldRememberValue( const QgsVectorLayer *la
   settings.beginGroup( CACHED_ATTRIBUTES_GROUP );
 
   QString fieldEnabledKey = QStringLiteral( "/%1/%2/%3/enabled" ).arg( mActiveProject->projectFullName() ).arg( layer->id() ).arg( fieldIndex );
+
   bool fieldEnabled = settings.value( fieldEnabledKey, false ).toBool();;
 
   settings.endGroup();
@@ -101,14 +107,21 @@ bool RememberAttributesController::shouldRememberValue( const QgsVectorLayer *la
 
 bool RememberAttributesController::setShouldRememberValue( const QgsVectorLayer *layer, int fieldIndex, bool shouldRemember )
 {
-  if ( !rememberValuesAllowed() || !layer || !mActiveProject )
+  if ( !layer || !mActiveProject )
     return false;
 
   QSettings settings;
   settings.beginGroup( CACHED_ATTRIBUTES_GROUP );
 
+  bool qgisReuse = layer->editFormConfig().reuseLastValue( ( fieldIndex ) );
+
+  bool currentlyEnabled;
   QString fieldEnabledKey = QStringLiteral( "/%1/%2/%3/enabled" ).arg( mActiveProject->projectFullName() ).arg( layer->id() ).arg( fieldIndex );
-  bool currentlyEnabled = settings.value( fieldEnabledKey, false ).toBool();
+
+  if (settings.contains(fieldEnabledKey))
+    currentlyEnabled = settings.value( fieldEnabledKey, false ).toBool();
+  else if (qgisReuse)
+    currentlyEnabled = qgisReuse;
 
   if ( currentlyEnabled != shouldRemember )
     settings.setValue( fieldEnabledKey, shouldRemember );
@@ -131,7 +144,11 @@ bool RememberAttributesController::rememberedValue(
   QString fieldEnabledKey = QStringLiteral( "/%1/%2/%3/enabled" ).arg( mActiveProject->projectFullName() ).arg( layer->id() ).arg( fieldIndex );
   bool fieldEnabled = settings.value( fieldEnabledKey, false ).toBool();
 
-  if ( fieldEnabled )
+  bool qgisReuse = layer->editFormConfig().reuseLastValue( ( fieldIndex ) );
+
+  bool con1 = (fieldEnabled && rememberValuesAllowed());
+  bool con2 = ( !rememberValuesAllowed() && qgisReuse);
+  if ( con1 || con2 )
   {
     QString fieldValueKey = QStringLiteral( "/%1/%2/%3/value" ).arg( mActiveProject->projectFullName() ).arg( layer->id() ).arg( fieldIndex );
     QVariant fieldValue = settings.value( fieldValueKey, QVariant() );

--- a/app/attributes/rememberattributescontroller.cpp
+++ b/app/attributes/rememberattributescontroller.cpp
@@ -81,8 +81,9 @@ void RememberAttributesController::storeFeature( const FeatureLayerPair &pair )
 bool RememberAttributesController::shouldRememberValue( const QgsVectorLayer *layer, int fieldIndex ) const
 {
   // global switch off of the functionality
+
   if ( !rememberValuesAllowed() )
-    return false;
+    return layer->editFormConfig().reuseLastValue( ( fieldIndex ) );
 
   if ( !layer )
     return false;
@@ -168,17 +169,11 @@ void RememberAttributesController::setFeatureLayerPair( const FeatureLayerPair &
   const QgsFields &fields = layer->fields();
   for ( int fieldIndex = 0; fieldIndex < fields.count(); fieldIndex++ )
   {
-    QVariant value = feature.attribute( fieldIndex );
-    QString fieldValueKey = QStringLiteral( "/%1/%2/%3/value" ).arg( mActiveProject->projectFullName() ).arg( layer->id() ).arg( fieldIndex );
-
     if ( shouldRememberValue( layer, fieldIndex ) )
     {
-      settings.setValue( fieldValueKey, value );
-    }
-    else if ( layer->editFormConfig().reuseLastValue( ( fieldIndex ) ) )
-    {
-      setShouldRememberValue( layer, fieldIndex, true );
-      settings.setValue( fieldValueKey, value );
+      QString fieldValueKey = QStringLiteral( "/%1/%2/%3/value" ).arg( mActiveProject->projectFullName() ).arg( layer->id() ).arg( fieldIndex );
+      QVariant rememberedValue = settings.value( fieldValueKey );
+      mFeatureLayerPair.featureRef().setAttribute( fieldIndex, rememberedValue );
     }
   }
 

--- a/app/attributes/rememberattributescontroller.h
+++ b/app/attributes/rememberattributescontroller.h
@@ -47,7 +47,7 @@ class  RememberAttributesController : public QObject
     bool rememberedValue( const QgsVectorLayer *layer, int fieldIndex, QVariant &value ) const;
 
     // Returns false if the value should not be remembered
-    bool shouldRememberValue( const QgsVectorLayer *layer, int fieldIndex ) const;
+    bool shouldRememberValue( const QgsVectorLayer *layer, int fieldIndex );
 
     // Returns whether value was changed
     bool setShouldRememberValue( const QgsVectorLayer *layer, int fieldIndex, bool shouldRemember );

--- a/app/attributes/rememberattributescontroller.h
+++ b/app/attributes/rememberattributescontroller.h
@@ -34,8 +34,6 @@ class  RememberAttributesController : public QObject
     //! Returns TRUE if remembering values is allowed
     Q_PROPERTY( bool rememberValuesAllowed READ rememberValuesAllowed WRITE setRememberValuesAllowed NOTIFY rememberValuesAllowedChanged )
 
-    Q_PROPERTY( QString activeProjectId MEMBER mActiveProjectId )
-
   public:
     RememberAttributesController( QObject *parent = nullptr );
     ~RememberAttributesController() override;
@@ -62,8 +60,6 @@ class  RememberAttributesController : public QObject
     void rememberValuesAllowedChanged();
 
   private:
-    QString mActiveProjectId;
-
     //! Remembered values struct contains last created feature instance and a boolean vector masking attributes that should be remembered
     struct RememberedValues
     {
@@ -72,10 +68,9 @@ class  RememberAttributesController : public QObject
     };
 
     bool mRememberValuesAllowed = false;
-    //! Remembered last created feature for each project/layer (key)
-    static QHash<QString, RememberedValues> sRememberedValues;
+    //! Remembered last created feature for each layer (key)
+    QHash<QString, RememberedValues> mRememberedValues;
 
-    QString keyForLayer( const QgsVectorLayer *layer ) const;
 };
 
 #endif // REMEMBERATTRIBUTESCONTROLLER_H

--- a/app/attributes/rememberattributescontroller.h
+++ b/app/attributes/rememberattributescontroller.h
@@ -18,8 +18,9 @@
 
 
 #include <QObject>
+#include <QString>
+#include <QSettings>
 
-class ActiveProject;
 class FeatureLayerPair;
 class QgsVectorLayer;
 
@@ -31,17 +32,14 @@ class  RememberAttributesController : public QObject
     Q_OBJECT
 
     //! Returns TRUE if remembering values is allowed
-    Q_PROPERTY( bool rememberValuesAllowed READ rememberValuesAllowed WRITE setRememberValuesAllowed NOTIFY rememberValuesAllowedChanged )
+    Q_PROPERTY( bool rememberValuesAllowed MEMBER mRememberValuesAllowed )
 
     //! Provides context for creating project-specific settings keys
-    Q_PROPERTY( ActiveProject *activeProject READ activeProject WRITE setActiveProject NOTIFY activeProjectChanged )
+    Q_PROPERTY( QString activeProjectId MEMBER mActiveProjectId )
 
   public:
     RememberAttributesController( QObject *parent = nullptr );
     ~RememberAttributesController() override;
-
-    bool rememberValuesAllowed() const;
-    void setRememberValuesAllowed( bool allowed );
 
     void storeFeature( const FeatureLayerPair &pair );
 
@@ -54,9 +52,6 @@ class  RememberAttributesController : public QObject
     // Returns whether value was changed
     bool setShouldRememberValue( const QgsVectorLayer *layer, int fieldIndex, bool shouldRemember );
 
-    ActiveProject *activeProject() const;
-    void setActiveProject( ActiveProject *newActiveProject );
-
   signals:
     void rememberValuesAllowedChanged();
     void activeProjectChanged();
@@ -65,7 +60,14 @@ class  RememberAttributesController : public QObject
     // Helper method to retrieve settings value keys;
     QString keyForField( const QgsVectorLayer *layer, int fieldIndex ) const;
 
-    ActiveProject *mActiveProject = nullptr;
+    // Returns if remember values is enabled in QGIS form config
+    bool enabledInQgis( const QgsVectorLayer *layer, int fieldIndex ) const;
+
+    QString mActiveProjectId;
+    bool mRememberValuesAllowed = false;
+    QSettings mSettings;
+
+    friend class TestRememberAttributesController;
 };
 
 #endif // REMEMBERATTRIBUTESCONTROLLER_H

--- a/app/attributes/rememberattributescontroller.h
+++ b/app/attributes/rememberattributescontroller.h
@@ -17,13 +17,11 @@
 #define REMEMBERATTRIBUTESCONTROLLER_H
 
 
-#include "qgsfeature.h"
-#include "qgsvectorlayer.h"
-#include "inputconfig.h"
-#include "activeproject.h"
-#include <QHash>
+#include <QObject>
 
+class ActiveProject;
 class FeatureLayerPair;
+class QgsVectorLayer;
 
 /**
  * \note QML Type: RememberAttributes
@@ -42,10 +40,8 @@ class  RememberAttributesController : public QObject
     RememberAttributesController( QObject *parent = nullptr );
     ~RememberAttributesController() override;
 
-    static const QString CACHED_ATTRIBUTES_GROUP;
-
     bool rememberValuesAllowed() const;
-    void setRememberValuesAllowed( bool rememberValuesAllowed );
+    void setRememberValuesAllowed( bool allowed );
 
     void storeFeature( const FeatureLayerPair &pair );
 
@@ -58,9 +54,6 @@ class  RememberAttributesController : public QObject
     // Returns whether value was changed
     bool setShouldRememberValue( const QgsVectorLayer *layer, int fieldIndex, bool shouldRemember );
 
-    // Helper method to retrieve enabled and value keys;
-    QString keyForField( const QString &suffix, const QgsVectorLayer *layer, int fieldIndex ) const;
-
     ActiveProject *activeProject() const;
     void setActiveProject( ActiveProject *newActiveProject );
 
@@ -69,6 +62,9 @@ class  RememberAttributesController : public QObject
     void activeProjectChanged();
 
   private:
+    // Helper method to retrieve settings value keys;
+    QString keyForField( const QgsVectorLayer *layer, int fieldIndex ) const;
+
     ActiveProject *mActiveProject = nullptr;
 };
 

--- a/app/attributes/rememberattributescontroller.h
+++ b/app/attributes/rememberattributescontroller.h
@@ -38,9 +38,6 @@ class  RememberAttributesController : public QObject
     //! Provides context for creating project-specific settings keys
     Q_PROPERTY( ActiveProject *activeProject READ activeProject WRITE setActiveProject NOTIFY activeProjectChanged )
 
-    //! Usage on attribute operations
-    Q_PROPERTY( FeatureLayerPair featureLayerPair READ featureLayerPair WRITE setFeatureLayerPair NOTIFY featureLayerPairChanged )
-
   public:
     RememberAttributesController( QObject *parent = nullptr );
     ~RememberAttributesController() override;
@@ -61,8 +58,8 @@ class  RememberAttributesController : public QObject
     // Returns whether value was changed
     bool setShouldRememberValue( const QgsVectorLayer *layer, int fieldIndex, bool shouldRemember );
 
-    FeatureLayerPair featureLayerPair() const;
-    void setFeatureLayerPair( const FeatureLayerPair &pair );
+    // Helper method to retrieve enabled and value keys;
+    QString keyForField( const QString &suffix, const QgsVectorLayer *layer, int fieldIndex ) const;
 
     ActiveProject *activeProject() const;
     void setActiveProject( ActiveProject *newActiveProject );
@@ -70,11 +67,9 @@ class  RememberAttributesController : public QObject
   signals:
     void rememberValuesAllowedChanged();
     void activeProjectChanged();
-    void featureLayerPairChanged();
 
   private:
     ActiveProject *mActiveProject = nullptr;
-    FeatureLayerPair mFeatureLayerPair;
 };
 
 #endif // REMEMBERATTRIBUTESCONTROLLER_H

--- a/app/attributes/rememberattributescontroller.h
+++ b/app/attributes/rememberattributescontroller.h
@@ -20,6 +20,7 @@
 #include "qgsfeature.h"
 #include "qgsvectorlayer.h"
 #include "inputconfig.h"
+#include "activeproject.h"
 #include <QHash>
 
 class FeatureLayerPair;
@@ -34,17 +35,21 @@ class  RememberAttributesController : public QObject
     //! Returns TRUE if remembering values is allowed
     Q_PROPERTY( bool rememberValuesAllowed READ rememberValuesAllowed WRITE setRememberValuesAllowed NOTIFY rememberValuesAllowedChanged )
 
+    //! Provides context for creating project-specific settings keys
+    Q_PROPERTY( ActiveProject *activeProject READ activeProject WRITE setActiveProject NOTIFY activeProjectChanged )
+
+    //! Usage on attribute operations
+    Q_PROPERTY( FeatureLayerPair featureLayerPair READ featureLayerPair WRITE setFeatureLayerPair NOTIFY featureLayerPairChanged )
+
   public:
     RememberAttributesController( QObject *parent = nullptr );
     ~RememberAttributesController() override;
 
-    //! Restore clean/initial state: no layers, no features!
-    Q_INVOKABLE void reset();
+    static const QString CACHED_ATTRIBUTES_GROUP;
 
     bool rememberValuesAllowed() const;
     void setRememberValuesAllowed( bool rememberValuesAllowed );
 
-    void storeLayerFields( const QgsVectorLayer *layer );
     void storeFeature( const FeatureLayerPair &pair );
 
     // Returns false if the value is not remembered
@@ -56,21 +61,20 @@ class  RememberAttributesController : public QObject
     // Returns whether value was changed
     bool setShouldRememberValue( const QgsVectorLayer *layer, int fieldIndex, bool shouldRemember );
 
+    FeatureLayerPair featureLayerPair() const;
+    void setFeatureLayerPair( const FeatureLayerPair &pair );
+
+    ActiveProject *activeProject() const;
+    void setActiveProject( ActiveProject *newActiveProject );
+
   signals:
     void rememberValuesAllowedChanged();
+    void activeProjectChanged();
+    void featureLayerPairChanged();
 
   private:
-    //! Remembered values struct contains last created feature instance and a boolean vector masking attributes that should be remembered
-    struct RememberedValues
-    {
-      QgsFeature feature;
-      QVector<bool> attributeFilter;
-    };
-
-    bool mRememberValuesAllowed = false;
-    //! Remembered last created feature for each layer (key)
-    QHash<QString, RememberedValues> mRememberedValues;
-
+    ActiveProject *mActiveProject = nullptr;
+    FeatureLayerPair mFeatureLayerPair;
 };
 
 #endif // REMEMBERATTRIBUTESCONTROLLER_H

--- a/app/qml/form/MMFormController.qml
+++ b/app/qml/form/MMFormController.qml
@@ -187,7 +187,6 @@ Item {
         rememberAttributesController: MM.RememberAttributesController {
           rememberValuesAllowed: __appSettings.reuseLastEnteredValues
           activeProject: __activeProject
-          featureLayerPair: root.featureLayerPair
         }
         // NOTE: order matters, we want to init variables manager before
         // assingning FeatureLayerPair, as VariablesManager is required

--- a/app/qml/form/MMFormController.qml
+++ b/app/qml/form/MMFormController.qml
@@ -186,7 +186,7 @@ Item {
 
         rememberAttributesController: MM.RememberAttributesController {
           rememberValuesAllowed: __appSettings.reuseLastEnteredValues
-          activeProject: __activeProject
+          activeProjectId: __activeProject.localProject.id()
         }
         // NOTE: order matters, we want to init variables manager before
         // assingning FeatureLayerPair, as VariablesManager is required

--- a/app/qml/form/MMFormController.qml
+++ b/app/qml/form/MMFormController.qml
@@ -186,8 +186,8 @@ Item {
 
         rememberAttributesController: MM.RememberAttributesController {
           rememberValuesAllowed: __appSettings.reuseLastEnteredValues
-          featureLayerPair: root.featureLayerPair
           activeProject: __activeProject
+          featureLayerPair: root.featureLayerPair
         }
         // NOTE: order matters, we want to init variables manager before
         // assingning FeatureLayerPair, as VariablesManager is required

--- a/app/qml/form/MMFormController.qml
+++ b/app/qml/form/MMFormController.qml
@@ -186,7 +186,6 @@ Item {
 
         rememberAttributesController: MM.RememberAttributesController {
           rememberValuesAllowed: __appSettings.reuseLastEnteredValues
-          activeProjectId: __activeProject.localProject.id()
         }
         // NOTE: order matters, we want to init variables manager before
         // assingning FeatureLayerPair, as VariablesManager is required

--- a/app/qml/form/MMFormController.qml
+++ b/app/qml/form/MMFormController.qml
@@ -186,6 +186,8 @@ Item {
 
         rememberAttributesController: MM.RememberAttributesController {
           rememberValuesAllowed: __appSettings.reuseLastEnteredValues
+          featureLayerPair: root.featureLayerPair
+          activeProject: __activeProject
         }
         // NOTE: order matters, we want to init variables manager before
         // assingning FeatureLayerPair, as VariablesManager is required

--- a/app/qml/form/MMFormPage.qml
+++ b/app/qml/form/MMFormPage.qml
@@ -316,7 +316,7 @@ Page {
         property var fieldFeatureLayerPair: root.controller.featureLayerPair
         property string fieldHomePath: root.project ? root.project.homePath : "" // for photo editor
 
-        property bool fieldRememberValueSupported: root.controller.rememberAttributesController.rememberValuesAllowed && root.state === "add" && model.EditorWidget !== "Hidden" && Type === MM.FormItem.Field
+        property bool fieldRememberValueSupported: __appSettings.reuseLastEnteredValues && root.state === "add" && model.EditorWidget !== "Hidden" && Type === MM.FormItem.Field
         property bool fieldRememberValueState: model.RememberValue ? true : false
 
         active: fieldWidget !== 'Hidden'

--- a/app/test/testrememberattributescontroller.cpp
+++ b/app/test/testrememberattributescontroller.cpp
@@ -54,7 +54,7 @@ void TestRememberAttributesController::storedFeatureTest()
   ActiveLayer activeLayer;
   LocalProjectsManager localProjectsManager( QDir::tempPath() );
   ActiveProject activeProject( appSettings, activeLayer, localProjectsManager, this );
-  controller.mActiveProjectId = activeProject.localProject().id();
+  controller.mActiveProjectId = QStringLiteral( "my-fake-project-id" );
   controller.mRememberValuesAllowed = true;
 
   std::unique_ptr<QgsVectorLayer> layer(
@@ -104,6 +104,7 @@ void TestRememberAttributesController::storedFeatureTest()
 
   // one feature is stored, and user does not want to use first field for new feature
   controller.setShouldRememberValue( layer.get(), 0, true );
+  controller.storeFeature( pair );
   QCOMPARE( controller.shouldRememberValue( layer.get(), 0 ), true );
   QCOMPARE( controller.rememberedValue( layer.get(), 0, val ), true );
   QCOMPARE( val, "one" );
@@ -124,6 +125,7 @@ void TestRememberAttributesController::storedFeatureTest()
 
   // user now wants to use field 1 from the second layer
   controller.setShouldRememberValue( layer2.get(), 1, true );
+  controller.storeFeature( pair2 );
   QCOMPARE( controller.shouldRememberValue( layer.get(), 0 ), true );
   QCOMPARE( controller.rememberedValue( layer.get(), 0, val ), true );
   QCOMPARE( val, "one" );

--- a/app/test/testrememberattributescontroller.cpp
+++ b/app/test/testrememberattributescontroller.cpp
@@ -21,6 +21,7 @@
 #include "activelayer.h"
 #include "localprojectsmanager.h"
 #include "activeproject.h"
+#include "coreutils.h"
 
 void TestRememberAttributesController::init()
 {

--- a/app/test/testrememberattributescontroller.cpp
+++ b/app/test/testrememberattributescontroller.cpp
@@ -38,14 +38,12 @@ void TestRememberAttributesController::noFeatureTest()
   RememberAttributesController controller;
 
 
-  QCOMPARE( controller.rememberValuesAllowed(), false );
-  controller.setRememberValuesAllowed( true );
-  QCOMPARE( controller.rememberValuesAllowed(), true );
+  QCOMPARE( controller.mRememberValuesAllowed, false );
+  controller.mRememberValuesAllowed = true;
 
   QCOMPARE( controller.shouldRememberValue( nullptr, 1 ), false );
   QVariant val;
   QCOMPARE( controller.rememberedValue( nullptr, 1, val ), false );
-
 }
 
 void TestRememberAttributesController::storedFeatureTest()
@@ -55,9 +53,8 @@ void TestRememberAttributesController::storedFeatureTest()
   ActiveLayer activeLayer;
   LocalProjectsManager localProjectsManager( QDir::tempPath() );
   ActiveProject activeProject( appSettings, activeLayer, localProjectsManager, this );
-  controller.setActiveProject( &activeProject );
-
-  controller.setRememberValuesAllowed( true );
+  controller.mActiveProjectId = activeProject.localProject().id();
+  controller.mRememberValuesAllowed = true;
 
   std::unique_ptr<QgsVectorLayer> layer(
     new QgsVectorLayer( QStringLiteral( "Point?field=fldtxt:string&field=fldint:integer" ),

--- a/app/test/testrememberattributescontroller.cpp
+++ b/app/test/testrememberattributescontroller.cpp
@@ -151,7 +151,7 @@ void TestRememberAttributesController::storedFeatureTest()
 
   // reset settings
   QSettings settings;
-  settings.beginGroup( RememberAttributesController::CACHED_ATTRIBUTES_GROUP );
+  settings.beginGroup( CoreUtils::CACHED_ATTRIBUTES_GROUP );
   settings.remove( "" );
   settings.endGroup();
 

--- a/core/coreutils.cpp
+++ b/core/coreutils.cpp
@@ -27,6 +27,7 @@
 #include "qcoreapplication.h"
 
 const QString CoreUtils::QSETTINGS_APP_GROUP_NAME = QStringLiteral( "inputApp" );
+const QString CoreUtils::CACHED_ATTRIBUTES_GROUP = QStringLiteral( "cachedAttributesValue" );
 const QString CoreUtils::LOG_TO_DEVNULL = QStringLiteral();
 const QString CoreUtils::LOG_TO_STDOUT = QStringLiteral( "TO_STDOUT" );
 QString CoreUtils::sLogFile = CoreUtils::LOG_TO_DEVNULL;

--- a/core/coreutils.h
+++ b/core/coreutils.h
@@ -109,6 +109,7 @@ class CoreUtils
     static QString deviceUuid();
 
     static const QString QSETTINGS_APP_GROUP_NAME;
+    static const QString CACHED_ATTRIBUTES_GROUP;
 
     /**
      * Returns available device storage

--- a/core/localprojectsmanager.cpp
+++ b/core/localprojectsmanager.cpp
@@ -115,6 +115,9 @@ void LocalProjectsManager::removeLocalProject( const QString &projectId )
     {
       emit aboutToRemoveLocalProject( mProjects[i] );
 
+      QString projectFullName = mProjects[i].fullName();
+      clearAllProjectSettings( projectFullName );
+
       CoreUtils::removeDir( mProjects[i].projectDir );
       mProjects.removeAt( i );
 
@@ -249,3 +252,17 @@ void LocalProjectsManager::addProject( const QString &projectDir, const QString 
   mProjects << project;
   emit localProjectAdded( project );
 }
+
+void LocalProjectsManager::clearAllProjectSettings( const QString &projectFullName )
+{
+  clearCachedAttributesValueSettings( projectFullName );
+}
+
+void LocalProjectsManager::clearCachedAttributesValueSettings( const QString &projectFullName )
+{
+  QSettings settings;
+  settings.beginGroup( "cachedAttributesValue/" + projectFullName );
+  settings.remove( "" );
+  settings.endGroup();
+}
+

--- a/core/localprojectsmanager.cpp
+++ b/core/localprojectsmanager.cpp
@@ -261,7 +261,7 @@ void LocalProjectsManager::clearAllProjectSettings( const QString &projectFullNa
 void LocalProjectsManager::clearCachedAttributesValueSettings( const QString &projectFullName )
 {
   QSettings settings;
-  settings.beginGroup( "cachedAttributesValue/" + projectFullName );
+  settings.beginGroup( QStringLiteral( "%1/%2" ).arg( CoreUtils::CACHED_ATTRIBUTES_GROUP, projectFullName ) );
   settings.remove( "" );
   settings.endGroup();
 }

--- a/core/localprojectsmanager.h
+++ b/core/localprojectsmanager.h
@@ -68,6 +68,12 @@ class LocalProjectsManager : public QObject
     //! Finds all QGIS project files and set the err variable if any occured.
     QString findQgisProjectFile( const QString &projectDir, QString &err );
 
+    //! Clears all settings groups for the given project full name
+    void clearAllProjectSettings( const QString &projectFullName );
+
+    //! Clears only the cachedAttributesValue settings group for the given project full name
+    void clearCachedAttributesValueSettings( const QString &projectFullName );
+
   signals:
     void localProjectAdded( const LocalProject &project );
     void localProjectDataChanged( const LocalProject &project );


### PR DESCRIPTION
Support for QGIS's native `reuseLastValue` option and refactoring of `RememberAttributesController` to store attribute values persistently in QSettings instead of in-memory, making them survive reinstantiation on each new form open. This adds project-specific storage with `ActiveProject` integration. On project deletion, stored settings from `RememberAttributesController` are cleared.

Fix #3784
