### PR TITLE
Fix password hint

### DIFF
--- a/core/merginapi.cpp
+++ b/core/merginapi.cpp
@@ -1311,6 +1311,12 @@ void MerginApi::registrationFinished( const QString &login, const QString &passw
         emit registrationFailed( msg, RegistrationError::RegistrationErrorType::EMAIL );
         emit notifyError( tr( "Registration failed" ) );
       }
+      else if ( serverErrorCode == "ExistingEmail" )
+      {
+        const QString msg = tr( "This email address is already registered" );
+        emit registrationFailed( msg, RegistrationError::RegistrationErrorType::EMAIL );
+        emit notifyError( tr( "Registration failed" ) );
+      }
       else if ( serverErrorCode == "InvalidPassword" )
       {
         const QString msg = tr( "Password not strong enough!%1"

--- a/core/merginapi.cpp
+++ b/core/merginapi.cpp
@@ -829,16 +829,15 @@ void MerginApi::registerUser( const QString &email,
 
   if ( password.isEmpty() || password.length() < 8 )
   {
-    QString msg = tr( "Password not strong enough!%1"
-                      "%3 Password must be at least 8 characters long.%4"
-                      "%3 Password must contain at least 3 character categories among the following:"
-                      "<ul type=\"disc\">"
-                      "%3 Lowercase characters (a-z)%4"
-                      "%3 Uppercase characters (A-Z)%4"
-                      "%3 Digits (0-9)%4"
-                      "%3 Special characters %4"
-                      "%2%4%2" )
-                  .arg( "<ul>", "</ul>", "<li>", "</li>" );
+    const QString msg = tr( "%1%3 Password must be at least 8 characters long.%4"
+                            "%3 Include at least 3 character categories among the following:"
+                            "<ul type=\"disc\">"
+                            "%3 Lowercase characters (a-z)%4"
+                            "%3 Uppercase characters (A-Z)%4"
+                            "%3 Digits (0-9)%4"
+                            "%3 Special characters %4"
+                            "%2%4%2" )
+                        .arg( "<ul>", "</ul>", "<li>", "</li>" );
     emit registrationFailed( msg, RegistrationError::RegistrationErrorType::PASSWORD );
     return;
 
@@ -1319,9 +1318,8 @@ void MerginApi::registrationFinished( const QString &login, const QString &passw
       }
       else if ( serverErrorCode == "InvalidPassword" )
       {
-        const QString msg = tr( "Password not strong enough!%1"
-                                "%3 Password must be at least 8 characters long.%4"
-                                "%3 Password must contain at least 3 character categories among the following:"
+        const QString msg = tr( "%1%3 Password must be at least 8 characters long.%4"
+                                "%3 Include at least 3 character categories among the following:"
                                 "<ul type=\"disc\">"
                                 "%3 Lowercase characters (a-z)%4"
                                 "%3 Uppercase characters (A-Z)%4"

--- a/core/merginapi.cpp
+++ b/core/merginapi.cpp
@@ -829,12 +829,16 @@ void MerginApi::registerUser( const QString &email,
 
   if ( password.isEmpty() || password.length() < 8 )
   {
-    QString msg = tr( "Password not strong enough. It must"
-                      "%1 be at least 8 characters long"
-                      "%1 contain lowercase characters"
-                      "%1 contain uppercase characters"
-                      "%1 contain digits or special characters" )
-                  .arg( "<br />  -" );
+    QString msg = tr( "Password not strong enough!%1"
+                      "%3 Password must be at least 8 characters long.%4"
+                      "%3 Password must contain at least 3 character categories among the following:"
+                      "<ul type=\"disc\">"
+                      "%3 Lowercase characters (a-z)%4"
+                      "%3 Uppercase characters (A-Z)%4"
+                      "%3 Digits (0-9)%4"
+                      "%3 Special characters %4"
+                      "%2%4%2" )
+                  .arg( "<ul>", "</ul>", "<li>", "</li>" );
     emit registrationFailed( msg, RegistrationError::RegistrationErrorType::PASSWORD );
     return;
 

--- a/core/merginapi.cpp
+++ b/core/merginapi.cpp
@@ -829,13 +829,11 @@ void MerginApi::registerUser( const QString &email,
 
   if ( password.isEmpty() || password.length() < 8 )
   {
-    const QString msg = tr( "%1%3 Password must be at least 8 characters long.%4"
-                            "%3 Include at least 3 character categories among the following:"
+    const QString msg = tr( "%1%3 Password must be at least 8 characters long and include:"
                             "<ul type=\"disc\">"
                             "%3 Lowercase characters (a-z)%4"
                             "%3 Uppercase characters (A-Z)%4"
-                            "%3 Digits (0-9)%4"
-                            "%3 Special characters %4"
+                            "%3 At least one digit (0–9) or special character%4"
                             "%2%4%2" )
                         .arg( "<ul>", "</ul>", "<li>", "</li>" );
     emit registrationFailed( msg, RegistrationError::RegistrationErrorType::PASSWORD );
@@ -1318,13 +1316,11 @@ void MerginApi::registrationFinished( const QString &login, const QString &passw
       }
       else if ( serverErrorCode == "InvalidPassword" )
       {
-        const QString msg = tr( "%1%3 Password must be at least 8 characters long.%4"
-                                "%3 Include at least 3 character categories among the following:"
+        const QString msg = tr( "%1%3 Password must be at least 8 characters long and include:"
                                 "<ul type=\"disc\">"
                                 "%3 Lowercase characters (a-z)%4"
                                 "%3 Uppercase characters (A-Z)%4"
-                                "%3 Digits (0-9)%4"
-                                "%3 Special characters %4"
+                                "%3 At least one digit (0–9) or special character%4"
                                 "%2%4%2" )
                             .arg( "<ul>", "</ul>", "<li>", "</li>" );
         emit registrationFailed( msg, RegistrationError::RegistrationErrorType::PASSWORD );


### PR DESCRIPTION
Fixes #3734 

We replace the outdated hint with new hint.

![image](https://github.com/user-attachments/assets/3c394476-9c74-4a74-aa08-b016996df5df)

Also part of this PR will be seeing this hint, when the password check fails on server (which actually does the whole check) and not just notification that password is not strong enough.