### PR TITLE
Tidy up after update to Qt 6.8.3

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -132,7 +132,7 @@ set(INPUT_SDK_PATH
     ${INPUT_SDK_PATH_DEFAULT}
     CACHE
       PATH
-      "Path to the Mergin Maps Input SDK on host machine; on android define ENV variable instead and without the ABI suffix (armeabi-v7a, arm64-v8a)"
+      "Path to the Mergin Maps Mobile-SDK on host machine; on android define ENV variable instead and without the ABI suffix (armeabi-v7a, arm64-v8a)"
 )
 set(ENABLE_TESTS
     ${ENABLE_TESTS_DEFAULT}
@@ -147,7 +147,7 @@ set(USE_KEYCHAIN
     FALSE
     CACHE
       BOOL
-      "Wheter to use keychains/wallets to store credentials. If false, we use QSettings"
+      "Whether to use keychains/wallets to store credentials. If false, we use QSettings"
 )
 
 set(QT6_VERSION
@@ -161,7 +161,7 @@ set(INPUT_VERSION_CODE
 )
 
 mm_detect_version()
-message(STATUS "Mergin Maps Input ${version_desc} - ${platform_desc}")
+message(STATUS "Mergin Maps Mobile ${version_desc} - ${platform_desc}")
 
 # ########################################################################################
 # FIND PACKAGES

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -1,4 +1,4 @@
-Building Mergin Maps mobile app from source - step by step
+Building Mergin Maps Mobile from source - step by step
 
 
 # Table of Contents
@@ -23,9 +23,9 @@ Building Mergin Maps mobile app from source - step by step
 # 1. Introduction
 
 This document is the original installation guide of the described software
-Mergin Maps Input. The software and hardware descriptions named in this
+Mergin Maps Mobile. The software and hardware descriptions named in this
 document are in most cases registered trademarks and are therefore subject
-to the legal requirements. Mergin Maps Input is subject to the GNU General Public
+to the legal requirements. Mergin Maps Mobile is subject to the GNU General Public
 License.
 
 The details, that are given in this document have been written and verified
@@ -44,14 +44,14 @@ place for describing build procedures. Please do not remove this notice.
 
 # 2. Overview
 
-Mergin Maps Input, like a number of major projects (e.g., KDE 4.0),
+Mergin Maps Mobile, like a number of major projects (e.g., KDE 4.0),
 uses [CMake](https://www.cmake.org) for building from source.
 
 It is C++ application build on top of [Qt](https://www.qt.io), [QGIS](https://www.qgis.org/en/site/)
 and many other FOSS libraries. 
 
 All required libraries (in release configuration) are packaged in the [Mobile-SDK](https://github.com/MerginMaps/mobile-sdk).
-If you need to debug some error in the library, you need to compile Input-SDK in debug yourself locally. Otherwise
+If you need to debug some error in the library, you need to compile Mobile-SDK in debug yourself locally. Otherwise,
 it is suggested to download required libraries from [Mobile-SDK tags](https://github.com/MerginMaps/mobile-sdk/tags)
 Mobile-SDK uses vcpkg packaging system, so if the SDK for your target system/architecture you can build it yourself.
 
@@ -103,8 +103,8 @@ In case you want to skip execution of pre-commit hooks, add additional flag `--n
 
 ## 2.3 Required Qt packages
 
-Mergin Maps is built with Qt. If you are using Qt's `Maintenance tool`, make sure to install these packages:
- - `Android` -> when building for Andoroid
+Mergin Maps Mobile is built with Qt. If you are using Qt's `Maintenance tool`, make sure to install these packages:
+ - `Android` -> when building for Android
  - `iOS` -> when building for iOS
  - `macOS` -> or other desktop platform based on your host machine
  - `Qt 5 Compatibility Module`
@@ -119,37 +119,37 @@ Mergin Maps is built with Qt. If you are using Qt's `Maintenance tool`, make sur
 
 This guide is tested with Ubuntu 22.04, on other distros some steps may need some adjustments.
 
-Steps to build and run Input:
+Steps to build and run Mobile:
 
 1. Install some dependencies, critically bison and flex. See "Install Build Dependencies" step in `.github/workflows/linux.yml`
 
-2. Get Input SDK - it contains pre-built dependencies of libraries used by Input
+2. Get Mobile-SDK - it contains pre-built dependencies of libraries used by Mobile
 
    - Check what SDK version is currently in use - look for `INPUT_SDK_VERSION` in `.github/workflows/linux.yml`
-   - Download Input SDK for Ubuntu - go to https://github.com/merginmaps/input-sdk/releases and download the built SDK.
-   - Unpack the downloaded .tar.gz to `~/input-sdk/x64-linux`
+   - Download Mobile-SDK for Ubuntu - go to https://github.com/merginmaps/mobile-sdk/releases and download the built SDK.
+   - Unpack the downloaded .tar.gz to `~/mobile-sdk/x64-linux`
 
-3. Get Qt libraries - Ubuntu's system libraries are too old, and currently Input SDK does not include Qt SDK.
+3. Get Qt libraries - Ubuntu's system libraries are too old, and currently Mobile-SDK does not include Qt SDK.
 
    - Check what Qt version is currently in use - look for `QT_VERSION` in `.github/workflows/linux.yml`
    - Download Qt online installer from https://www.qt.io/download-open-source
    - Use the online installer to install Qt to `~/Qt`
 
-4. Build Input (update CMake command with the correct Qt and Input SDK versions)
+4. Build Mobile (update CMake command with the correct Qt and Mobile-SDK versions)
 
    ```
    mkdir build
    cd build
    cmake -G Ninja \
      -DCMAKE_PREFIX_PATH=~/Qt/6.8.3/gcc_64 \
-     -DINPUT_SDK_PATH=~/input-sdk/x64-linux \
+     -DINPUT_SDK_PATH=~/mobile-sdk/x64-linux \
      -DQGIS_QUICK_DATA_PATH=../app/android/assets/qgis-data \
      -DUSE_MM_SERVER_API_KEY=FALSE \
      ..
    ninja
    ```
 
-5. Run Input
+5. Run Mobile
 
    ```
    ./app/Input
@@ -158,7 +158,7 @@ Steps to build and run Input:
 
 # 4. Building Android (on Ubuntu/macOS/Windows)
 
-For building ABIS see https://www.qt.io/blog/android-multi-abi-builds-are-back
+For building ABIs see https://www.qt.io/blog/android-multi-abi-builds-are-back
 
 If you have "error: undefined reference to 'stdout'" or so, make sure that in BUILD ENV you have ANDROID_NDK_PLATFORM=android-24 or later!
 
@@ -168,35 +168,35 @@ If you have "error: undefined reference to 'stdout'" or so, make sure that in BU
 
 1. Install some dependencies, see requirements in `.github/workflows/android.yml`
 
-   - Java >= 17 (on Ubuntu 22.04 do `sudo apt install openjdk-17-jdk` and make sure it is the default by checking `java --version`)
+   - Java 17 (on Ubuntu 22.04 do `sudo apt install openjdk-17-jdk` and make sure it is the default by checking `java --version`)
    - android SDK + build tools to `~/android`, android NDK to `~/android/ndk/<ver>`:
       - Get [Android command line tools](https://developer.android.com/studio/index.html#command-line-tools-only) and extract to `~/android/cmdline-tools`
-      - `./cmdline-tools/bin/sdkmanager --sdk_root=./ "build-tools;33.0.1" "ndk;25.2.9519653" "platforms;android-33" platform-tools tools`
+      - `./cmdline-tools/bin/sdkmanager --sdk_root=./ "build-tools;34.0.0" "ndk;26.1.10909125" "platforms;android-34" platform-tools tools`
    - flex and bison
 
-2. Get Input SDK - it contains pre-built dependencies of libraries used by Input
+2. Get Mobile-SDK - it contains pre-built dependencies of libraries used by Mobile
 
    - Check what SDK version is currently in use - look for `INPUT_SDK_VERSION` in `.github/workflows/android.yml`
-   - Download TWO Input SDKs for android - go to https://github.com/merginmaps/input-sdk/releases and download the built SDK.
-   - Unpack the downloaded .tar.gz to `~/input-sdk/arm-android` and `~/input-sdk/arm64-android`
+   - Download **TWO** Mobile-SDKs for android - go to https://github.com/merginmaps/mobile-sdk/releases and download the built SDK.
+   - Unpack the downloaded .tar.gz to `~/mobile-sdk/arm-android` and `~/mobile-sdk/arm64-android`
+   - WARNING!! It is super important to have both SDKs in same subfolder (e.g. `~/mobile-sdk`) and have folder name `arm64-android` and `arm-android`
 
-3. Get Qt libraries - Ubuntu's system libraries are too old, and currently Input SDK does not include Qt SDK.
+3. Get Qt libraries - Ubuntu's system libraries are too old, and currently Mobile-SDK does not include Qt SDK.
  
    - You need both linux and android Qt installed!
    - Check what Qt version is currently in use - look for `QT_VERSION` in `.github/workflows/android.yml`
    - Download Qt online installer from https://www.qt.io/download-open-source
    - Use the online installer to install Qt to `~/Qt`
 
-4. Build Input (update CMake command with the correct Qt and Input SDK versions)
+4. Build Mobile (update CMake command with the correct Qt and Mobile-SDK versions)
 ```
   mkdir build
   cd build
 
   export ANDROID_SDK_ROOT=~/android;
-  export ANDROID_NDK_ROOT=~/android/ndk/25.2.9519653;
-  export ANDROID_NDK_PLATFORM=android-25;
-  export QT_BASE=~/Qt/6.6.3;
-  export INPUT_SDK_ANDROID_BASE=~/input-sdk;
+  export ANDROID_NDK_ROOT=~/android/ndk/26.1.10909125;
+  export QT_BASE=~/Qt/6.8.3;
+  export INPUT_SDK_ANDROID_BASE=~/mobile-sdk;
   
   cmake \
     -DCMAKE_BUILD_TYPE=Release \
@@ -214,7 +214,7 @@ If you have "error: undefined reference to 'stdout'" or so, make sure that in BU
 
 1. Get Qt libraries
  
-   - You need both macos and android Qt installed!
+   - You need both macOS and android Qt installed!
    - Check what Qt version is currently in use - look for `QT_VERSION` in `.github/workflows/android.yml`
    - Download Qt online installer from https://www.qt.io/download-open-source
    - Use the online installer to install Qt to `~/Qt`
@@ -222,7 +222,7 @@ If you have "error: undefined reference to 'stdout'" or so, make sure that in BU
 
 2. Install Java
 
-   - `brew install openjdk@17`, then make this java version default ``export JAVA_HOME=`usr/libexec/java_home -v 17` ``. Check if it default by executing `java --version`
+   - `brew install openjdk@17`, then make this java version default ``export JAVA_HOME=`usr/libexec/java_home -v 17` ``. Check if it's default by executing `java --version`
 
 3. Setup Android SDK & NDK [Automatic, via QtCreator]
    - This step can now be performed via QtCreator, if it for some reason fails/does not work, skip this step and continue with manual setup
@@ -241,10 +241,10 @@ If you have "error: undefined reference to 'stdout'" or so, make sure that in BU
    - Get Android `sdkmanager` by following these steps https://developer.android.com/tools/sdkmanager
    - Now perform `./cmdline-tools/bin/sdkmanager --sdk_root=./ "build-tools;34.0.0" "ndk;26.1.10909125" "platforms;android-34" platform-tools tools` to install all needed Android tools, make sure to double-check if the version numbers are correct
 
-5. Get MM mobile SDK - it contains pre-built dependencies of used libraries (QGIS, etc..)
+5. Get Mobile-SDK - it contains pre-built dependencies of used libraries (QGIS, etc..)
 
    - Check what SDK version is currently in use - look for `INPUT_SDK_VERSION` in `.github/workflows/android.yml`
-   - Download TWO SDKs for android (arm and arm64) - go to https://github.com/merginmaps/mobile-sdk/releases and download the built SDK.
+   - Download **TWO** SDKs for android (arm and arm64) - go to https://github.com/merginmaps/mobile-sdk/releases and download the built SDK.
    - Unpack the downloaded .tar.gz to `~/mobile-sdk/arm-android` and `~/mobile-sdk/arm64-android`
    - WARNING!! It is super important to have both SDKs in same subfolder (e.g. `~/mobile-sdk`) and have folder name `arm64-android` and `arm-android`
 
@@ -253,8 +253,7 @@ If you have "error: undefined reference to 'stdout'" or so, make sure that in BU
 ```
   # Needed Android variables
   export ANDROID_SDK_ROOT=~/android;
-  export ANDROID_NDK_ROOT=~/android/ndk/25.1.8937393;
-  export ANDROID_NDK_PLATFORM=android-24;
+  export ANDROID_NDK_ROOT=~/android/ndk/26.1.10909125;
 
   # INPUT_SDK_ANDROID_BASE is a path where you stored the two SDKs from the mobile-sdk repo
   export INPUT_SDK_ANDROID_BASE=~/mobile-sdk;
@@ -279,12 +278,12 @@ If you have "error: undefined reference to 'stdout'" or so, make sure that in BU
 **Note to document writers:**: This section needs a proper rewrite
 
 Even technically it should be possible, we haven't tried this setup yet. If you managed to compile 
-Mergin Maps Input Android on Windows, please help us to update this section. 
+Mobile for Android on Windows, please help us to update this section. 
 
 # 5. Building iOS
 
 - you have to run Release or RelWithDebInfo builds. Debug builds will usually crash on some Qt's assert
-- if there is any problem running Input App from Qt Creator, open cmake-generated project in XCode directly
+- if there is any problem running Mobile from Qt Creator, open cmake-generated project in XCode directly
   
 1. Setup development environment
    - XCode
@@ -292,27 +291,27 @@ Mergin Maps Input Android on Windows, please help us to update this section.
    - if you want to build for production, you need development certificates. These are not needed for local development, signing is handled automatically (see IOS_USE_PRODUCTION_SIGNING cmake variable for more info). You can get the certificates by following:
        - Get device UDID: either iTunes or about this mac->system report->USB->find iPAD (Serial Number)
        - Create dev iOS certificate for development
-       - Create provisioning profile for Input App + your certificate + your device (for this ask Lutra Apple development team)
+       - Create provisioning profile for Mobile + your certificate + your device (for this ask Lutra Apple development team)
    - ios-toolchain 
-       - download ios.toolchain.cmake from https://github.com/leetal/ios-cmake to `~/input-sdk/ios.toolchain.cmake`
+       - download ios.toolchain.cmake from https://github.com/leetal/ios-cmake to `~/mobile-sdk/ios.toolchain.cmake`
        - version from `.github/workflows/ios.yml`
 
-2. Get Input SDK - it contains pre-built dependencies of libraries used by Input
+2. Get Mobile-SDK - it contains pre-built dependencies of libraries used by Mobile
 
    - Check what SDK version is currently in use - look for `INPUT_SDK_VERSION` in `.github/workflows/ios.yml`
-   - Download Input SDKs for ios - go to https://github.com/merginmaps/input-sdk/releases and download the built SDK.
-   - Unpack the downloaded .tar.gz to `~/input-sdk/arm64-ios`
+   - Download Mobile-SDKs for ios - go to https://github.com/merginmaps/mobile-sdk/releases and download the built SDK.
+   - Unpack the downloaded .tar.gz to `~/mobile-sdk/arm64-ios`
 
 3. Get Qt libraries
  
-   - You need both macos and ios Qt installed!
+   - You need both macOS and ios Qt installed!
    - Check what Qt version is currently in use - look for `QT_VERSION` in `.github/workflows/ios.yml`
    - Download Qt online installer from https://www.qt.io/download-open-source
    - Use the online installer to install Qt to `/opt/Qt`
 
-4. Build Input (update CMake command with the correct Qt and Input SDK versions)
+4. Build Mobile (update CMake command with the correct Qt and Mobile-SDK versions)
 
-Now you can create a build (either on commmand line or by setting these variables in Qt Creator)
+Now you can create a build (either on command line or by setting these variables in Qt Creator)
 
 ```
   mkdir build
@@ -323,10 +322,10 @@ Now you can create a build (either on commmand line or by setting these variable
     -DIOS=TRUE \
     -DCMAKE_PREFIX_PATH=/opt/Qt/6.8.3/ios \
     -DQT_HOST_PATH=/opt/Qt/6.8.3/macos \
-    -DCMAKE_TOOLCHAIN_FILE:PATH="~/input-sdk/ios.toolchain.cmake" \
+    -DCMAKE_TOOLCHAIN_FILE:PATH="~/mobile-sdk/ios.toolchain.cmake" \
     -DCMAKE_INSTALL_PREFIX:PATH="../install" \
     -DUSE_SERVER_API_KEY=FALSE \
-    -DINPUT_SDK_PATH=~/input-sdk/arm64-ios \
+    -DINPUT_SDK_PATH=~/mobile-sdk/arm64-ios \
     -G "Xcode" \
     ../input
 ```
@@ -335,13 +334,13 @@ Now you can create a build (either on commmand line or by setting these variable
 
 1. Install some dependencies, critically XCode, bison and flex. See "Install Build Dependencies" step in `.github/workflows/macos.yml`
 
-2. Get MM mobile SDK - it contains pre-built dependencies of used libraries
+2. Get Mobile-SDK - it contains pre-built dependencies of used libraries
 
    - Check what SDK version is currently in use - look for `INPUT_SDK_VERSION` in `.github/workflows/macos.yml`
-   - Download mobile SDK for `osx` - go to https://github.com/merginmaps/mobile-sdk/releases and download the built SDK.
+   - Download Mobile-SDK for `osx` - go to https://github.com/merginmaps/mobile-sdk/releases and download the built SDK.
    - Unpack the downloaded .tar.gz to `~/mobile-sdk/x64-osx` or `~/mobile-sdk/arm64-osx`
 
-3. Get Qt libraries - Mobile SDK does not include Qt SDK
+3. Get Qt libraries - Mobile-SDK does not include Qt SDK
 
    - Check what Qt version is currently in use - look for `QT_VERSION` in `.github/workflows/macos.yml`
    - Download Qt online installer from https://www.qt.io/download-open-source
@@ -349,31 +348,31 @@ Now you can create a build (either on commmand line or by setting these variable
 
 4. Build (update CMake command with the correct Qt and paths)
 
-```
-mkdir build-desktop 
-cd build-desktop
-
-cmake \
-  -DCMAKE_BUILD_TYPE=Debug \
-  -DCMAKE_PREFIX_PATH=/opt/Qt/6.8.3/macos \
-  -DINPUT_SDK_PATH=<path_to_mobile_sdk_from_step_2> \
-  -DQGIS_QUICK_DATA_PATH=<path_to_mobile_repo>/app/android/assets/qgis-data \
-  -GNinja \
-  ..
-
-ninja
-```
+    ```
+    mkdir build-desktop 
+    cd build-desktop
+    
+    cmake \
+      -DCMAKE_BUILD_TYPE=Debug \
+      -DCMAKE_PREFIX_PATH=/opt/Qt/6.8.3/macos \
+      -DINPUT_SDK_PATH=<path_to_mobile_sdk_from_step_2> \
+      -DQGIS_QUICK_DATA_PATH=<path_to_mobile_repo>/app/android/assets/qgis-data \
+      -GNinja \
+      ..
+    
+    ninja
+    ```
 
 5. Run the app
-```
-./app/Input.app/Contents/MacOS/Input
-```
+    ```
+    ./app/Input.app/Contents/MacOS/Input
+    ```
 
 # 7. Building Windows
 
 For version of the tools used, see `.github/workflows/win.yml`
 
-- download input-sdk for win, extract to C:\projects\input-sdk\win-sdk
+- download Mobile-SDK for win, extract to C:\projects\mobile-sdk\win-sdk
 - download and install Qt
 - download and install QtCreator for debugging executable
 - download and install Visual Studio, SDK, Python, Cmake
@@ -381,7 +380,7 @@ For version of the tools used, see `.github/workflows/win.yml`
 - open cmd
 - setup build environment
 ```
-set ROOT_DIR=C:\Users\zilol\Projects
+set ROOT_DIR=C:\Users\<your_user>\Projects
 set Qt6_DIR=C:\Qt\6.8.3\msvc2019_64
 set PATH=%QT_ROOT%\bin;C:\Program Files\CMake\bin\;%PATH%
 "C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\Common7\Tools\VsDevCmd.bat" -arch=x64
@@ -395,7 +394,7 @@ cmake ^
    -DCMAKE_BUILD_TYPE=Release ^
    -DCMAKE_PREFIX_PATH:PATH=%Qt6_Dir%^
    -DCMAKE_INSTALL_PREFIX:PATH=%ROOT_DIR%\install\input ^
-   -DINPUT_SDK_PATH:PATH=%ROOT_DIR%\input-sdk\x64-windows ^
+   -DINPUT_SDK_PATH:PATH=%ROOT_DIR%\mobile-sdk\x64-windows ^
    -G "NMake Makefiles" ^
    -DCMAKE_CXX_COMPILER_LAUNCHER=ccache ^
    -S %ROOT_DIR%\input ^
@@ -411,10 +410,10 @@ nmake
 # 8. Auto Testing
 
 You need to add cmake define `-DENABLE_TESTING=TRUE` on your cmake configure line.
-Also you need to open Passbolt and check for password for user `test_mobileapp` on `app.dev.merginmaps.com`, 
+Also, you need to open Passbolt and check for password for user `test_mobileapp` on `app.dev.merginmaps.com`, 
 or you need some user with unlimited projects limit. First workspace from list is taken.
 
-! Note that the same user cannot run tests in paraller ! This user is used for CI, consider creating your own account for local development !
+! Note that the same user cannot run tests in parallel ! This user is used for CI, consider creating your own account for local development !
 
 now you need to set environment variables: 
 ```
@@ -423,5 +422,5 @@ TEST_API_USERNAME=test_mobileapp
 TEST_API_PASSWORD=<your_password>
 ```
 
-Build binary and you can run tests either with `ctest` or you can run individual tests by adding `--test<TestName>`
+Build binary, and you can run tests either with `ctest` or you can run individual tests by adding `--test<TestName>`
 e.g. ` ./input --testMerginApi`

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -1,6 +1,3 @@
-Building Mergin Maps Mobile from source - step by step
-
-
 # Table of Contents
 <!-- Table of contents generated with https://freelance-tech-writer.github.io/table-of-contents-generator/index.html -->
 
@@ -10,22 +7,23 @@ Building Mergin Maps Mobile from source - step by step
   - [2.1 Secrets](#21-secrets)
   - [2.2 Code formatting](#22-code-formatting)
   - [2.3 Required Qt packages](#23-required-qt-packages)
-- [3. Building GNU/Ubuntu](#3-building-gnuubuntu)
-- [4. Building Android (on Ubuntu/macOS/Windows)](#4-building-android-on-ubuntumacoswindows)
+- [3. Building GNU/Linux](#3-building-gnulinux)
+- [4. Building Android (on Linux/macOS/Windows)](#4-building-android-on-linuxmacoswindows)
   - [4.1. Android on Ubuntu](#41-android-on-ubuntu)
   - [4.2. Android on macOS](#42-android-on-macos)
   - [4.3. Android on Windows](#43-android-on-windows)
 - [5. Building iOS](#5-building-ios)
 - [6. Building macOS](#6-building-macos)
 - [7. Building Windows](#7-building-windows)
-- [8. Auto Testing](#8-auto-testing)
+- [8. Common problems](#8-common-problems)
+- [9. Auto Testing](#9-auto-testing)
 
 # 1. Introduction
 
 This document is the original installation guide of the described software
-Mergin Maps Mobile. The software and hardware descriptions named in this
+Mergin Maps mobile app. The software and hardware descriptions named in this
 document are in most cases registered trademarks and are therefore subject
-to the legal requirements. Mergin Maps Mobile is subject to the GNU General Public
+to the legal requirements. Mergin Maps mobile app is subject to the GNU General Public
 License.
 
 The details, that are given in this document have been written and verified
@@ -44,7 +42,7 @@ place for describing build procedures. Please do not remove this notice.
 
 # 2. Overview
 
-Mergin Maps Mobile, like a number of major projects (e.g., KDE 4.0),
+Mobile app, like a number of major projects (e.g., KDE 4.0),
 uses [CMake](https://www.cmake.org) for building from source.
 
 It is C++ application build on top of [Qt](https://www.qt.io), [QGIS](https://www.qgis.org/en/site/)
@@ -52,7 +50,7 @@ and many other FOSS libraries.
 
 All required libraries (in release configuration) are packaged in the [Mobile-SDK](https://github.com/MerginMaps/mobile-sdk).
 If you need to debug some error in the library, you need to compile Mobile-SDK in debug yourself locally. Otherwise,
-it is suggested to download required libraries from [Mobile-SDK tags](https://github.com/MerginMaps/mobile-sdk/tags)
+it is suggested to download required libraries from [Mobile-SDK tags](https://github.com/MerginMaps/mobile-sdk/tags).
 Mobile-SDK uses vcpkg packaging system, so if the SDK for your target system/architecture you can build it yourself.
 
 Generally, for building setup, you need the same versions of libraries/SDKs/NDKs/compilers as used in the official 
@@ -65,13 +63,13 @@ To communicate with MerginAPI, some endpoints need to attach `api_key`. To not l
 the source code that returns the API_KEYS is encrypted.
 
 As a developer, if you want to develop against local Mergin Maps server, it is OK, but to
-work with public or dev.dev server, you need to manually decrypt the file. Decrypted file is never
+work with public or dev server, you need to manually decrypt the file. Decrypted file is never
 pushed to git!
 
-The password for decryption is in out password manager.
+The password for decryption is in our password manager.
 
-if you want to change the secrets, decrypt, change and encrypt the file
-[openssl](http://stackoverflow.com/questions/16056135/ddg#16056298)
+if you want to change the secrets, decrypt, change and encrypt the file with
+[openssl](http://stackoverflow.com/questions/16056135/ddg#16056298), also
 make sure you update the keys in password manager and in the kubernetes
 manifest files.
 
@@ -103,7 +101,7 @@ In case you want to skip execution of pre-commit hooks, add additional flag `--n
 
 ## 2.3 Required Qt packages
 
-Mergin Maps Mobile is built with Qt. If you are using Qt's `Maintenance tool`, make sure to install these packages:
+Mergin Maps Mobile app is built with Qt. If you are using Qt's `Maintenance tool`, make sure to install these packages:
  - `Android` -> when building for Android
  - `iOS` -> when building for iOS
  - `macOS` -> or other desktop platform based on your host machine
@@ -115,91 +113,96 @@ Mergin Maps Mobile is built with Qt. If you are using Qt's `Maintenance tool`, m
    - `Qt Positioning`
    - `Qt Sensors`
 
-# 3. Building GNU/Ubuntu
+# 3. Building GNU/Linux
 
 This guide is tested with Ubuntu 22.04, on other distros some steps may need some adjustments.
 
-Steps to build and run Mobile:
+Steps to build and run mobile app:
 
 1. Install some dependencies, critically bison and flex. See "Install Build Dependencies" step in `.github/workflows/linux.yml`
 
-2. Get Mobile-SDK - it contains pre-built dependencies of libraries used by Mobile
+2. Get Mobile-SDK - it contains pre-built dependencies of libraries used by mobile app
 
    - Check what SDK version is currently in use - look for `INPUT_SDK_VERSION` in `.github/workflows/linux.yml`
-   - Download Mobile-SDK for Ubuntu - go to https://github.com/merginmaps/mobile-sdk/releases and download the built SDK.
+   - Download Mobile-SDK for Linux - go to https://github.com/merginmaps/mobile-sdk/releases and download the built SDK.
    - Unpack the downloaded .tar.gz to `~/mobile-sdk/x64-linux`
 
-3. Get Qt libraries - Ubuntu's system libraries are too old, and currently Mobile-SDK does not include Qt SDK.
+3. Get Qt libraries - currently Mobile-SDK does not include Qt SDK.
 
-   - Check what Qt version is currently in use - look for `QT_VERSION` in `.github/workflows/linux.yml`
-   - Download Qt online installer from https://www.qt.io/download-open-source
-   - Use the online installer to install Qt to `~/Qt`
+   - Ubuntu's system libraries are too old, and we recommend to use Qt's online installer
+     - Check what Qt version is currently in use - look for `QT_VERSION` in `.github/workflows/linux.yml`
+     - Download Qt online installer from https://www.qt.io/download-open-source
+     - Use the online installer to install Qt to `~/Qt`
+   - Fedora and any more recent distribution can probably use the system packages
+     - Check what Qt version is currently in use - look for `QT_VERSION` in `.github/workflows/linux.yml`
+     - If the system package version is same or higher use it
 
-4. Build Mobile (update CMake command with the correct Qt and Mobile-SDK versions)
+4. Build mobile app (update CMake command with the correct Qt version)
+   - If you are using system packages drop `-DCMAKE_PREFIX_PATH=~/Qt/<current_version>/gcc_64`  from the command
 
    ```
    mkdir build
    cd build
    cmake -G Ninja \
-     -DCMAKE_PREFIX_PATH=~/Qt/6.8.3/gcc_64 \
-     -DINPUT_SDK_PATH=~/mobile-sdk/x64-linux \
-     -DQGIS_QUICK_DATA_PATH=../app/android/assets/qgis-data \
-     -DUSE_MM_SERVER_API_KEY=FALSE \
-     ..
+   -DCMAKE_PREFIX_PATH=~/Qt/<current_version>/gcc_64 \
+   -DINPUT_SDK_PATH=~/mobile-sdk/x64-linux \
+   -DQGIS_QUICK_DATA_PATH=../app/android/assets/qgis-data \
+   -DUSE_MM_SERVER_API_KEY=FALSE \
+   ..
    ninja
    ```
 
-5. Run Mobile
+5. Run mobile app
 
    ```
    ./app/Input
    ```
 
 
-# 4. Building Android (on Ubuntu/macOS/Windows)
+# 4. Building Android (on Linux/macOS/Windows)
 
 For building ABIs see https://www.qt.io/blog/android-multi-abi-builds-are-back
 
-If you have "error: undefined reference to 'stdout'" or so, make sure that in BUILD ENV you have ANDROID_NDK_PLATFORM=android-24 or later!
-
-![image](https://user-images.githubusercontent.com/22449698/166630970-a776576f-c505-4265-b4c8-ffbe212c6745.png)
-
-## 4.1. Android on Ubuntu
+## 4.1. Android on Linux
 
 1. Install some dependencies, see requirements in `.github/workflows/android.yml`
 
    - Java 17 (on Ubuntu 22.04 do `sudo apt install openjdk-17-jdk` and make sure it is the default by checking `java --version`)
    - android SDK + build tools to `~/android`, android NDK to `~/android/ndk/<ver>`:
       - Get [Android command line tools](https://developer.android.com/studio/index.html#command-line-tools-only) and extract to `~/android/cmdline-tools`
-      - `./cmdline-tools/bin/sdkmanager --sdk_root=./ "build-tools;34.0.0" "ndk;26.1.10909125" "platforms;android-34" platform-tools tools`
+      - See current versions of build tools (`SDK_BUILD_TOOLS`), ndk (`NDK_VERSION`) and platform (`SDK_PLATFORM`) in `.github/workflows/android.yml`
+      - `./cmdline-tools/bin/sdkmanager --sdk_root=./ "build-tools;<current_version>" "ndk;<current_version>" "platforms;<current_version>" platform-tools tools`
    - flex and bison
 
-2. Get Mobile-SDK - it contains pre-built dependencies of libraries used by Mobile
+2. Get Mobile-SDK - it contains pre-built dependencies of libraries used by mobile app
 
    - Check what SDK version is currently in use - look for `INPUT_SDK_VERSION` in `.github/workflows/android.yml`
    - Download **TWO** Mobile-SDKs for android - go to https://github.com/merginmaps/mobile-sdk/releases and download the built SDK.
    - Unpack the downloaded .tar.gz to `~/mobile-sdk/arm-android` and `~/mobile-sdk/arm64-android`
    - WARNING!! It is super important to have both SDKs in same subfolder (e.g. `~/mobile-sdk`) and have folder name `arm64-android` and `arm-android`
 
-3. Get Qt libraries - Ubuntu's system libraries are too old, and currently Mobile-SDK does not include Qt SDK.
+3. Get Qt libraries - currently Mobile-SDK does not include Qt SDK.
  
-   - You need both linux and android Qt installed!
-   - Check what Qt version is currently in use - look for `QT_VERSION` in `.github/workflows/android.yml`
-   - Download Qt online installer from https://www.qt.io/download-open-source
-   - Use the online installer to install Qt to `~/Qt`
+   - Ubuntu's system libraries are too old, and usually system packages don't contain android Qt packages
+   - Either use online installer:
+     - You need both linux and android Qt installed!
+     - Check what Qt version is currently in use - look for `QT_VERSION` in `.github/workflows/android.yml`
+     - Download Qt online installer from https://www.qt.io/download-open-source
+     - Use the online installer to install Qt to `~/Qt`
+   - Or cross-compile Qt for android
 
-4. Build Mobile (update CMake command with the correct Qt and Mobile-SDK versions)
+4. Build mobile app (update CMake command with the correct Qt and Android NDK versions)
 ```
   mkdir build
   cd build
 
   export ANDROID_SDK_ROOT=~/android;
-  export ANDROID_NDK_ROOT=~/android/ndk/26.1.10909125;
-  export QT_BASE=~/Qt/6.8.3;
+  export ANDROID_NDK_ROOT=~/android/ndk/<current_version>;
+  export QT_BASE=~/Qt/<current_version>;
   export INPUT_SDK_ANDROID_BASE=~/mobile-sdk;
   
   cmake \
-    -DCMAKE_BUILD_TYPE=Release \
+    -DCMAKE_BUILD_TYPE=Debug \
     -DQT_ANDROID_ABIS="arm64-v8a" \
     -DQT_HOST_PATH=$QT_BASE/gcc_64 \
     -DCMAKE_TOOLCHAIN_FILE=$QT_BASE/android_arm64_v8a/lib/cmake/Qt6/qt.toolchain.cmake \
@@ -239,7 +242,8 @@ If you have "error: undefined reference to 'stdout'" or so, make sure that in BU
    - Proceed with this step only if the previous automatic step did not work for you or you do not want to use QtCreator
 
    - Get Android `sdkmanager` by following these steps https://developer.android.com/tools/sdkmanager
-   - Now perform `./cmdline-tools/bin/sdkmanager --sdk_root=./ "build-tools;34.0.0" "ndk;26.1.10909125" "platforms;android-34" platform-tools tools` to install all needed Android tools, make sure to double-check if the version numbers are correct
+   - See current versions of build tools (`SDK_BUILD_TOOLS`), ndk (`NDK_VERSION`) and platform (`SDK_PLATFORM`) in `.github/workflows/android.yml`
+   - Now perform `./cmdline-tools/bin/sdkmanager --sdk_root=./ "build-tools;<current_version>" "ndk;<current_version>" "platforms;<current_version>" platform-tools tools` to install all needed Android tools, make sure to double-check if the version numbers are correct
 
 5. Get Mobile-SDK - it contains pre-built dependencies of used libraries (QGIS, etc..)
 
@@ -253,7 +257,7 @@ If you have "error: undefined reference to 'stdout'" or so, make sure that in BU
 ```
   # Needed Android variables
   export ANDROID_SDK_ROOT=~/android;
-  export ANDROID_NDK_ROOT=~/android/ndk/26.1.10909125;
+  export ANDROID_NDK_ROOT=~/android/ndk/<current_version>;
 
   # INPUT_SDK_ANDROID_BASE is a path where you stored the two SDKs from the mobile-sdk repo
   export INPUT_SDK_ANDROID_BASE=~/mobile-sdk;
@@ -264,8 +268,8 @@ If you have "error: undefined reference to 'stdout'" or so, make sure that in BU
   cmake \
     -DCMAKE_BUILD_TYPE=Debug \
     -DQT_ANDROID_ABIS=arm64-v8a \
-    -DQT_HOST_PATH=/opt/Qt/6.8.3/macos \
-    -DCMAKE_TOOLCHAIN_FILE=/opt/Qt/6.8.3/android_arm64_v8a/lib/cmake/Qt6/qt.toolchain.cmake \
+    -DQT_HOST_PATH=/opt/Qt/<current_version>/macos \
+    -DCMAKE_TOOLCHAIN_FILE=/opt/Qt/<current_version>/android_arm64_v8a/lib/cmake/Qt6/qt.toolchain.cmake \
     -DUSE_MM_SERVER_API_KEY=FALSE \
     -GNinja \
     ../input/
@@ -278,12 +282,12 @@ If you have "error: undefined reference to 'stdout'" or so, make sure that in BU
 **Note to document writers:**: This section needs a proper rewrite
 
 Even technically it should be possible, we haven't tried this setup yet. If you managed to compile 
-Mobile for Android on Windows, please help us to update this section. 
+mobile app for Android on Windows, please help us to update this section. 
 
 # 5. Building iOS
 
 - you have to run Release or RelWithDebInfo builds. Debug builds will usually crash on some Qt's assert
-- if there is any problem running Mobile from Qt Creator, open cmake-generated project in XCode directly
+- if there is any problem running mobile app from Qt Creator, open cmake-generated project in XCode directly
   
 1. Setup development environment
    - XCode
@@ -291,12 +295,12 @@ Mobile for Android on Windows, please help us to update this section.
    - if you want to build for production, you need development certificates. These are not needed for local development, signing is handled automatically (see IOS_USE_PRODUCTION_SIGNING cmake variable for more info). You can get the certificates by following:
        - Get device UDID: either iTunes or about this mac->system report->USB->find iPAD (Serial Number)
        - Create dev iOS certificate for development
-       - Create provisioning profile for Mobile + your certificate + your device (for this ask Lutra Apple development team)
+       - Create provisioning profile for mobile app + your certificate + your device (for this ask Lutra Apple development team)
    - ios-toolchain 
        - download ios.toolchain.cmake from https://github.com/leetal/ios-cmake to `~/mobile-sdk/ios.toolchain.cmake`
        - version from `.github/workflows/ios.yml`
 
-2. Get Mobile-SDK - it contains pre-built dependencies of libraries used by Mobile
+2. Get Mobile-SDK - it contains pre-built dependencies of libraries used by mobile app
 
    - Check what SDK version is currently in use - look for `INPUT_SDK_VERSION` in `.github/workflows/ios.yml`
    - Download Mobile-SDKs for ios - go to https://github.com/merginmaps/mobile-sdk/releases and download the built SDK.
@@ -309,7 +313,7 @@ Mobile for Android on Windows, please help us to update this section.
    - Download Qt online installer from https://www.qt.io/download-open-source
    - Use the online installer to install Qt to `/opt/Qt`
 
-4. Build Mobile (update CMake command with the correct Qt and Mobile-SDK versions)
+4. Build mobile app (update CMake command with the correct Qt and Mobile-SDK versions)
 
 Now you can create a build (either on command line or by setting these variables in Qt Creator)
 
@@ -320,8 +324,8 @@ Now you can create a build (either on command line or by setting these variables
 
   cmake \
     -DIOS=TRUE \
-    -DCMAKE_PREFIX_PATH=/opt/Qt/6.8.3/ios \
-    -DQT_HOST_PATH=/opt/Qt/6.8.3/macos \
+    -DCMAKE_PREFIX_PATH=/opt/Qt/<current_version>/ios \
+    -DQT_HOST_PATH=/opt/Qt/<current_version>/macos \
     -DCMAKE_TOOLCHAIN_FILE:PATH="~/mobile-sdk/ios.toolchain.cmake" \
     -DCMAKE_INSTALL_PREFIX:PATH="../install" \
     -DUSE_SERVER_API_KEY=FALSE \
@@ -354,7 +358,7 @@ Now you can create a build (either on command line or by setting these variables
     
     cmake \
       -DCMAKE_BUILD_TYPE=Debug \
-      -DCMAKE_PREFIX_PATH=/opt/Qt/6.8.3/macos \
+      -DCMAKE_PREFIX_PATH=/opt/Qt/<current_version>/macos \
       -DINPUT_SDK_PATH=<path_to_mobile_sdk_from_step_2> \
       -DQGIS_QUICK_DATA_PATH=<path_to_mobile_repo>/app/android/assets/qgis-data \
       -GNinja \
@@ -363,7 +367,7 @@ Now you can create a build (either on command line or by setting these variables
     ninja
     ```
 
-5. Run the app
+5. Run the mobile app
     ```
     ./app/Input.app/Contents/MacOS/Input
     ```
@@ -381,7 +385,7 @@ For version of the tools used, see `.github/workflows/win.yml`
 - setup build environment
 ```
 set ROOT_DIR=C:\Users\<your_user>\Projects
-set Qt6_DIR=C:\Qt\6.8.3\msvc2019_64
+set Qt6_DIR=C:\Qt\<current_version>\msvc2019_64
 set PATH=%QT_ROOT%\bin;C:\Program Files\CMake\bin\;%PATH%
 "C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\Common7\Tools\VsDevCmd.bat" -arch=x64
 ```
@@ -407,7 +411,17 @@ set CL=/MP
 nmake
 ```
 
-# 8. Auto Testing
+# 8. Common problems
+
+- If you have "error: undefined reference to 'stdout'" or so, make sure that in BUILD ENV you have ANDROID_NDK_PLATFORM=android-24 or later!
+
+    ![image](https://user-images.githubusercontent.com/22449698/166630970-a776576f-c505-4265-b4c8-ffbe212c6745.png)
+- If for all projects the OSM layer fails to load the `QGIS_QUICK_DATA_PATH` is probably wrong
+  - Check where the projects are getting created
+  - Either change the path to point to `app/android/assets/qgis-data` of the project directory or copy the `proj` directory
+    from project directory to the same directory in the build directory
+
+# 9. Auto Testing
 
 You need to add cmake define `-DENABLE_TESTING=TRUE` on your cmake configure line.
 Also, you need to open Passbolt and check for password for user `test_mobileapp` on `app.dev.merginmaps.com`, 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 <picture>
   <source media="(prefers-color-scheme: dark)" width=350 srcset="https://raw.githubusercontent.com/MerginMaps/.github/main/images/MM_logo_HORIZ_COLOR_INVERSE_VECTOR.svg">
-  <img width=350 src="https://raw.githubusercontent.com/MerginMaps/.github/main/images/MM_logo_HORIZ_COLOR_VECTOR.svg">
+  <img width=350 src="https://raw.githubusercontent.com/MerginMaps/.github/main/images/MM_logo_HORIZ_COLOR_VECTOR.svg" alt="Mergin Maps logo">
 </picture>
 
 Platform builds:
@@ -50,11 +50,11 @@ For more information on how to use the app, see [Documentation](https://merginma
 - Help with translations, join [Mergin Maps mobile app Transifex Team](https://explore.transifex.com/lutra-consulting/mergin-maps-mobile/)
 - Write a review of the application on [App Store](https://apps.apple.com/us/app/mergin-maps/id1478603559) or [Google Play](https://play.google.com/store/apps/details?id=uk.co.lutraconsulting&hl=en&gl=US)
 - Test the application and [report bugs](https://github.com/MerginMaps/mobile/issues)
-- Write a blog post or case study or create a Youtube video. We are happy to help to promote it or co-author and place on our websites
+- Write a blog post or case study or create a YouTube video. We are happy to help to promote it or co-author and place on our websites
 - Software developer? Code and prepare a pull request. We will help you with [setup of the development environment](./INSTALL.md) and answer your questions.
 - Donate or [subscribe](https://merginmaps.com/) to the Mergin Maps Cloud service to help us maintain the project.
 
-<div><img align="left" width="45" height="45" src="https://raw.githubusercontent.com/MerginMaps/docs/main/src/.vuepress/public/slack.svg"><a href="https://merginmaps.com/community/join">Join our community chat</a><br/>and ask questions!</div>
+<div><img style="float: left" width="45" height="45" src="https://raw.githubusercontent.com/MerginMaps/docs/main/src/.vuepress/public/slack.svg" alt="Slack icon"><a href="https://merginmaps.com/community/join">Join our community chat</a><br/>and ask questions!</div>
 
 ## Features
 
@@ -63,10 +63,10 @@ Mergin Maps mobile app features touch optimised GUI components based on Qt Quick
 * Mapping components - map canvas, GPS position, scale bar, markers
 * Support for capturing of new geometries
 * Display and editing of feature forms
-* Built-in service for [storing and synchronising data](https://github.com/MerginMaps/server))
+* Built-in service for [storing and synchronising data](https://github.com/MerginMaps/server)
 * Translated to several [languages](https://explore.transifex.com/lutra-consulting/mergin-maps-input/)
 
-<div><a href="https://merginmaps.com/product"><img src="https://raw.githubusercontent.com/MerginMaps/.github/main/images/mm_app-1-800x600.jpg"></div>
+<div><a href="https://merginmaps.com/product"><img src="https://raw.githubusercontent.com/MerginMaps/.github/main/images/mm_app-1-800x600.jpg" alt="Picture showcasing Mergin Maps mobile features like collaboration, recording geospatial data."></a></div>
 
 ## Documentation
 
@@ -76,7 +76,7 @@ Read more about the app [https://merginmaps.com/docs](https://merginmaps.com/doc
 
 To setup your development environment, read [INSTALL](./INSTALL.md)
 
-New sub-project 'gallery' app is used to develop/design all UI components, used in the Mergin Maps app
+New subproject 'gallery' app is used to develop/design all UI components, used in the Mergin Maps app
 
 ### Code conventions
 

--- a/cmake/FindAbsl.cmake
+++ b/cmake/FindAbsl.cmake
@@ -1911,4 +1911,4 @@ if (NOT TARGET Absl::Absl)
 
 endif ()
 
-find_package_handle_standard_args(absl REQUIRED_VARS ABSL_TARGETS)
+find_package_handle_standard_args(Absl REQUIRED_VARS ABSL_TARGETS)


### PR DESCRIPTION
This PR fixes some minor things after the update:
- fix Absl typo, which generated CMake warning
- fix and update `INSTALL.md`
- clean up some more "input" references