### PR TITLE
Minimal fix for photo deletion 

### DIFF
--- a/app/qml/form/MMFormPage.qml
+++ b/app/qml/form/MMFormPage.qml
@@ -386,13 +386,13 @@ Page {
         ignoreUnknownSignals: true
 
         function onSaved() {
-          if ( formEditorsLoader.item && typeof formEditorsLoader.item.callbackOnSave === "function" ) {
+          if ( formEditorsLoader.item && typeof formEditorsLoader.item.callbackOnFormSaved === "function" ) {
             formEditorsLoader.item.callbackOnFormSaved()
           }
         }
 
         function onCanceled() {
-          if ( formEditorsLoader.item && typeof formEditorsLoader.item.callbackOnCancel === "function" ) {
+          if ( formEditorsLoader.item && typeof formEditorsLoader.item.callbackOnFormCanceled === "function" ) {
             formEditorsLoader.item.callbackOnFormCanceled()
           }
         }


### PR DESCRIPTION
Save/cancel callbacks on `MMFormPage` have been renamed to match existing methods in `MMFormPhotoEditor`, `callbackOnFormSaved` and `callbackOnFormCanceled`. `onSaved()` and `onCanceled()` methods now invoke these callbacks properly. 

Fixes #3786