### PR TITLE
Fix ios bugs after qt upgrade

### DIFF
--- a/app/ios/iosutils.cpp
+++ b/app/ios/iosutils.cpp
@@ -31,6 +31,13 @@ bool IosUtils::isIos() const
 #endif
 }
 
+void IosUtils::rotateScreenToPortrait()
+{
+#ifdef Q_OS_IOS
+  rotateScreenToPortraitImpl();
+#endif
+}
+
 void IosUtils::callImagePicker( const QString &targetPath, const QString &code )
 {
   mLastCode = code;

--- a/app/ios/iosutils.h
+++ b/app/ios/iosutils.h
@@ -36,6 +36,8 @@ class IosUtils: public QObject
     explicit IosUtils( QObject *parent = nullptr );
     bool isIos() const;
 
+    void rotateScreenToPortrait();
+
     Q_INVOKABLE void callImagePicker( const QString &targetPath, const QString &code = "" );
     Q_INVOKABLE void callCamera( const QString &targetPath, const QString &code = "" );
     IOSImagePicker *imagePicker() const;
@@ -66,6 +68,8 @@ class IosUtils: public QObject
     void setIdleTimerDisabled();
 
     QVector<int> getSafeAreaImpl();
+
+    void rotateScreenToPortraitImpl();
 
     static QString getManufacturerImpl();
     static QString getDeviceModelImpl();

--- a/app/ios/iosutils.mm
+++ b/app/ios/iosutils.mm
@@ -25,6 +25,27 @@ void IosUtils::setIdleTimerDisabled()
   [[UIApplication sharedApplication] setIdleTimerDisabled:YES];
 }
 
+void IosUtils::rotateScreenToPortraitImpl()
+{
+  if ( @available( iOS 16.0, * ) )
+  {
+    NSArray *array = [[[UIApplication sharedApplication] connectedScenes] allObjects];
+    UIWindowScene *scene = (UIWindowScene *)array[0];
+
+    if ( scene )
+    {
+      UIWindowScene *windowScene = (UIWindowScene *)scene;
+      UIInterfaceOrientation orientation = windowScene.interfaceOrientation;
+
+      if ( orientation == UIInterfaceOrientationLandscapeLeft || orientation == UIInterfaceOrientationLandscapeRight )
+      {
+        UIWindowSceneGeometryPreferencesIOS *geometryPreferences = [[UIWindowSceneGeometryPreferencesIOS alloc] initWithInterfaceOrientations:UIInterfaceOrientationMaskPortrait];
+        [scene requestGeometryUpdateWithPreferences:geometryPreferences errorHandler:^(NSError * _Nonnull error) { NSLog(@"%@", error); }];
+      }
+    }
+  }
+}
+
 QVector<int> IosUtils::getSafeAreaImpl()
 {
   QVector<int> ret;

--- a/app/ios/iosutils.mm
+++ b/app/ios/iosutils.mm
@@ -30,17 +30,17 @@ void IosUtils::rotateScreenToPortraitImpl()
   if ( @available( iOS 16.0, * ) )
   {
     NSArray *array = [[[UIApplication sharedApplication] connectedScenes] allObjects];
-    UIWindowScene *scene = (UIWindowScene *)array[0];
+    UIWindowScene *scene = ( UIWindowScene * )array[0];
 
     if ( scene )
     {
-      UIWindowScene *windowScene = (UIWindowScene *)scene;
+      UIWindowScene *windowScene = ( UIWindowScene * )scene;
       UIInterfaceOrientation orientation = windowScene.interfaceOrientation;
 
       if ( orientation == UIInterfaceOrientationLandscapeLeft || orientation == UIInterfaceOrientationLandscapeRight )
       {
         UIWindowSceneGeometryPreferencesIOS *geometryPreferences = [[UIWindowSceneGeometryPreferencesIOS alloc] initWithInterfaceOrientations:UIInterfaceOrientationMaskPortrait];
-        [scene requestGeometryUpdateWithPreferences:geometryPreferences errorHandler:^(NSError * _Nonnull error) { NSLog(@"%@", error); }];
+        [scene requestGeometryUpdateWithPreferences:geometryPreferences errorHandler: ^ ( NSError * _Nonnull error ) { NSLog( @"%@", error ); }];
       }
     }
   }

--- a/app/main.cpp
+++ b/app/main.cpp
@@ -740,6 +740,26 @@ int main( int argc, char *argv[] )
     style->setSafeAreaBottom( safeAreaInsets[2] );
     style->setSafeAreaLeft( safeAreaInsets[3] );
   }
+
+  //
+  // Workaround for Qt bug <link> on iOS.
+  // ApplicationWindow's height and width are not properly updated (updated without signals),
+  // causing visual layout issues throughout the app.
+  // Forcing the screen to portrait mode triggers a recalculation and repaint of visual items,
+  // resolving the layout problems.
+  //
+  // Therefore, as a temporary fix, we rotate the screen to portrait mode on iOS when the app
+  // starts in landscape mode. It's crucial to execute this code after a short delay using
+  // QTimer, ensuring that the UIScene has been properly initialized.
+  //
+
+  const int SHORT_STARTUP_DELAY = 1;
+
+  QTimer::singleShot( SHORT_STARTUP_DELAY, &lambdaContext, [&iosUtils]()
+  {
+    iosUtils.rotateScreenToPortrait();
+  } );
+
 #endif
 
   // Set simulated position for desktop builds

--- a/cmake_templates/iOSInfo.plist.in
+++ b/cmake_templates/iOSInfo.plist.in
@@ -93,6 +93,8 @@
 	<array>
 		<string>location</string>
 	</array>
+	<key>UIRequiresFullScreen</key>
+	<true/>
 	<key>UISupportedInterfaceOrientations</key>
 	<array>
 		<string>UIInterfaceOrientationPortrait</string>


### PR DESCRIPTION
2 bug fixes / workarounds for iOS

1. We were reading safe area margins on app start (in `main.cpp`). With the latest Qt and Xcode iOS API upgrade, the values returned at this stage are empty. The fix is to query the margins once the event loop is running, the `UIWindow` should be all initialized then and return correct safe area margins.

2. When opening the app in landscape mode, the `orientation changed` information is received only after the `main.qml` is constructed. This would not be an issue, but is seems that `ApplicationWindow`'s `width` and `height` properties do not emit the `valueChanged` signal, leaving out components that depend on it (which is most of our components) not repainted. Summary: the `width` and `height` properties are updated, but without value changed signal. What helps here is to change the orientation of the device - that triggers repaint. Our fix is that when we open the app in landscape, we automatically rotate to portrait mode :( This is just a workaround and I'll discuss with Qt (TODO: bug report) to see if there is a better way to fix the issue.
 