### PR TITLE
Map extent stored in app settings following no map movement

### DIFF
--- a/app/activeproject.cpp
+++ b/app/activeproject.cpp
@@ -185,6 +185,11 @@ bool ActiveProject::forceLoad( const QString &filePath, bool force )
     QString role = MerginProjectMetadata::fromCachedJson( CoreUtils::getProjectMetadataPath( mLocalProject.projectDir ) ).role;
     setProjectRole( role );
 
+    if ( mMapSettings )
+    {
+      mMapSettings->setProjectId( projectFullName() );
+    }
+
     updateMapTheme();
     updateActiveLayer();
     updateMapSettingsLayers();
@@ -346,6 +351,7 @@ void ActiveProject::setMapSettings( InputMapSettings *mapSettings )
 
   mMapSettings = mapSettings;
   updateMapSettingsLayers();
+  mMapSettings->setProjectId( projectFullName() );
 
   emit mapSettingsChanged();
 }

--- a/app/map/inputmapsettings.cpp
+++ b/app/map/inputmapsettings.cpp
@@ -20,6 +20,8 @@
 #include "qgsmessagelog.h"
 #include "qgsprojectviewsettings.h"
 
+static constexpr int EXTENT_SAVE_DELAY_MS = 2000;
+
 InputMapSettings::InputMapSettings( QObject *parent )
   : QObject( parent )
 {
@@ -34,7 +36,7 @@ InputMapSettings::InputMapSettings( QObject *parent )
   // store map extent to QSettings when extent hasn't changed for 2 seconds
   mSaveExtentTimer.setSingleShot( true );
   connect( &mSaveExtentTimer, &QTimer::timeout, this, &InputMapSettings::saveExtentToSettings );
-  connect( this, &InputMapSettings::extentChanged, this, [this]() { mSaveExtentTimer.start( 2000 ); } );
+  connect( this, &InputMapSettings::extentChanged, this, [this]() { mSaveExtentTimer.start( EXTENT_SAVE_DELAY_MS ); } );
 }
 
 void InputMapSettings::setProject( QgsProject *project )
@@ -378,5 +380,11 @@ void InputMapSettings::loadSavedExtent()
   settings.endGroup();
 
   if ( !extent.isEmpty() && extent.isFinite() )
+  {
     setExtent( extent );
+  }
+  else
+  {
+    CoreUtils::log( "MapSettings", QStringLiteral( "No valid saved extent found for project %1" ).arg( mProject->baseName() ) );
+  }
 }

--- a/app/map/inputmapsettings.cpp
+++ b/app/map/inputmapsettings.cpp
@@ -33,7 +33,7 @@ InputMapSettings::InputMapSettings( QObject *parent )
   connect( this, &InputMapSettings::rotationChanged, this, &InputMapSettings::visibleExtentChanged );
   connect( this, &InputMapSettings::outputSizeChanged, this, &InputMapSettings::visibleExtentChanged );
 
-  // store map extent to QSettings when extent hasn't changed for 2 seconds
+  // store map extent to QSettings when extent hasn't changed
   mSaveExtentTimer.setSingleShot( true );
   connect( &mSaveExtentTimer, &QTimer::timeout, this, &InputMapSettings::saveExtentToSettings );
   connect( this, &InputMapSettings::extentChanged, this, [this]() { mSaveExtentTimer.start( EXTENT_SAVE_DELAY_MS ); } );

--- a/app/map/inputmapsettings.cpp
+++ b/app/map/inputmapsettings.cpp
@@ -267,8 +267,6 @@ void InputMapSettings::onReadProject( const QDomDocument &doc )
     mMapSettings.setExtent( mProject->viewSettings()->fullExtent() );
   }
 
-  loadSavedExtent();
-
   mMapSettings.setRotation( 0 );
 
   mMapSettings.setTransformContext( mProject->transformContext() );

--- a/app/map/inputmapsettings.cpp
+++ b/app/map/inputmapsettings.cpp
@@ -370,6 +370,10 @@ void InputMapSettings::saveExtentToSettings()
     settings.setValue( "extent", extent );
     settings.endGroup();
   }
+  else
+  {
+    CoreUtils::log( "MapSettings", QStringLiteral( "No valid extent to be saved for project %1" ).arg( mProject->baseName() ) );
+  }
 }
 
 void InputMapSettings::loadSavedExtent()
@@ -385,6 +389,6 @@ void InputMapSettings::loadSavedExtent()
   }
   else
   {
-    CoreUtils::log( "MapSettings", QStringLiteral( "No valid saved extent found for project %1" ).arg( mProject->baseName() ) );
+    CoreUtils::log( "MapSettings", QStringLiteral( "No valid loaded extent found for project %1" ).arg( mProject->baseName() ) );
   }
 }

--- a/app/map/inputmapsettings.cpp
+++ b/app/map/inputmapsettings.cpp
@@ -266,10 +266,7 @@ void InputMapSettings::onReadProject( const QDomDocument &doc )
     mMapSettings.setExtent( mProject->viewSettings()->fullExtent() );
   }
 
-  if ( mMapSettings.extent().isEmpty() )
-  {
-    loadSavedExtent();
-  }
+  loadSavedExtent();
 
   mMapSettings.setRotation( 0 );
 
@@ -360,35 +357,42 @@ void InputMapSettings::setTemporalEnd( const QDateTime &end )
   emit temporalStateChanged();
 }
 
+QString InputMapSettings::projectId() const
+{
+  return mProjectId;
+}
+
+void InputMapSettings::setProjectId( const QString &projectId )
+{
+  if ( projectId == mProjectId )
+    return;
+
+  mProjectId = projectId;
+  emit projectIdChanged();
+}
+
 void InputMapSettings::saveExtentToSettings()
 {
   QSettings settings;
   const QgsRectangle extent = this->extent();
-  if ( !extent.isEmpty() && extent.isFinite() )
+  if ( !extent.isEmpty() && extent.isFinite() && !mProjectId.isEmpty() )
   {
-    settings.beginGroup( QStringLiteral( "%1/%2" ).arg( CoreUtils::QSETTINGS_CACHED_MAP_EXTENT_GROUP, mProject->baseName() ) );
+    settings.beginGroup( QStringLiteral( "%1/%2" ).arg( mProjectId, CoreUtils::QSETTINGS_CACHED_MAP_EXTENT_GROUP ) );
     settings.setValue( "extent", extent );
     settings.endGroup();
-  }
-  else
-  {
-    CoreUtils::log( "MapSettings", QStringLiteral( "No valid extent to be saved for project %1" ).arg( mProject->baseName() ) );
   }
 }
 
 void InputMapSettings::loadSavedExtent()
 {
   QSettings settings;
-  settings.beginGroup( QStringLiteral( "%1/%2" ).arg( CoreUtils::QSETTINGS_CACHED_MAP_EXTENT_GROUP, mProject->baseName() ) );
+  settings.beginGroup( QStringLiteral( "%1/%2" ).arg( mProjectId, CoreUtils::QSETTINGS_CACHED_MAP_EXTENT_GROUP ) );
   QgsRectangle extent = settings.value( "extent" ).value<QgsRectangle>();
   settings.endGroup();
 
-  if ( !extent.isEmpty() && extent.isFinite() )
+  if ( !extent.isEmpty() && extent.isFinite() && !mProjectId.isEmpty() )
   {
     setExtent( extent );
   }
-  else
-  {
-    CoreUtils::log( "MapSettings", QStringLiteral( "No valid loaded extent found for project %1" ).arg( mProject->baseName() ) );
-  }
 }
+

--- a/app/map/inputmapsettings.cpp
+++ b/app/map/inputmapsettings.cpp
@@ -386,12 +386,15 @@ void InputMapSettings::saveExtentToSettings()
 
 void InputMapSettings::loadSavedExtent()
 {
+  if ( mProjectId.isEmpty() )
+    return;
+
   QSettings settings;
   settings.beginGroup( QStringLiteral( "%1/%2" ).arg( mProjectId, CoreUtils::QSETTINGS_CACHED_MAP_EXTENT_GROUP ) );
   QgsRectangle extent = settings.value( "extent" ).value<QgsRectangle>();
   settings.endGroup();
 
-  if ( !extent.isEmpty() && extent.isFinite() && !mProjectId.isEmpty() )
+  if ( !extent.isEmpty() && extent.isFinite() )
   {
     setExtent( extent );
   }

--- a/app/map/inputmapsettings.cpp
+++ b/app/map/inputmapsettings.cpp
@@ -37,6 +37,7 @@ InputMapSettings::InputMapSettings( QObject *parent )
   mSaveExtentTimer.setSingleShot( true );
   connect( &mSaveExtentTimer, &QTimer::timeout, this, &InputMapSettings::saveExtentToSettings );
   connect( this, &InputMapSettings::extentChanged, this, [this]() { mSaveExtentTimer.start( EXTENT_SAVE_DELAY_MS ); } );
+  connect( this, &InputMapSettings::projectIdChanged, this, &InputMapSettings::loadSavedExtent );
 }
 
 void InputMapSettings::setProject( QgsProject *project )

--- a/app/map/inputmapsettings.h
+++ b/app/map/inputmapsettings.h
@@ -130,6 +130,12 @@ class InputMapSettings : public QObject
      */
     Q_PROPERTY( QDateTime temporalEnd READ temporalEnd WRITE setTemporalEnd NOTIFY temporalStateChanged )
 
+    /**
+     * Identifier for current project.
+     */
+    Q_PROPERTY( QString projectId READ projectId WRITE setProjectId NOTIFY projectIdChanged )
+
+
   public:
     //! Create new map settings
     explicit InputMapSettings( QObject *parent = nullptr );
@@ -286,9 +292,28 @@ class InputMapSettings : public QObject
     //! \copydoc InputMapSettings::temporalEnd
     void setTemporalEnd( const QDateTime &end );
 
+    //! \copydoc InputMapSettings::projectId
+    QString projectId() const;
+
+    //! \copydoc InputMapSettings::projectId
+    void setProjectId( const QString &projectId );
+
+     /**
+     * Saves current map extent to QSettings
+     */
+    void saveExtentToSettings();
+
+    /**
+     * Retrieves saved map extent from QSettings and set it as the map extent
+     */
+    void loadSavedExtent();
+
   signals:
     //! \copydoc InputMapSettings::project
     void projectChanged();
+
+    //! \copydoc InputMapSettings::projectId
+    void projectIdChanged();
 
     //! \copydoc InputMapSettings::extent
     void extentChanged();
@@ -344,21 +369,12 @@ class InputMapSettings : public QObject
      */
     void onCrsChanged();
 
-    /**
-     * Saves current map extent to QSettings
-     */
-    void saveExtentToSettings();
-
-    /**
-     * Retrieves saved map extent from QSettings and set it as the map extent
-     */
-    void loadSavedExtent();
-
   private:
     QgsProject *mProject = nullptr;
     QgsMapSettings mMapSettings;
     qreal mDevicePixelRatio = 1.0;
     QTimer mSaveExtentTimer;
+    QString mProjectId;
 };
 
 #endif // INPUTMAPSETTINGS_H

--- a/app/map/inputmapsettings.h
+++ b/app/map/inputmapsettings.h
@@ -18,6 +18,7 @@
 #include "inputconfig.h"
 
 #include <QObject>
+#include <QTimer>
 
 #include "qgscoordinatetransformcontext.h"
 #include "qgsmaplayer.h"
@@ -343,10 +344,21 @@ class InputMapSettings : public QObject
      */
     void onCrsChanged();
 
+    /**
+     * Saves current map extent to QSettings
+     */
+    void saveExtentToSettings();
+
+    /**
+     * Retrieves saved map extent from QSettings and set it as the map extent
+     */
+    void loadSavedExtent();
+
   private:
     QgsProject *mProject = nullptr;
     QgsMapSettings mMapSettings;
     qreal mDevicePixelRatio = 1.0;
+    QTimer mSaveExtentTimer;
 };
 
 #endif // INPUTMAPSETTINGS_H

--- a/app/map/inputmapsettings.h
+++ b/app/map/inputmapsettings.h
@@ -298,9 +298,9 @@ class InputMapSettings : public QObject
     //! \copydoc InputMapSettings::projectId
     void setProjectId( const QString &projectId );
 
-     /**
-     * Saves current map extent to QSettings
-     */
+    /**
+    * Saves current map extent to QSettings
+    */
     void saveExtentToSettings();
 
     /**

--- a/app/qml/map/MMMapController.qml
+++ b/app/qml/map/MMMapController.qml
@@ -239,7 +239,6 @@ Item {
     anchors.fill: parent
 
     mapSettings.project: __activeProject.qgsProject
-    mapSettings.projectId: __activeProject.projectFullName()
 
     MM.IdentifyKit {
       id: identifyKit

--- a/app/qml/map/MMMapController.qml
+++ b/app/qml/map/MMMapController.qml
@@ -239,6 +239,7 @@ Item {
     anchors.fill: parent
 
     mapSettings.project: __activeProject.qgsProject
+    mapSettings.projectId: __activeProject.projectFullName()
 
     MM.IdentifyKit {
       id: identifyKit

--- a/app/test/testmaptools.h
+++ b/app/test/testmaptools.h
@@ -26,8 +26,6 @@ class TestMapTools : public QObject
     void init();
     void cleanup();
 
-    void testExtentSaveAndLoad();
-
     void testSnapping();
     void testSplitting();
     void testRecording();
@@ -54,6 +52,8 @@ class TestMapTools : public QObject
     void testSmallTracking();
 
     void testAvoidIntersections();
+
+    void testExtentSaveAndLoad();
 
   private:
     PositionKit *mPositionKit;

--- a/app/test/testmaptools.h
+++ b/app/test/testmaptools.h
@@ -26,6 +26,8 @@ class TestMapTools : public QObject
     void init();
     void cleanup();
 
+    void testExtentSaveAndLoad();
+
     void testSnapping();
     void testSplitting();
     void testRecording();

--- a/app/test/testmerginapi.cpp
+++ b/app/test/testmerginapi.cpp
@@ -2744,7 +2744,6 @@ void TestMerginApi::writeFileContent( const QString &filename, const QByteArray 
   bool ok = f.open( QIODeviceBase::WriteOnly );
   Q_ASSERT( ok );
   f.write( data );
-  f.flush();
   f.close();
 }
 

--- a/core/coreutils.cpp
+++ b/core/coreutils.cpp
@@ -384,3 +384,11 @@ bool CoreUtils::isValidEmail( const QString &email )
   const thread_local QRegularExpression regEx( "\\S+@\\S+\\.\\S+" );
   return regEx.match( email ).hasMatch();
 }
+
+QString CoreUtils::sanitizePathSlashes( const QString &name )
+{
+  QString sanitizedName = name;
+  sanitizedName.replace( '/', '_' );
+  sanitizedName.replace( '\\', '_' );
+  return sanitizedName;
+}

--- a/core/coreutils.cpp
+++ b/core/coreutils.cpp
@@ -27,6 +27,7 @@
 #include "qcoreapplication.h"
 
 const QString CoreUtils::QSETTINGS_APP_GROUP_NAME = QStringLiteral( "inputApp" );
+const QString CoreUtils::QSETTINGS_CACHED_MAP_EXTENT_GROUP = QStringLiteral( "mapExtent" );
 const QString CoreUtils::LOG_TO_DEVNULL = QStringLiteral();
 const QString CoreUtils::LOG_TO_STDOUT = QStringLiteral( "TO_STDOUT" );
 QString CoreUtils::sLogFile = CoreUtils::LOG_TO_DEVNULL;

--- a/core/coreutils.h
+++ b/core/coreutils.h
@@ -109,6 +109,7 @@ class CoreUtils
     static QString deviceUuid();
 
     static const QString QSETTINGS_APP_GROUP_NAME;
+    static const QString QSETTINGS_CACHED_MAP_EXTENT_GROUP;
 
     /**
      * Returns available device storage

--- a/core/coreutils.h
+++ b/core/coreutils.h
@@ -141,6 +141,12 @@ class CoreUtils
      */
     static bool isValidEmail( const QString &email );
 
+    /**
+     * Sanitizes a string by replacing path separators with underscores
+     * Useful to set QSettings group names, avoiding unpredicted behavior caused by slashes
+     */
+    static QString sanitizePathSlashes( const QString &input );
+
   private:
     static QString sLogFile;
     static int CHECKSUM_CHUNK_SIZE;

--- a/core/localprojectsmanager.cpp
+++ b/core/localprojectsmanager.cpp
@@ -255,14 +255,10 @@ void LocalProjectsManager::addProject( const QString &projectDir, const QString 
 
 void LocalProjectsManager::clearAllProjectSettings( const QString &projectFullName )
 {
-  clearCachedMapExtentSettings( projectFullName );
-}
-
-void LocalProjectsManager::clearCachedMapExtentSettings( const QString &projectFullName )
-{
   QSettings settings;
-  settings.beginGroup( QStringLiteral( "%1/%2" ).arg( CoreUtils::QSETTINGS_CACHED_MAP_EXTENT_GROUP, projectFullName ) );
+  settings.beginGroup( projectFullName );
   settings.remove( "" );
   settings.endGroup();
 }
+
 

--- a/core/localprojectsmanager.cpp
+++ b/core/localprojectsmanager.cpp
@@ -115,6 +115,9 @@ void LocalProjectsManager::removeLocalProject( const QString &projectId )
     {
       emit aboutToRemoveLocalProject( mProjects[i] );
 
+      QString projectFullName = mProjects[i].fullName();
+      clearAllProjectSettings( projectFullName );
+
       CoreUtils::removeDir( mProjects[i].projectDir );
       mProjects.removeAt( i );
 
@@ -249,3 +252,17 @@ void LocalProjectsManager::addProject( const QString &projectDir, const QString 
   mProjects << project;
   emit localProjectAdded( project );
 }
+
+void LocalProjectsManager::clearAllProjectSettings( const QString &projectFullName )
+{
+  clearCachedMapExtentSettings( projectFullName );
+}
+
+void LocalProjectsManager::clearCachedMapExtentSettings( const QString &projectFullName )
+{
+  QSettings settings;
+  settings.beginGroup( QStringLiteral( "%1/%2" ).arg( CoreUtils::QSETTINGS_CACHED_MAP_EXTENT_GROUP, projectFullName ) );
+  settings.remove( "" );
+  settings.endGroup();
+}
+

--- a/core/localprojectsmanager.cpp
+++ b/core/localprojectsmanager.cpp
@@ -115,8 +115,8 @@ void LocalProjectsManager::removeLocalProject( const QString &projectId )
     {
       emit aboutToRemoveLocalProject( mProjects[i] );
 
-      QString projectFullName = mProjects[i].fullName();
-      clearAllProjectSettings( projectFullName );
+      QString sanitizedProjectFullName = CoreUtils::sanitizePathSlashes( mProjects[i].fullName() );
+      clearAllProjectSettings( sanitizedProjectFullName );
 
       CoreUtils::removeDir( mProjects[i].projectDir );
       mProjects.removeAt( i );
@@ -253,10 +253,10 @@ void LocalProjectsManager::addProject( const QString &projectDir, const QString 
   emit localProjectAdded( project );
 }
 
-void LocalProjectsManager::clearAllProjectSettings( const QString &projectFullName )
+void LocalProjectsManager::clearAllProjectSettings( const QString &projectId )
 {
   QSettings settings;
-  settings.beginGroup( projectFullName );
+  settings.beginGroup( projectId );
   settings.remove( "" );
   settings.endGroup();
 }

--- a/core/localprojectsmanager.h
+++ b/core/localprojectsmanager.h
@@ -78,6 +78,12 @@ class LocalProjectsManager : public QObject
   private:
     void addProject( const QString &projectDir, const QString &projectNamespace, const QString &projectName );
 
+    //! Clears all settings groups for the given project full name
+    void clearAllProjectSettings( const QString &projectFullName );
+
+    //! Clears only mapExtent settings group for the given project full name
+    void clearCachedMapExtentSettings( const QString &projectFullName );
+
     QString mDataDir;   //!< directory with all local projects
     LocalProjectsList mProjects;
 };

--- a/core/localprojectsmanager.h
+++ b/core/localprojectsmanager.h
@@ -81,9 +81,6 @@ class LocalProjectsManager : public QObject
     //! Clears all settings groups for the given project full name
     void clearAllProjectSettings( const QString &projectFullName );
 
-    //! Clears only mapExtent settings group for the given project full name
-    void clearCachedMapExtentSettings( const QString &projectFullName );
-
     QString mDataDir;   //!< directory with all local projects
     LocalProjectsList mProjects;
 };


### PR DESCRIPTION
Map extent is now stored in app settings after 2 seconds of map movement inactivity (no extentChanged). Each time the extent changes, a timer is reset, and if no further changes occur within 2 seconds, current extent is saved. When opening the app, if no extent can be retrieved from the map canvas XML, the app falls back to using last stored extent.

Fixes #2445 
Relates to #2644