### PR TITLE
Fix reset model sequence

### DIFF
--- a/app/layer/layertreeflatmodel.cpp
+++ b/app/layer/layertreeflatmodel.cpp
@@ -69,9 +69,9 @@ void LayerTreeFlatModel::reset()
 
 void LayerTreeFlatModel::populate()
 {
-  beginResetModel();
-
   clear();
+
+  beginResetModel();
 
   if ( mLayerTreeModel )
   {


### PR DESCRIPTION
Newer Qt version introduces a warning when a model reset is initiated while another reset operation is still in progress (see https://github.com/qt/qtbase/commit/9d8663c18e88cb0b5a65f86cfd7726f3d31e04d6). To resolve this issue, we will invoke QStandardItemModel's `clear` method within LayerTreeFlatModel's `populate` method prior to calling `beginResetModel`.

Fixes #3815