### PR TITLE
Api root should not end with slash

### DIFF
--- a/app/inputhelp.cpp
+++ b/app/inputhelp.cpp
@@ -24,7 +24,7 @@
 const QString helpRoot = QStringLiteral( "https://merginmaps.com/docs" );
 const QString reportLogUrl = QStringLiteral( "https://g4pfq226j0.execute-api.eu-west-1.amazonaws.com/mergin_client_log_submit" );
 const QString helpDeskMail = QStringLiteral( "support@merginmaps.com" );
-const QString inputWeb = QStringLiteral( "https://merginmaps.com" );
+const QString mmWeb = QStringLiteral( "https://merginmaps.com" );
 const QString changelogRss = QStringLiteral( "https://wishlist.merginmaps.com/rss/changelog.xml" );
 
 const QString utmTagHelp = QStringLiteral( "?utm_source=input-help&utm_medium=help&utm_campaign=input" );
@@ -46,19 +46,9 @@ QString InputHelp::helpRootLink() const
   return helpRoot + "/" + utmTagHelp;
 }
 
-QString InputHelp::inputWebLink() const
+QString InputHelp::mmWebLink() const
 {
-  return inputWeb + "/" +  utmTagOther;
-}
-
-QString InputHelp::merginWebLink() const
-{
-  if ( mMerginApi && mMerginApi->apiRoot() != MerginApi::defaultApiRoot() )
-  {
-    return mMerginApi->apiRoot(); // UTM tags are included only for production server
-  }
-
-  return MerginApi::defaultApiRoot() + utmTagOther;
+  return mmWeb + "/" +  utmTagOther;
 }
 
 QString InputHelp::merginLinkHelper( const QString &subpath, const QString &utmTag ) const
@@ -76,7 +66,7 @@ QString InputHelp::merginLinkHelper( const QString &subpath, const QString &utmT
 
   if ( mMerginApi && mMerginApi->apiRoot() != MerginApi::defaultApiRoot() )
   {
-    return mMerginApi->apiRoot() + subpath + activeWorkspacePathPart;
+    return mMerginApi->apiRoot() + "/" + subpath + activeWorkspacePathPart;
   }
 
   // Let's include UTM tags for production server
@@ -96,7 +86,7 @@ QString InputHelp::merginLinkHelper( const QString &subpath, const QString &utmT
     queryParams = utmTag;
   }
 
-  return MerginApi::defaultApiRoot() + subpath + queryParams;
+  return MerginApi::defaultApiRoot() + "/" + subpath + queryParams;
 }
 
 QString InputHelp::merginDashboardLink() const
@@ -118,7 +108,7 @@ QString InputHelp::merginSubscriptionLink() const
 
 QString InputHelp::privacyPolicyLink() const
 {
-  return inputWeb + "/privacy-policy" + utmTagOther;
+  return mmWeb + "/privacy-policy" + utmTagOther;
 }
 
 QString InputHelp::merginSubscriptionDetailsLink() const
@@ -158,7 +148,7 @@ QString InputHelp::howToConnectGPSLink() const
 
 QString InputHelp::merginTermsLink() const
 {
-  return MerginApi::marketingPageRoot() + "terms-of-service" + utmTagOther;
+  return mmWeb + "/terms-of-service" + utmTagOther;
 }
 
 QString InputHelp::projectLoadingErrorHelpLink() const
@@ -168,7 +158,7 @@ QString InputHelp::projectLoadingErrorHelpLink() const
 
 QString InputHelp::whatsNewPostLink() const
 {
-  return inputWeb + "/blog/introducing-workspaces-simplified-collaboration" + utmTagOther;
+  return mmWeb + "/blog/introducing-workspaces-simplified-collaboration" + utmTagOther;
 }
 
 QString InputHelp::changelogLink()

--- a/app/inputhelp.h
+++ b/app/inputhelp.h
@@ -25,8 +25,7 @@ class InputHelp: public QObject
 
     Q_PROPERTY( QString privacyPolicyLink READ privacyPolicyLink NOTIFY linkChanged )
     Q_PROPERTY( QString helpRootLink READ helpRootLink )
-    Q_PROPERTY( QString inputWebLink READ inputWebLink NOTIFY linkChanged )
-    Q_PROPERTY( QString merginWebLink READ merginWebLink NOTIFY merginLinkChanged )
+    Q_PROPERTY( QString mmWebLink READ mmWebLink NOTIFY linkChanged )
     Q_PROPERTY( QString merginDashboardLink READ merginDashboardLink NOTIFY merginLinkChanged )
     Q_PROPERTY( QString merginSubscriptionLink READ merginSubscriptionLink NOTIFY merginLinkChanged )
     Q_PROPERTY( QString merginSubscriptionDetailsLink READ merginSubscriptionDetailsLink NOTIFY linkChanged )
@@ -59,8 +58,7 @@ class InputHelp: public QObject
     explicit InputHelp( MerginApi *merginApi );
 
     QString helpRootLink() const;
-    QString inputWebLink() const;
-    QString merginWebLink() const;
+    QString mmWebLink() const;
     QString merginDashboardLink() const;
     QString merginSubscriptionLink() const;
     QString privacyPolicyLink() const;

--- a/app/qml/account/MMAccountController.qml
+++ b/app/qml/account/MMAccountController.qml
@@ -112,12 +112,6 @@ Item {
       }
 
       onChangeServerClicked: function ( newServer ) {
-        // Ensure the newServer string ends with a '/'
-        // to format it as "https://my-server-app.com/"
-        if ( newServer && newServer.slice( -1 ) !== '/' ) {
-          newServer += '/';
-        }
-
         __merginApi.apiRoot = newServer
       }
 

--- a/app/qml/account/MMLoginPage.qml
+++ b/app/qml/account/MMLoginPage.qml
@@ -204,7 +204,7 @@ MMPage {
             textFieldBackground.color: __style.lightGreenColor
 
             text: root.apiRoot
-            placeholderText: "https://my-server-app.com/"
+            placeholderText: "https://app.merginmaps.com"
 
             // Qt.ImhNoPredictiveText must be accompanied by Qt.ImhSensitiveData, see https://bugreports.qt.io/browse/QTBUG-86982
             textField.inputMethodHints: Qt.ImhNoPredictiveText | Qt.ImhSensitiveData | Qt.ImhNoAutoUppercase | Qt.ImhUrlCharactersOnly

--- a/app/qml/settings/MMSettingsController.qml
+++ b/app/qml/settings/MMSettingsController.qml
@@ -82,7 +82,7 @@ Item {
 
     MMAboutPage {
       onBackClicked: root.back()
-      onVisitWebsiteClicked: Qt.openUrlExternally( __inputHelp.inputWebLink )
+      onVisitWebsiteClicked: Qt.openUrlExternally( __inputHelp.mmWebLink )
     }
   }
 

--- a/app/test/testlinks.h
+++ b/app/test/testlinks.h
@@ -49,9 +49,9 @@ class TestLinks: public QObject
     void initTestCase() {}
     void cleanupTestCase() {}
 
-    void testInputWebLink()
+    void testMMWebLink()
     {
-      _run( mHelp.inputWebLink() );
+      _run( mHelp.mmWebLink() );
     }
 
     void testPrivacyPolicy()
@@ -77,11 +77,6 @@ class TestLinks: public QObject
     void testHelpRootLink()
     {
       _run( mHelp.helpRootLink() );
-    }
-
-    void testMerginWebLink()
-    {
-      _run( mHelp.merginWebLink() );
     }
 
     void testMerginDashboardLink()

--- a/app/test/testmerginapi.cpp
+++ b/app/test/testmerginapi.cpp
@@ -3303,3 +3303,30 @@ void TestMerginApi::testHasLocalProjectChanges()
   // clean up
   QDir( projectDir ).removeRecursively();
 }
+
+void TestMerginApi::testApiRoot()
+{
+  QString originalRoot = mApi->apiRoot();
+
+  QVector< QPair<QString, QString> > testcases =
+  {
+    { "https://app.merginmaps.com/", "https://app.merginmaps.com" },
+    { "https://app.merginmaps.com", "https://app.merginmaps.com" },
+    { "http://app.merginmaps.com/", "http://app.merginmaps.com" },
+    { "http://app.merginmaps.com", "http://app.merginmaps.com" },
+    { "https://app.merginmaps.com//", "https://app.merginmaps.com" },
+    { "https://app.merginmaps.com///", "https://app.merginmaps.com" },
+    { "https://app.merginmaps.com////", "https://app.merginmaps.com" },
+    { "https://app.merginmaps.com", "https://app.merginmaps.com" },
+    { "https://example.com", "https://example.com" },
+    { "example.com/", "example.com" }
+  };
+
+  for ( auto testcase : testcases )
+  {
+    mApi->setApiRoot( testcase.first );
+    QCOMPARE( mApi->apiRoot(), testcase.second );
+  }
+
+  mApi->setApiRoot( originalRoot );
+}

--- a/app/test/testmerginapi.h
+++ b/app/test/testmerginapi.h
@@ -169,6 +169,8 @@ class TestMerginApi: public QObject
 
     void testParseVersion();
 
+    void testApiRoot();
+
   private:
     MerginApi *mApi = nullptr;
 

--- a/core/merginapi.cpp
+++ b/core/merginapi.cpp
@@ -32,8 +32,7 @@
 const QString MerginApi::sMetadataFile = QStringLiteral( "/.mergin/mergin.json" );
 const QString MerginApi::sMetadataFolder = QStringLiteral( ".mergin" );
 const QString MerginApi::sMerginConfigFile = QStringLiteral( "mergin-config.json" );
-const QString MerginApi::sMarketingPageRoot = QStringLiteral( "https://merginmaps.com/" );
-const QString MerginApi::sDefaultApiRoot = QStringLiteral( "https://app.merginmaps.com/" );
+const QString MerginApi::sDefaultApiRoot = QStringLiteral( "https://app.merginmaps.com" );
 const QSet<QString> MerginApi::sIgnoreExtensions = QSet<QString>() << "gpkg-shm" << "gpkg-wal" << "qgs~" << "qgz~" << "pyc" << "swap";
 const QSet<QString> MerginApi::sIgnoreImageExtensions = QSet<QString>() << "jpg" << "jpeg" << "png";
 const QSet<QString> MerginApi::sIgnoreFiles = QSet<QString>() << "mergin.json" << ".DS_Store";
@@ -115,7 +114,7 @@ MerginApi::MerginApi( LocalProjectsManager &localProjects, QObject *parent )
 void MerginApi::loadCache()
 {
   QSettings settings;
-  mApiRoot = settings.value( QStringLiteral( "Input/apiRoot" ) ).toString();
+  setApiRoot( settings.value( QStringLiteral( "Input/apiRoot" ) ).toString() );
   int serverType = settings.value( QStringLiteral( "Input/serverType" ) ).toInt();
 
   mServerType = static_cast<MerginServerType::ServerType>( serverType );
@@ -591,7 +590,7 @@ void MerginApi::pushStart( const QString &projectFullName, const QByteArray &jso
   TransactionStatus &transaction = mTransactionalStatus[projectFullName];
 
   QNetworkRequest request = getDefaultRequest();
-  QUrl url( mApiRoot + QStringLiteral( "v1/project/push/%1" ).arg( projectFullName ) );
+  QUrl url( mApiRoot + QStringLiteral( "/v1/project/push/%1" ).arg( projectFullName ) );
   request.setUrl( url );
   request.setRawHeader( "Content-Type", "application/json" );
   request.setAttribute( static_cast<QNetworkRequest::Attribute>( AttrProjectFullName ), projectFullName );
@@ -655,7 +654,7 @@ void MerginApi::cancelPush( const QString &projectFullName )
 void MerginApi::sendPushCancelRequest( const QString &projectFullName, const QString &transactionUUID )
 {
   QNetworkRequest request = getDefaultRequest();
-  QUrl url( mApiRoot + QStringLiteral( "v1/project/push/cancel/%1" ).arg( transactionUUID ) );
+  QUrl url( mApiRoot + QStringLiteral( "/v1/project/push/cancel/%1" ).arg( transactionUUID ) );
   request.setUrl( url );
   request.setRawHeader( "Content-Type", "application/json" );
   request.setAttribute( static_cast<QNetworkRequest::Attribute>( AttrProjectFullName ), projectFullName );
@@ -708,7 +707,7 @@ void MerginApi::pushFinish( const QString &projectFullName, const QString &trans
   TransactionStatus &transaction = mTransactionalStatus[projectFullName];
 
   QNetworkRequest request = getDefaultRequest();
-  QUrl url( mApiRoot + QStringLiteral( "v1/project/push/finish/%1" ).arg( transactionUUID ) );
+  QUrl url( mApiRoot + QStringLiteral( "/v1/project/push/finish/%1" ).arg( transactionUUID ) );
   request.setUrl( url );
   request.setRawHeader( "Content-Type", "application/json" );
   request.setAttribute( static_cast<QNetworkRequest::Attribute>( AttrProjectFullName ), projectFullName );
@@ -798,7 +797,7 @@ void MerginApi::authorize( const QString &login, const QString &password )
   mUserAuth->blockSignals( false );
 
   QNetworkRequest request = getDefaultRequest( false );
-  QString urlString = mApiRoot + QStringLiteral( "v1/auth/login" );
+  QString urlString = mApiRoot + QStringLiteral( "/v1/auth/login" );
   QUrl url( urlString );
   request.setUrl( url );
   request.setRawHeader( "Content-Type", "application/json" );
@@ -850,7 +849,7 @@ void MerginApi::registerUser( const QString &email,
 
   // request
   QNetworkRequest request = getDefaultRequest( false );
-  QString urlString = mApiRoot + QStringLiteral( "v1/auth/register" );
+  QString urlString = mApiRoot + QStringLiteral( "/v1/auth/register" );
   QUrl url( urlString );
   request.setUrl( url );
   request.setRawHeader( "Content-Type", "application/json" );
@@ -886,7 +885,7 @@ void MerginApi::postRegisterUser( const QString &marketingChannel, const QString
   }
   // request
   QNetworkRequest request = getDefaultRequest( false );
-  QString urlString = mApiRoot + QStringLiteral( "v1/post-register" );
+  QString urlString = mApiRoot + QStringLiteral( "/v1/post-register" );
   QUrl url( urlString );
   request.setUrl( url );
   request.setRawHeader( "Content-Type", "application/json" );
@@ -913,11 +912,11 @@ void MerginApi::getUserInfo()
   QString urlString;
   if ( mServerType == MerginServerType::OLD )
   {
-    urlString = mApiRoot + QStringLiteral( "v1/user/%1" ).arg( mUserAuth->username() );
+    urlString = mApiRoot + QStringLiteral( "/v1/user/%1" ).arg( mUserAuth->username() );
   }
   else
   {
-    urlString = mApiRoot + QStringLiteral( "v1/user/profile" );
+    urlString = mApiRoot + QStringLiteral( "/v1/user/profile" );
   }
 
   QNetworkRequest request = getDefaultRequest();
@@ -946,7 +945,7 @@ void MerginApi::getWorkspaceInfo()
     return;
   }
 
-  QString urlString = mApiRoot + QStringLiteral( "v1/workspace/%1" ).arg( mUserInfo->activeWorkspaceId() );
+  QString urlString = mApiRoot + QStringLiteral( "/v1/workspace/%1" ).arg( mUserInfo->activeWorkspaceId() );
   QNetworkRequest request = getDefaultRequest();
   QUrl url( urlString );
   request.setUrl( url );
@@ -967,11 +966,11 @@ void MerginApi::getServiceInfo()
 
   if ( mServerType == MerginServerType::SAAS )
   {
-    urlString = mApiRoot + QStringLiteral( "v1/workspace/%1/service" ).arg( mUserInfo->activeWorkspaceId() );
+    urlString = mApiRoot + QStringLiteral( "/v1/workspace/%1/service" ).arg( mUserInfo->activeWorkspaceId() );
   }
   else if ( mServerType == MerginServerType::OLD )
   {
-    urlString = mApiRoot + QStringLiteral( "v1/user/service" );
+    urlString = mApiRoot + QStringLiteral( "/v1/user/service" );
   }
   else
   {
@@ -1038,14 +1037,6 @@ void MerginApi::clearAuth()
   mUserInfo->clearCachedWorkspacesInfo();
   mWorkspaceInfo->clear();
   mSubscriptionInfo->clear();
-}
-
-void MerginApi::resetApiRoot()
-{
-  QSettings settings;
-  settings.beginGroup( QStringLiteral( "Input/" ) );
-  setApiRoot( defaultApiRoot() );
-  settings.endGroup();
 }
 
 QString MerginApi::resetPasswordUrl()
@@ -1724,6 +1715,12 @@ void MerginApi::setApiRoot( const QString &apiRoot )
   else
   {
     newApiRoot = apiRoot;
+  }
+
+  // Api root should not include the trailing slash!
+  while ( newApiRoot.endsWith( "/" ) )
+  {
+    newApiRoot.chop( 1 );
   }
 
   if ( newApiRoot != mApiRoot )
@@ -3839,7 +3836,7 @@ void MerginApi::processInvitation( const QString &uuid, bool accept )
   }
 
   QNetworkRequest request = getDefaultRequest( true );
-  QString urlString = mApiRoot + QStringLiteral( "v1/workspace/invitation/%1" ).arg( uuid );
+  QString urlString = mApiRoot + QStringLiteral( "/v1/workspace/invitation/%1" ).arg( uuid );
   QUrl url( urlString );
   request.setUrl( url );
   request.setRawHeader( "Content-Type", "application/json" );

--- a/core/merginapi.h
+++ b/core/merginapi.h
@@ -312,7 +312,6 @@ class MerginApi: public QObject
     Q_INVOKABLE void getWorkspaceInfo();
     Q_INVOKABLE void getServiceInfo();
     Q_INVOKABLE void clearAuth();
-    Q_INVOKABLE void resetApiRoot();
     Q_INVOKABLE QString resetPasswordUrl();
 
     /**
@@ -374,13 +373,10 @@ class MerginApi: public QObject
     static const QString sMetadataFile;
     static const QString sMetadataFolder;
     static const QString sMerginConfigFile;
-    static const QString sMarketingPageRoot;
     static const QString sDefaultApiRoot;
     static const QString sSyncCanceledMessage;
 
     static QString defaultApiRoot() { return sDefaultApiRoot; }
-
-    static QString marketingPageRoot() { return sMarketingPageRoot; }
 
     static bool isFileDiffable( const QString &fileName ) { return fileName.endsWith( ".gpkg" ); }
 


### PR DESCRIPTION
Api root will not include the trailing slash(es) from now on. URLs in api calls must start with `/`

Fixes #3862