### PR TITLE
Fix project list scrolling

### DIFF
--- a/app/qml/project/MMProjectList.qml
+++ b/app/qml/project/MMProjectList.qml
@@ -183,10 +183,12 @@ Item {
     id: loadingSpinnerComponent
 
     Item {
-      width:listview.width
-      height: listview.height
+      width: listview.width
+      height: controllerModel.isLoading ? busyIndicator.height : root.spacing
+      visible: controllerModel.isLoading
 
       MMComponents.MMBusyIndicator {
+        id: busyIndicator
         anchors.centerIn: parent
         running: controllerModel.isLoading
       }


### PR DESCRIPTION
Scrolling was allowed beyond project list items end due to excessive height contributed by loading spinner component.

Behavior with issue:
https://github.com/user-attachments/assets/d596973f-ee1a-4a99-a0e3-a7de0ad0d71c

After fix:

https://github.com/user-attachments/assets/da8edf10-f1c6-446f-9805-8bbd37bad30b

