### PR TITLE
Honour avoid overlaps settings from QGIS 

### DIFF
--- a/app/maptools/recordingmaptool.h
+++ b/app/maptools/recordingmaptool.h
@@ -322,6 +322,11 @@ class RecordingMapTool : public AbstractMapTool
      */
     bool shouldBeVisible( QgsPoint point );
 
+    /**
+     * Check the layers intersection mode and change the feature geometry accordingly
+     */
+    void avoidIntersections();
+
     QgsGeometry mRecordedGeometry;
 
     bool mCenteredToGPS = false;


### PR DESCRIPTION
Fixes #3739 

With these settings: 
![image](https://github.com/user-attachments/assets/652260ec-42df-431d-aa76-df0167dc1959)
Changing geometries of features will use those predefined settings.

https://github.com/user-attachments/assets/eb3f3f47-cf3e-435b-ad66-4bceeeab54f5

