### PR TITLE
Fix cmake warnings

### DIFF
--- a/app/CMakeLists.txt
+++ b/app/CMakeLists.txt
@@ -308,6 +308,8 @@ target_include_directories(
          ${CMAKE_CURRENT_SOURCE_DIR}/position
 )
 
+qt_policy(SET QTP0002 NEW)
+
 if (ANDROID)
   if (EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/android/AndroidManifest.xml)
     file(REMOVE ${CMAKE_CURRENT_SOURCE_DIR}/android/AndroidManifest.xml)
@@ -565,8 +567,7 @@ target_compile_definitions(
 
 add_subdirectory(qml)
 
-# register Singleton TODO REMOVE!
-set_source_files_properties(qml/InputStyle.qml PROPERTIES QT_QML_SINGLETON_TYPE TRUE)
+qt_policy(SET QTP0004 NEW)
 
 # make sure the QML files are not prefixed with "qml/" in the qmldir
 set(MM_QML_SRCS)


### PR DESCRIPTION
This PR fixes CMake warnings from QT policies.

- Sets QT policy [QTP0002](https://doc.qt.io/qt-6/qt-cmake-policy-qtp0002.html) to `NEW` as the old one is getting deprecated. We are not using either the old or new specific way to give paths.

- Sets QT policy [QTP0004](https://doc.qt.io/qt-6/qt-cmake-policy-qtp0004.html) to `NEW` as the old one is getting deprecated.

- Removes `set_source_files_properties` line. As far as I know `InputStyle.qml` doesn't exist anymore.

Fixes #3461 