### PR TITLE
Introduce new QGIS expression variables

### DIFF
--- a/app/test/testvariablesmanager.cpp
+++ b/app/test/testvariablesmanager.cpp
@@ -111,6 +111,11 @@ void TestVariablesManager::userVariables()
   evaluateExpression( QStringLiteral( "@mergin_url" ),  mApi->apiRoot(), &context );
   evaluateExpression( QStringLiteral( "@mergin_user_email" ), mApi->userInfo()->email(), &context );
   evaluateExpression( QStringLiteral( "@mergin_username" ), username, &context );
+  evaluateExpression( QStringLiteral( "@mergin_full_name" ), mApi->userInfo()->name(), &context );
+  evaluateExpression( QStringLiteral( "@mm_url" ),  mApi->apiRoot(), &context );
+  evaluateExpression( QStringLiteral( "@mm_user_email" ), mApi->userInfo()->email(), &context );
+  evaluateExpression( QStringLiteral( "@mm_username" ), username, &context );
+  evaluateExpression( QStringLiteral( "@mm_full_name" ), mApi->userInfo()->name(), &context );
 }
 
 GeoPosition TestVariablesManager::testGeoPosition()

--- a/app/test/testvariablesmanager.cpp
+++ b/app/test/testvariablesmanager.cpp
@@ -71,7 +71,7 @@ void TestVariablesManager::testPositionVariables()
   evaluateExpression( QStringLiteral( "@position_magnetic_variation" ), QStringLiteral( "0.00" ), &context );
   evaluateExpression( QStringLiteral( "@position_direction" ), QStringLiteral( "0" ), &context );
   evaluateExpression( QStringLiteral( "@position_satellites_visible" ), QStringLiteral( "9" ), &context );
-  evaluateExpression( QStringLiteral( "@position_satellites_used" ), QStringLiteral( "3" ), &context );
+  evaluateExpression( QStringLiteral( "@position_satellites_used" ), QStringLiteral( "9" ), &context );
   evaluateExpression( QStringLiteral( "@position_hdop" ), QStringLiteral( "3.20" ), &context );
   evaluateExpression( QStringLiteral( "@position_vdop" ), QStringLiteral( "4.90" ), &context );
   evaluateExpression( QStringLiteral( "@position_pdop" ), QStringLiteral( "5.90" ), &context );
@@ -96,12 +96,11 @@ void TestVariablesManager::testPositionVariables()
 
 void TestVariablesManager::testUserVariables()
 {
-  QString apiRoot, username, password, workspace;
+  QString apiRoot, username, password;
   TestUtils::merginGetAuthCredentials( mApi, apiRoot, username, password );
   if ( TestUtils::needsToAuthorizeAgain( mApi, username ) )
   {
     TestUtils::authorizeUser( mApi, username, password );
-    TestUtils::selectFirstWorkspace( mApi, workspace );
   }
 
   QgsExpressionContext context;

--- a/app/test/testvariablesmanager.cpp
+++ b/app/test/testvariablesmanager.cpp
@@ -12,7 +12,6 @@
 #include "qgsexpressioncontextutils.h"
 
 #include "test/testmerginapi.h"
-#include "inputtests.h"
 #include "testutils.h"
 #include "position/providers/bluetoothpositionprovider.h"
 #include "merginapi.h"
@@ -40,7 +39,7 @@ void TestVariablesManager::cleanup()
 
 }
 
-void TestVariablesManager::positionVariables()
+void TestVariablesManager::testPositionVariables()
 {
   mAppSettings->setGpsAntennaHeight( 0 );
 
@@ -95,7 +94,7 @@ void TestVariablesManager::positionVariables()
   mAppSettings->setGpsAntennaHeight( 0 );
 }
 
-void TestVariablesManager::userVariables()
+void TestVariablesManager::testUserVariables()
 {
   QString apiRoot, username, password, workspace;
   TestUtils::merginGetAuthCredentials( mApi, apiRoot, username, password );
@@ -143,7 +142,7 @@ void TestVariablesManager::evaluateExpression( const QString &expStr, const QStr
   QgsExpression exp( expStr );
   QVERIFY2( exp.prepare( context ), expStr.toStdString().c_str() );
   QVERIFY( !exp.hasParserError() );
-  QVariant value = exp.evaluate();
+  const QVariant value = exp.evaluate();
   QVERIFY2( !exp.hasEvalError(), expStr.toStdString().c_str() );
   QCOMPARE( value, expectedValue );
 }

--- a/app/test/testvariablesmanager.h
+++ b/app/test/testvariablesmanager.h
@@ -6,18 +6,15 @@
  *   (at your option) any later version.                                   *
  *                                                                         *
  ***************************************************************************/
-#include <QObject>
-#include <QtTest>
-
-#include "inputconfig.h"
-#include "variablesmanager.h"
-#include "qgeopositioninfo.h"
-#include "positionkit.h"
-#include "appsettings.h"
-#include "compass.h"
-
 #ifndef TESTVARIABLESMANAGER_H
 #define TESTVARIABLESMANAGER_H
+
+#include <QtTest>
+
+#include "variablesmanager.h"
+#include "positionkit.h"
+#include "appsettings.h"
+
 
 class MerginApi;
 
@@ -30,8 +27,8 @@ class TestVariablesManager: public QObject
     void init(); // will be called before each testfunction is executed.
     void cleanup(); // will be called after every testfunction.
 
-    void positionVariables();
-    void userVariables();
+    void testPositionVariables();
+    void testUserVariables();
 
   private:
     MerginApi *mApi;

--- a/app/variablesmanager.cpp
+++ b/app/variablesmanager.cpp
@@ -67,7 +67,7 @@ QgsExpressionContextScope *VariablesManager::positionScope()
     providerType = mPositionKit->positionProvider()->type();
   }
 
-  GeoPosition position = mPositionKit->position();
+  const GeoPosition position = mPositionKit->position();
   const QgsGeometry point = QgsGeometry( new QgsPoint( position.longitude, position.latitude, position.elevation ) );
 
   QgsExpressionContextScope *scope = new QgsExpressionContextScope( QStringLiteral( "Position" ) );
@@ -82,7 +82,7 @@ QgsExpressionContextScope *VariablesManager::positionScope()
   addPositionVariable( scope, QStringLiteral( "vertical_speed" ), getGeoPositionAttribute( position.verticalSpeed ) );
   addPositionVariable( scope, QStringLiteral( "magnetic_variation" ), getGeoPositionAttribute( position.magneticVariation ) );
   addPositionVariable( scope, QStringLiteral( "timestamp" ), position.utcDateTime );
-  addPositionVariable( scope, QStringLiteral( "direction" ), ( 360 + int( direction ) ) % 360 );
+  addPositionVariable( scope, QStringLiteral( "direction" ), ( 360 + static_cast<int>( direction ) ) % 360 );
   addPositionVariable( scope, QStringLiteral( "from_gps" ), mUseGpsPoint );
   addPositionVariable( scope, QStringLiteral( "satellites_visible" ), position.satellitesVisible );
   addPositionVariable( scope, QStringLiteral( "satellites_used" ), position.satellitesUsed );
@@ -135,7 +135,7 @@ bool VariablesManager::useGpsPoint() const
   return mUseGpsPoint;
 }
 
-void VariablesManager::setUseGpsPoint( bool useGpsPoint )
+void VariablesManager::setUseGpsPoint( const bool useGpsPoint )
 {
   if ( mUseGpsPoint != useGpsPoint )
   {
@@ -184,15 +184,15 @@ void VariablesManager::setProjectVariables()
     return;
 
 
-  QString filePath = mCurrentProject->fileName();
-  QString projectDir = mMerginApi->localProjectsManager().projectFromProjectFilePath( filePath ).projectDir;
+  const QString filePath = mCurrentProject->fileName();
+  const QString projectDir = mMerginApi->localProjectsManager().projectFromProjectFilePath( filePath ).projectDir;
   if ( projectDir.isEmpty() )
   {
     removeMerginProjectVariables( mCurrentProject );
     return;
   }
 
-  MerginProjectMetadata metadata = MerginProjectMetadata::fromCachedJson( projectDir + "/" + MerginApi::sMetadataFile );
+  const MerginProjectMetadata metadata = MerginProjectMetadata::fromCachedJson( projectDir + "/" + MerginApi::sMetadataFile );
   if ( metadata.isValid() )
   {
     QgsExpressionContextUtils::setProjectVariable( mCurrentProject, QStringLiteral( "mergin_project_version" ), metadata.version );
@@ -222,7 +222,7 @@ void VariablesManager::addPositionVariable( QgsExpressionContextScope *scope, co
   }
 }
 
-QVariant VariablesManager::getGeoPositionAttribute( double attributeValue, int precision )
+QVariant VariablesManager::getGeoPositionAttribute( const double attributeValue, const int precision )
 {
   if ( attributeValue >= 0 )
   {

--- a/app/variablesmanager.cpp
+++ b/app/variablesmanager.cpp
@@ -34,6 +34,10 @@ void VariablesManager::removeMerginProjectVariables( QgsProject *project )
   QgsExpressionContextUtils::removeProjectVariable( project, QStringLiteral( "mergin_project_full_name" ) );
   QgsExpressionContextUtils::removeProjectVariable( project, QStringLiteral( "mergin_project_version" ) );
   QgsExpressionContextUtils::removeProjectVariable( project, QStringLiteral( "mergin_project_owner" ) );
+  QgsExpressionContextUtils::removeProjectVariable( project, QStringLiteral( "mm_project_name" ) );
+  QgsExpressionContextUtils::removeProjectVariable( project, QStringLiteral( "mm_project_full_name" ) );
+  QgsExpressionContextUtils::removeProjectVariable( project, QStringLiteral( "mm_project_version" ) );
+  QgsExpressionContextUtils::removeProjectVariable( project, QStringLiteral( "mm_project_owner" ) );
 }
 
 void VariablesManager::registerInputExpressionFunctions()
@@ -97,16 +101,21 @@ QgsExpressionContextScope *VariablesManager::positionScope()
 void VariablesManager::apiRootChanged()
 {
   QgsExpressionContextUtils::setGlobalVariable( QStringLiteral( "mergin_url" ),  mMerginApi->apiRoot() );
+  QgsExpressionContextUtils::setGlobalVariable( QStringLiteral( "mm_url" ),  mMerginApi->apiRoot() );
 }
 
 void VariablesManager::authChanged()
 {
   QgsExpressionContextUtils::setGlobalVariable( QStringLiteral( "mergin_username" ),  mMerginApi->userAuth()->username() );
+  QgsExpressionContextUtils::setGlobalVariable( QStringLiteral( "mm_username" ),  mMerginApi->userAuth()->username() );
 }
 
 void VariablesManager::setUserVariables()
 {
   QgsExpressionContextUtils::setGlobalVariable( QStringLiteral( "mergin_user_email" ),  mMerginApi->userInfo()->email() );
+  QgsExpressionContextUtils::setGlobalVariable( QStringLiteral( "mergin_full_name" ),  mMerginApi->userInfo()->name() );
+  QgsExpressionContextUtils::setGlobalVariable( QStringLiteral( "mm_user_email" ),  mMerginApi->userInfo()->email() );
+  QgsExpressionContextUtils::setGlobalVariable( QStringLiteral( "mm_full_name" ),  mMerginApi->userInfo()->name() );
 }
 
 void VariablesManager::setVersionVariable( const QString &projectFullName )
@@ -114,7 +123,10 @@ void VariablesManager::setVersionVariable( const QString &projectFullName )
   if ( !mCurrentProject )
     return;
 
-  if ( mCurrentProject->customVariables().value( QStringLiteral( "mergin_project_full_name" ) ).toString() == projectFullName )
+  const QString oldVariableName = mCurrentProject->customVariables().value( QStringLiteral( "mergin_project_full_name" ) ).toString();
+  const QString newVariableName = mCurrentProject->customVariables().value( QStringLiteral( "mm_project_full_name" ) ).toString();
+
+  if ( oldVariableName == projectFullName  && newVariableName == projectFullName )
     setProjectVariables();
 }
 
@@ -187,6 +199,10 @@ void VariablesManager::setProjectVariables()
     QgsExpressionContextUtils::setProjectVariable( mCurrentProject, QStringLiteral( "mergin_project_name" ),  metadata.name );
     QgsExpressionContextUtils::setProjectVariable( mCurrentProject, QStringLiteral( "mergin_project_full_name" ),  mMerginApi->getFullProjectName( metadata.projectNamespace,  metadata.name ) );
     QgsExpressionContextUtils::setProjectVariable( mCurrentProject, QStringLiteral( "mergin_project_owner" ),   metadata.projectNamespace );
+    QgsExpressionContextUtils::setProjectVariable( mCurrentProject, QStringLiteral( "mm_project_version" ), metadata.version );
+    QgsExpressionContextUtils::setProjectVariable( mCurrentProject, QStringLiteral( "mm_project_name" ),  metadata.name );
+    QgsExpressionContextUtils::setProjectVariable( mCurrentProject, QStringLiteral( "mm_project_full_name" ),  mMerginApi->getFullProjectName( metadata.projectNamespace,  metadata.name ) );
+    QgsExpressionContextUtils::setProjectVariable( mCurrentProject, QStringLiteral( "mm_project_owner" ),   metadata.projectNamespace );
   }
   else
   {

--- a/app/variablesmanager.h
+++ b/app/variablesmanager.h
@@ -21,7 +21,7 @@
 class MerginApi;
 
 /*
- * The class sets global and project variables related to Mergin.
+ * The class sets global and project variables related to Mergin Maps.
  */
 class VariablesManager : public QObject
 {
@@ -31,8 +31,8 @@ class VariablesManager : public QObject
     //! Source of direction
     Q_PROPERTY( Compass *compass READ compass WRITE setCompass NOTIFY compassChanged )
     /**
-     * Property binded with RecordingMapTool. If true, the RecordingMapTool has used current position to create or edit geometry
-     * for a feature. Therefore current position information matches geometry for that feature.
+     * Property bound with RecordingMapTool. If true, the RecordingMapTool has used current position to create or edit geometry
+     * for a feature. Therefore, current position information matches geometry for that feature.
      **/
     Q_PROPERTY( bool useGpsPoint READ useGpsPoint WRITE setUseGpsPoint NOTIFY useGpsPointChanged )
 
@@ -41,7 +41,7 @@ class VariablesManager : public QObject
     ~VariablesManager() override;
 
     void removeMerginProjectVariables( QgsProject *project );
-    //! Creates and registers custom expression functions to Input, so they can be used in default value definitions.
+    //! Creates and registers custom expression functions to mobile app, so they can be used in default value definitions.
     void registerInputExpressionFunctions();
     QgsExpressionContextScope *positionScope();
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -24,6 +24,7 @@ set(MM_TESTS
     testLayerTree
     testActiveProject
     testProjectChecksumCache
+    testVariablesManager
 )
 
 foreach (test ${MM_TESTS})


### PR DESCRIPTION
Fixes #3799 

This PR adds new QGIS expression variable `mergin_full_name`, which gives users name. Also we change the format of variables from `mergin_variable` to `mm_variable`. We keep the old format for backward compatibility. 