### PR TITLE
Notify users of permission issues during project creation

### DIFF
--- a/app/qml/main.qml
+++ b/app/qml/main.qml
@@ -992,7 +992,7 @@ ApplicationWindow {
       }
     }
 
-    function onInsufficientPermissions()
+    function onProjectCreationFailed()
     {
       syncButton.iconRotateAnimationRunning = false
     }

--- a/app/qml/main.qml
+++ b/app/qml/main.qml
@@ -991,6 +991,11 @@ ApplicationWindow {
         __notificationModel.addSuccess( qsTr( "Up to date" ) )
       }
     }
+
+    function onInsufficientPermissions()
+    {
+      syncButton.iconRotateAnimationRunning = false
+    }
   }
 
   Connections {

--- a/core/merginapi.cpp
+++ b/core/merginapi.cpp
@@ -1152,7 +1152,9 @@ void MerginApi::createProjectFinished()
     QString code = extractServerErrorCode( data );
     QString serverMsg = extractServerErrorMsg( data );
     QString message = QStringLiteral( "FAILED - %1: %2" ).arg( r->errorString(), serverMsg );
+    int httpCode = r->attribute( QNetworkRequest::HttpStatusCodeAttribute ).toInt();
     bool showLimitReachedDialog = EnumHelper::isEqual( code, ErrorCode::ProjectsLimitHit );
+    bool userMissingPermissions = ( httpCode == 403 );
 
     CoreUtils::log( "create " + projectFullName, message );
 
@@ -1166,9 +1168,13 @@ void MerginApi::createProjectFinished()
         maxProjects = maxProjectVariant.toInt();
       emit projectLimitReached( maxProjects, serverMsg );
     }
+    else if ( userMissingPermissions )
+    {
+      emit notifyError( tr( "You don't have permission to create new projects in this workspace." ) );
+      emit insufficientPermissions();
+    }
     else
     {
-      int httpCode = r->attribute( QNetworkRequest::HttpStatusCodeAttribute ).toInt();
       emit networkErrorOccurred( serverMsg, QStringLiteral( "Mergin API error: createProject" ), httpCode, projectName );
     }
   }

--- a/core/merginapi.cpp
+++ b/core/merginapi.cpp
@@ -1171,10 +1171,12 @@ void MerginApi::createProjectFinished()
     else if ( userMissingPermissions )
     {
       emit notifyError( tr( "You don't have permission to create new projects in this workspace." ) );
-      emit insufficientPermissions();
+      emit projectCreationFailed();
     }
     else
     {
+      emit notifyError( tr( "Couldn't create the project." ) );
+      emit projectCreationFailed();
       emit networkErrorOccurred( serverMsg, QStringLiteral( "Mergin API error: createProject" ), httpCode, projectName );
     }
   }

--- a/core/merginapi.cpp
+++ b/core/merginapi.cpp
@@ -1175,7 +1175,7 @@ void MerginApi::createProjectFinished()
     }
     else
     {
-      emit notifyError( tr( "Couldn't create the project." ) );
+      emit notifyError( tr( "Couldn't create the project. Please try again later or contact support if the problem persists." ) );
       emit projectCreationFailed();
       emit networkErrorOccurred( serverMsg, QStringLiteral( "Mergin API error: createProject" ), httpCode, projectName );
     }

--- a/core/merginapi.h
+++ b/core/merginapi.h
@@ -613,6 +613,7 @@ class MerginApi: public QObject
 
     void storageLimitReached( qreal uploadSize );
     void projectLimitReached( int maxProjects, const QString &message );
+    void insufficientPermissions();
     void migrationRequested( const QString &version );
     void notifySuccess( const QString &message );
     void notifyInfo( const QString &message );

--- a/core/merginapi.h
+++ b/core/merginapi.h
@@ -613,7 +613,7 @@ class MerginApi: public QObject
 
     void storageLimitReached( qreal uploadSize );
     void projectLimitReached( int maxProjects, const QString &message );
-    void insufficientPermissions();
+    void projectCreationFailed();
     void migrationRequested( const QString &version );
     void notifySuccess( const QString &message );
     void notifyInfo( const QString &message );


### PR DESCRIPTION
Added a new error notification when a user tries to first upload a project to the server but lacks sufficient permissions in the current workspace and for generic project creation errors. Also halts syncing animation in the UI during project creation errors.

Resolves #3817, Resolves #3910