### PR TITLE
Fix multiline feature title breaking eliding & unintended HTML tags parsing 

### DIFF
--- a/app/qml/components/MMListDelegate.qml
+++ b/app/qml/components/MMListDelegate.qml
@@ -84,6 +84,7 @@ Item {
 
           font: __style.t3
           text: root.text
+          textFormat: Text.PlainText
 
           color: __style.nightColor
         }

--- a/app/qml/components/MMPageHeader.qml
+++ b/app/qml/components/MMPageHeader.qml
@@ -56,6 +56,7 @@ Rectangle {
 
     text: root.title?.toString()?.replace(/\n/g, ' ') ?? ''
     elide: Text.ElideMiddle
+    textFormat: Text.PlainText
 
     font: root.titleFont
     color: __style.forestColor

--- a/app/qml/components/MMPageHeader.qml
+++ b/app/qml/components/MMPageHeader.qml
@@ -54,7 +54,7 @@ Rectangle {
       topMargin: root.topSpacing
     }
 
-    text: root.title
+    text: root.title?.toString()?.replace(/\n/g, ' ') ?? ''
     elide: Text.ElideMiddle
 
     font: root.titleFont

--- a/app/qml/form/MMPreviewDrawer.qml
+++ b/app/qml/form/MMPreviewDrawer.qml
@@ -90,6 +90,7 @@ Item {
           Layout.preferredHeight: implicitHeight
 
           text: root.controller.title
+          textFormat: Text.PlainText
 
           font: __style.t1
           color: __style.forestColor
@@ -249,6 +250,7 @@ Item {
                 width: parent.width
 
                 text: model.Value
+                textFormat: Text.PlainText
                 font: __style.t3
                 color: __style.nightColor
 


### PR DESCRIPTION
Fixes #3760 and also some unintended HTML parsing

| bug | old version | new version |
| --- | --- | --- |
| Multi line feature name overflows | ![image](https://github.com/user-attachments/assets/c361bb21-40ae-4142-9957-1dc56795755a) | ![image](https://github.com/user-attachments/assets/d24a494b-0959-41d8-9b8c-6968c93af918) |
| Feature name with html tag in form page | ![image](https://github.com/user-attachments/assets/dcd5df24-78f6-4829-b0f7-2965ae80174d) | ![image](https://github.com/user-attachments/assets/2e731c30-ab4d-4151-83b1-473f8e6426b9) |
| Feature name with html tag in form preview & Feature field with html tag in form preview | ![image](https://github.com/user-attachments/assets/3e192a2c-6db6-4c2d-9ac5-2edb04933fb7) | ![image](https://github.com/user-attachments/assets/e0f489f9-0947-4156-89f4-709eb702c2a1) |
| Feature name with html tag in feature list | ![image](https://github.com/user-attachments/assets/ae4ad5ca-4b47-48fd-a738-993e60ce7189) | ![image](https://github.com/user-attachments/assets/8eb9a5aa-1591-46e9-9077-52b08232d6ac) |

