### PR TITLE
Use project IDs internaly to manage projects

### DIFF
--- a/app/activeproject.h
+++ b/app/activeproject.h
@@ -15,14 +15,12 @@
 
 #include "qgsproject.h"
 
-#include "inputconfig.h"
 #include "appsettings.h"
 #include "activelayer.h"
 #include "recordinglayersproxymodel.h"
 #include "localprojectsmanager.h"
 #include "autosynccontroller.h"
 #include "inputmapsettings.h"
-#include "merginprojectmetadata.h"
 
 /**
  * \brief The ActiveProject class can load a QGIS project and holds its data.
@@ -47,7 +45,7 @@ class ActiveProject: public QObject
       , LocalProjectsManager &localProjectsManager
       , QObject *parent = nullptr );
 
-    virtual ~ActiveProject();
+    ~ActiveProject() override;
 
     //! Returns active project's QgsProject instance to do QGIS API magic
     QgsProject *qgsProject() const;
@@ -57,6 +55,8 @@ class ActiveProject: public QObject
 
     Q_INVOKABLE QString projectFullName() const;
 
+    Q_INVOKABLE QString projectId() const;
+
     /**
      * Loads a .qgz/.qgs project file specified by filePath.
      * \param filePath Path to project file.
@@ -64,10 +64,10 @@ class ActiveProject: public QObject
     Q_INVOKABLE bool load( const QString &filePath );
 
     /**
-     * Applies map theme with 'name' to currently loaded QGIS project
+     * Applies map theme with 'themeName' to currently loaded QGIS project
      * Invalidates active layer if it is no longer visible
      */
-    Q_INVOKABLE void setMapTheme( const QString &name );
+    Q_INVOKABLE void setMapTheme( const QString &themeName );
 
     /**
      * setActiveLayer sets active layer from layer
@@ -128,7 +128,7 @@ class ActiveProject: public QObject
      * Returns if project layer allows recording (has geometry, editable, not position tracking layer, not map
      * sketching layer) regardless of visibility
      */
-    bool recordingAllowed( QgsMapLayer *layer ) const ;
+    bool recordingAllowed( const QgsMapLayer *layer ) const ;
 
     //! Returns position tracking layer ID if exists
     Q_INVOKABLE QString positionTrackingLayerId() const;
@@ -165,7 +165,7 @@ class ActiveProject: public QObject
 
     void positionTrackingSupportedChanged();
 
-    // Emited when the app (UI) should show tracking because there is a running tracking service
+    // Emitted when the app (UI) should show tracking because there is a running tracking service
     void startPositionTracking();
 
     void projectRoleChanged();
@@ -174,7 +174,7 @@ class ActiveProject: public QObject
 
   public slots:
     // Reloads project if current project path matches given path (its the same project)
-    bool reloadProject( QString projectDir );
+    bool reloadProject( const QString &projectDir );
 
     void setAutosyncEnabled( bool enabled );
 
@@ -196,10 +196,7 @@ class ActiveProject: public QObject
      *  if not, sets first available layer as active;
      *  sets nullptr if there are no other available layers
      */
-    void updateActiveLayer();
-
-    //! Reloads layers in 'recoring layers model'
-    void updateRecordingLayers();
+    void updateActiveLayer() const;
 
     QgsProject *mQgsProject = nullptr;
     LocalProject mLocalProject;

--- a/app/main.cpp
+++ b/app/main.cpp
@@ -586,20 +586,20 @@ int main( int argc, char *argv[] )
 
   QObject::connect( &activeProject, &ActiveProject::projectReloaded, &lambdaContext, [merginApi = ma.get(), &activeProject]()
   {
-    merginApi->reloadProjectRole( activeProject.projectFullName() );
+    merginApi->reloadProjectRole( activeProject.projectId() );
   } );
 
   QObject::connect( ma.get(), &MerginApi::authChanged, &lambdaContext, [merginApi = ma.get(), &activeProject]()
   {
     if ( activeProject.isProjectLoaded() )
     {
-      merginApi->reloadProjectRole( activeProject.projectFullName() );
+      merginApi->reloadProjectRole( activeProject.projectId() );
     }
   } );
 
-  QObject::connect( ma.get(), &MerginApi::projectRoleUpdated, &activeProject, [&activeProject]( const QString & projectFullName, const QString & role )
+  QObject::connect( ma.get(), &MerginApi::projectRoleUpdated, &activeProject, [&activeProject]( const QString & projectId, const QString & role )
   {
-    if ( projectFullName == activeProject.projectFullName() )
+    if ( projectId == activeProject.projectId() )
     {
       activeProject.setProjectRole( role );
     }
@@ -624,11 +624,11 @@ int main( int argc, char *argv[] )
   QObject::connect( &pw, &ProjectWizard::projectCreated, &localProjectsManager, &LocalProjectsManager::addLocalProject );
   QObject::connect( &activeProject, &ActiveProject::projectReloaded, vm.get(), &VariablesManager::merginProjectChanged );
   QObject::connect( &activeProject, &ActiveProject::projectWillBeReloaded, &inputProjUtils, &InputProjUtils::resetHandlers );
-  QObject::connect( &syncManager, &SynchronizationManager::syncFinished, &activeProject, [&activeProject]( const QString & projectFullName, bool successfully, int version, bool reloadNeeded )
+  QObject::connect( &syncManager, &SynchronizationManager::syncFinished, &activeProject, [&activeProject]( const QString & projectId, const bool successfully, const int version, const bool reloadNeeded )
   {
     Q_UNUSED( successfully );
     Q_UNUSED( version );
-    if ( reloadNeeded && activeProject.projectFullName() == projectFullName )
+    if ( reloadNeeded && activeProject.projectId() == projectId )
     {
       activeProject.reloadProject( activeProject.qgsProject()->homePath() );
     }
@@ -680,7 +680,7 @@ int main( int argc, char *argv[] )
   // and properly close connection after writting changes to gpkg.
   qputenv( "OGR_SQLITE_JOURNAL", "DELETE" );
 
-
+  // TODO: rework to singletons instead (check Qt docs why)
   // Register to QQmlEngine
   engine.rootContext()->setContextProperty( "__notificationModel", &notificationModel );
   engine.rootContext()->setContextProperty( "__androidUtils", &androidUtils );

--- a/app/projectsmodel.cpp
+++ b/app/projectsmodel.cpp
@@ -27,44 +27,44 @@ void ProjectsModel::initializeProjectsModel()
   if ( !mSyncManager || !mBackend || !mLocalProjectsManager || mModelType == EmptyProjectsModel ) // Model is not set up properly yet
     return;
 
-  QObject::connect( mSyncManager, &SynchronizationManager::syncStarted, this, &ProjectsModel::onProjectSyncStarted );
-  QObject::connect( mSyncManager, &SynchronizationManager::syncFinished, this, &ProjectsModel::onProjectSyncFinished );
-  QObject::connect( mSyncManager, &SynchronizationManager::syncCancelled, this, &ProjectsModel::onProjectSyncCancelled );
-  QObject::connect( mSyncManager, &SynchronizationManager::syncProgressChanged, this, &ProjectsModel::onProjectSyncProgressChanged );
+  connect( mSyncManager, &SynchronizationManager::syncStarted, this, &ProjectsModel::onProjectSyncStarted );
+  connect( mSyncManager, &SynchronizationManager::syncFinished, this, &ProjectsModel::onProjectSyncFinished );
+  connect( mSyncManager, &SynchronizationManager::syncCancelled, this, &ProjectsModel::onProjectSyncCancelled );
+  connect( mSyncManager, &SynchronizationManager::syncProgressChanged, this, &ProjectsModel::onProjectSyncProgressChanged );
 
-  QObject::connect( mBackend, &MerginApi::projectDetached, this, &ProjectsModel::onProjectDetachedFromMergin );
-  QObject::connect( mBackend, &MerginApi::projectAttachedToMergin, this, &ProjectsModel::onProjectAttachedToMergin );
-  QObject::connect( mBackend, &MerginApi::authChanged, this, &ProjectsModel::onAuthChanged );
+  connect( mBackend, &MerginApi::projectDetached, this, &ProjectsModel::onProjectDetachedFromMergin );
+  connect( mBackend, &MerginApi::projectAttachedToMergin, this, &ProjectsModel::onProjectAttachedToMergin );
+  connect( mBackend, &MerginApi::authChanged, this, &ProjectsModel::onAuthChanged );
 
   if ( mModelType == ProjectModelTypes::LocalProjectsModel )
   {
-    QObject::connect( mBackend, &MerginApi::listProjectsByNameFinished, this, &ProjectsModel::onListProjectsByNameFinished );
+    connect( mBackend, &MerginApi::listProjectsByNameFinished, this, &ProjectsModel::onListProjectsByNameFinished );
     loadLocalProjects();
   }
   else if ( mModelType != ProjectModelTypes::RecentProjectsModel )
   {
-    QObject::connect( mBackend, &MerginApi::listProjectsFinished, this, &ProjectsModel::onListProjectsFinished );
+    connect( mBackend, &MerginApi::listProjectsFinished, this, &ProjectsModel::onListProjectsFinished );
   }
   else
   {
     // Implement RecentProjectsModel type
   }
 
-  QObject::connect( mLocalProjectsManager, &LocalProjectsManager::localProjectAdded, this, &ProjectsModel::onProjectAdded );
-  QObject::connect( mLocalProjectsManager, &LocalProjectsManager::aboutToRemoveLocalProject, this, &ProjectsModel::onAboutToRemoveProject );
-  QObject::connect( mLocalProjectsManager, &LocalProjectsManager::localProjectDataChanged, this, &ProjectsModel::onProjectDataChanged );
-  QObject::connect( mLocalProjectsManager, &LocalProjectsManager::dataDirReloaded, this, &ProjectsModel::loadLocalProjects );
+  connect( mLocalProjectsManager, &LocalProjectsManager::localProjectAdded, this, &ProjectsModel::onProjectAdded );
+  connect( mLocalProjectsManager, &LocalProjectsManager::aboutToRemoveLocalProject, this, &ProjectsModel::onAboutToRemoveProject );
+  connect( mLocalProjectsManager, &LocalProjectsManager::localProjectDataChanged, this, &ProjectsModel::onProjectDataChanged );
+  connect( mLocalProjectsManager, &LocalProjectsManager::dataDirReloaded, this, &ProjectsModel::loadLocalProjects );
 
   emit modelInitialized();
 }
 
-QVariant ProjectsModel::data( const QModelIndex &index, int role ) const
+QVariant ProjectsModel::data( const QModelIndex &index, const int role ) const
 {
   if ( !index.isValid() )
-    return QVariant();
+    return {};
 
   if ( index.row() < 0 || index.row() >= mProjects.size() )
-    return QVariant();
+    return {};
 
   const Project project = mProjects.at( index.row() );
 
@@ -95,7 +95,7 @@ QVariant ProjectsModel::data( const QModelIndex &index, int role ) const
         }
         else
         {
-          ProjectStatus::Status status = ProjectStatus::projectStatus( project, mBackend->supportsSelectiveSync() );
+          const ProjectStatus::Status status = ProjectStatus::projectStatus( project, mBackend->supportsSelectiveSync() );
 
           if ( status == ProjectStatus::NeedsSync )
           {
@@ -108,7 +108,7 @@ QVariant ProjectsModel::data( const QModelIndex &index, int role ) const
           }
         }
 
-        QFileInfo fi( project.local.projectDir );
+        const QFileInfo fi( project.local.projectDir );
 
         // Up to date
         // lastModified of projectDir is not reliable - gpkg file may have modified header after opening it. See more #1320
@@ -121,7 +121,7 @@ QVariant ProjectsModel::data( const QModelIndex &index, int role ) const
 
       // This should not happen
       CoreUtils::log( "Project error", "Found project that is not downloaded nor remote" );
-      return QVariant();
+      return {};
     }
     case ProjectIsActiveProject:
     {
@@ -129,20 +129,20 @@ QVariant ProjectsModel::data( const QModelIndex &index, int role ) const
     }
     default:
     {
-      if ( !project.isMergin() ) return QVariant();
+      if ( !project.isMergin() ) return {};
 
       // Roles only for projects that has mergin part
       if ( role == ProjectSyncPending ) return QVariant( mSyncManager->hasPendingSync( project.fullName() ) );
       else if ( role == ProjectSyncProgress ) return QVariant( mSyncManager->syncProgress( project.fullName() ) );
       else if ( role == ProjectRemoteError ) return QVariant( project.mergin.remoteError );
-      return QVariant();
+      return {};
     }
   }
 }
 
-QModelIndex ProjectsModel::index( int row, int col, const QModelIndex &parent ) const
+QModelIndex ProjectsModel::index( const int row, const int column, const QModelIndex &parent ) const
 {
-  Q_UNUSED( col )
+  Q_UNUSED( column )
   Q_UNUSED( parent )
   return createIndex( row, 0, nullptr );
 }
@@ -170,14 +170,14 @@ QHash<int, QByteArray> ProjectsModel::roleNames() const
 
 int ProjectsModel::rowCount( const QModelIndex & ) const
 {
-  return mProjects.count();
+  return static_cast<int>( mProjects.count() );
 }
 
-void ProjectsModel::listProjects( const QString &searchExpression, int page )
+void ProjectsModel::listProjects( const QString &searchExpression, const int page )
 {
   if ( mModelType == LocalProjectsModel )
   {
-    listProjectsByName();
+    fetchProjectsByProjectId();
     return;
   }
 
@@ -192,14 +192,29 @@ void ProjectsModel::listProjects( const QString &searchExpression, int page )
   }
 }
 
-void ProjectsModel::listProjectsByName()
+void ProjectsModel::fetchProjectsByProjectId( const QStringList &projectIds )
 {
   if ( mModelType != LocalProjectsModel )
   {
     return;
   }
 
-  mLastRequestId = mBackend->listProjectsByName( projectNames() );
+  QStringList projectNamesList{};
+  if ( projectIds.isEmpty() )
+  {
+    for ( auto project : mLocalProjectsManager->projects().values() )
+    {
+      projectNamesList << project.fullName();
+    }
+  }
+  else
+  {
+    for ( auto key : projectIds )
+    {
+      projectNamesList << mLocalProjectsManager->projectFromProjectId( key ).fullName();
+    }
+  }
+  mLastRequestId = mBackend->listProjectsByName( projectNamesList );
 
   if ( !mLastRequestId.isEmpty() )
   {
@@ -218,7 +233,7 @@ void ProjectsModel::fetchAnotherPage( const QString &searchExpression )
   listProjects( searchExpression, mPaginatedPage + 1 );
 }
 
-void ProjectsModel::onListProjectsFinished( const MerginProjectsList &merginProjects, int projectsCount, int page, QString requestId )
+void ProjectsModel::onListProjectsFinished( const MerginProjectsList &merginProjects, const int projectsCount, const int page, const QString &requestId )
 {
   if ( mLastRequestId != requestId )
   {
@@ -235,7 +250,7 @@ void ProjectsModel::onListProjectsFinished( const MerginProjectsList &merginProj
   else
   {
     // paginating next page, keep previous projects and emit model add items
-    beginInsertRows( QModelIndex(), mProjects.size(), mProjects.size() + merginProjects.size() - 1 );
+    beginInsertRows( QModelIndex(), static_cast<int>( mProjects.size() ), static_cast<int>( mProjects.size() ) + merginProjects.size() - 1 );
     mergeProjects( merginProjects, MergeStrategy::KeepPrevious );
     endInsertRows();
   }
@@ -246,7 +261,7 @@ void ProjectsModel::onListProjectsFinished( const MerginProjectsList &merginProj
   setModelIsLoading( false );
 }
 
-void ProjectsModel::onListProjectsByNameFinished( const MerginProjectsList &merginProjects, QString requestId )
+void ProjectsModel::onListProjectsByNameFinished( const MerginProjectsList &merginProjects, const QString &requestId )
 {
   if ( mLastRequestId != requestId )
   {
@@ -262,7 +277,7 @@ void ProjectsModel::onListProjectsByNameFinished( const MerginProjectsList &merg
 
 void ProjectsModel::mergeProjects( const MerginProjectsList &merginProjects, MergeStrategy mergeStrategy )
 {
-  const LocalProjectsList localProjects = mLocalProjectsManager->projects();
+  const LocalProjectsDict localProjects = mLocalProjectsManager->projects();
 
   if ( mergeStrategy == DiscardPrevious )
   {
@@ -272,7 +287,7 @@ void ProjectsModel::mergeProjects( const MerginProjectsList &merginProjects, Mer
   if ( mModelType == ProjectModelTypes::LocalProjectsModel )
   {
     // Keep all local projects and ignore all not downloaded remote projects
-    for ( const LocalProject &localProject : localProjects )
+    for ( const LocalProject &localProject : localProjects.values() )
     {
       Project project;
       project.local = localProject;
@@ -301,7 +316,7 @@ void ProjectsModel::mergeProjects( const MerginProjectsList &merginProjects, Mer
       mProjects << project;
     }
 
-    // lets check also for projects that are currently being downloaded and add them to local projects list
+    // let's check also for projects that are currently being downloaded and add them to local projects list
     QList<QString> pendingProjects = mSyncManager->pendingProjects();
 
     for ( const QString &pendingProjectName : pendingProjects )
@@ -316,7 +331,7 @@ void ProjectsModel::mergeProjects( const MerginProjectsList &merginProjects, Mer
       {
         Project project;
 
-        MerginApi::extractProjectName( pendingProjectName, project.mergin.projectNamespace, project.mergin.projectName );
+        CoreUtils::extractProjectName( pendingProjectName, project.mergin.projectNamespace, project.mergin.projectName );
         project.mergin.status = ProjectStatus::projectStatus( project, mBackend->supportsSelectiveSync() );
 
         mProjects << project;
@@ -349,7 +364,7 @@ void ProjectsModel::mergeProjects( const MerginProjectsList &merginProjects, Mer
 
 void ProjectsModel::syncProject( const QString &projectId )
 {
-  int ix = projectIndexFromId( projectId );
+  const int ix = projectIndexFromId( projectId );
 
   if ( ix < 0 )
     return;
@@ -367,7 +382,7 @@ void ProjectsModel::syncProject( const QString &projectId )
   }
 }
 
-void ProjectsModel::stopProjectSync( const QString &projectId )
+void ProjectsModel::stopProjectSync( const QString &projectId ) const
 {
   if ( mSyncManager )
   {
@@ -375,46 +390,46 @@ void ProjectsModel::stopProjectSync( const QString &projectId )
   }
 }
 
-void ProjectsModel::removeLocalProject( const QString &projectId )
+void ProjectsModel::removeLocalProject( const QString &projectId ) const
 {
   mLocalProjectsManager->removeLocalProject( projectId );
 }
 
 void ProjectsModel::migrateProject( const QString &projectId )
 {
-  int ix = projectIndexFromId( projectId );
+  const int ix = projectIndexFromId( projectId );
 
   if ( ix < 0 )
     return;
 
-  mSyncManager->migrateProjectToMergin( mProjects[ix].local.projectName );
+  mSyncManager->migrateProjectToMergin( mProjects[ix].local.projectName, projectId );
 }
 
-void ProjectsModel::onProjectSyncStarted( const QString &projectFullName )
+void ProjectsModel::onProjectSyncStarted( const QString &projectId )
 {
-  int ix = projectIndexFromId( projectFullName );
+  const int ix = projectIndexFromId( projectId );
 
   if ( ix < 0 )
     return;
 
-  QModelIndex changeIndex = index( ix );
+  const QModelIndex changeIndex = index( ix );
   emit dataChanged( changeIndex, changeIndex, { ProjectSyncPending, ProjectSyncProgress } );
 }
 
-void ProjectsModel::onProjectSyncCancelled( const QString &projectFullName )
+void ProjectsModel::onProjectSyncCancelled( const QString &projectId )
 {
-  int ix = projectIndexFromId( projectFullName );
+  const int ix = projectIndexFromId( projectId );
 
   if ( ix < 0 )
     return;
 
-  QModelIndex changeIndex = index( ix );
+  const QModelIndex changeIndex = index( ix );
   emit dataChanged( changeIndex, changeIndex, { ProjectSyncPending, ProjectSyncProgress, ProjectStatus } );
 }
 
-void ProjectsModel::onProjectSyncFinished( const QString &projectFullName, bool successfully, int newVersion )
+void ProjectsModel::onProjectSyncFinished( const QString &projectId, const bool successfully, const int newVersion )
 {
-  int ix = projectIndexFromId( projectFullName );
+  const int ix = projectIndexFromId( projectId );
 
   if ( ix < 0 )
     return;
@@ -431,7 +446,7 @@ void ProjectsModel::onProjectSyncFinished( const QString &projectFullName, bool 
 
   project.mergin.status = ProjectStatus::projectStatus( project, mBackend->supportsSelectiveSync() );
 
-  QModelIndex changeIndex = index( ix );
+  const QModelIndex changeIndex = index( ix );
   emit dataChanged( changeIndex, changeIndex, { ProjectSyncPending, ProjectSyncProgress, ProjectStatus } );
 
   // remove project from list of projects if this was a first-time download of remote project in local projects list
@@ -446,11 +461,11 @@ void ProjectsModel::onProjectSyncFinished( const QString &projectFullName, bool 
   }
 }
 
-void ProjectsModel::onProjectSyncProgressChanged( const QString &projectFullName, qreal progress )
+void ProjectsModel::onProjectSyncProgressChanged( const QString &projectId, const qreal progress )
 {
   Q_UNUSED( progress )
 
-  int ix = projectIndexFromId( projectFullName );
+  const int ix = projectIndexFromId( projectId );
 
   if ( ix < 0 )
     return;
@@ -458,14 +473,14 @@ void ProjectsModel::onProjectSyncProgressChanged( const QString &projectFullName
   if ( !mProjects[ix].isMergin() )
     return;
 
-  QModelIndex changeIndex = index( ix );
+  const QModelIndex changeIndex = index( ix );
   emit dataChanged( changeIndex, changeIndex, { ProjectSyncPending, ProjectSyncProgress } );
 }
 
 void ProjectsModel::onProjectAdded( const LocalProject &localProject )
 {
   // Check if such project is already in project list
-  int ix = projectIndexFromId( localProject.id() );
+  const int ix = projectIndexFromId( localProject.id() );
   if ( ix >= 0 )
   {
     // add local information ~ project downloaded
@@ -477,7 +492,7 @@ void ProjectsModel::onProjectAdded( const LocalProject &localProject )
       project.mergin.status = ProjectStatus::projectStatus( project, mBackend->supportsSelectiveSync() );
     }
 
-    QModelIndex modelIx = index( ix );
+    const QModelIndex modelIx = index( ix );
     emit dataChanged( modelIx, modelIx );
   }
   else if ( mModelType == LocalProjectsModel )
@@ -486,7 +501,7 @@ void ProjectsModel::onProjectAdded( const LocalProject &localProject )
     Project project;
     project.local = localProject;
 
-    int insertIndex = mProjects.size();
+    const int insertIndex = static_cast<int>( mProjects.size() );
 
     beginInsertRows( QModelIndex(), insertIndex, insertIndex );
     mProjects << project;
@@ -496,7 +511,7 @@ void ProjectsModel::onProjectAdded( const LocalProject &localProject )
 
 void ProjectsModel::onAboutToRemoveProject( const LocalProject &localProject )
 {
-  int ix = projectIndexFromId( localProject.id() );
+  const int ix = projectIndexFromId( localProject.id() );
 
   if ( ix >= 0 )
   {
@@ -512,7 +527,7 @@ void ProjectsModel::onAboutToRemoveProject( const LocalProject &localProject )
       mProjects[ix].local = LocalProject();
       mProjects[ix].mergin.status = ProjectStatus::projectStatus( mProjects[ix], mBackend->supportsSelectiveSync() );
 
-      QModelIndex modelIx = index( ix );
+      const QModelIndex modelIx = index( ix );
       emit dataChanged( modelIx, modelIx );
     }
   }
@@ -520,7 +535,7 @@ void ProjectsModel::onAboutToRemoveProject( const LocalProject &localProject )
 
 void ProjectsModel::onProjectDataChanged( const LocalProject &localProject )
 {
-  int ix = projectIndexFromId( localProject.id() );
+  const int ix = projectIndexFromId( localProject.id() );
 
   if ( ix < 0 )
     return;
@@ -534,13 +549,13 @@ void ProjectsModel::onProjectDataChanged( const LocalProject &localProject )
     project.mergin.status = ProjectStatus::projectStatus( project, mBackend->supportsSelectiveSync() );
   }
 
-  QModelIndex editIndex = index( ix );
+  const QModelIndex editIndex = index( ix );
   emit dataChanged( editIndex, editIndex );
 }
 
-void ProjectsModel::onProjectDetachedFromMergin( const QString &projectFullName )
+void ProjectsModel::onProjectDetachedFromMergin( const QString &projectId )
 {
-  int ix = projectIndexFromId( projectFullName );
+  const int ix = projectIndexFromId( projectId );
 
   if ( ix < 0 )
     return;
@@ -549,21 +564,20 @@ void ProjectsModel::onProjectDetachedFromMergin( const QString &projectFullName 
   project.mergin = MerginProject();
   project.local.projectNamespace = QLatin1String();
 
-  QModelIndex editIndex = index( ix );
+  const QModelIndex editIndex = index( ix );
   emit dataChanged( editIndex, editIndex );
 
   // This project should also be removed from project list for remote project model types,
   // however, currently one needs to click on "My projects/Shared/Explore" and that sends
   // another listProjects request. In new list this project will not be shown.
-  // However, this option is not allowed in GUI anyways.
+  // However, this option is not allowed in GUI anyway.
 
 }
 
-void ProjectsModel::onProjectAttachedToMergin( const QString & )
+void ProjectsModel::onProjectAttachedToMergin( const QString &projectId )
 {
-  // To ensure project will be in sync with server, send listProjectByName request.
-  // In theory we could send that request only for this one project.
-  listProjectsByName();
+  // To ensure project will be in sync with server, send fetchProjectsByProjectId request.
+  fetchProjectsByProjectId( { projectId } );
 }
 
 void ProjectsModel::onAuthChanged()
@@ -595,7 +609,7 @@ void ProjectsModel::setLocalProjectsManager( LocalProjectsManager *localProjects
   emit localProjectsManagerChanged( mLocalProjectsManager );
 }
 
-void ProjectsModel::setModelType( ProjectsModel::ProjectModelTypes modelType )
+void ProjectsModel::setModelType( const ProjectsModel::ProjectModelTypes modelType )
 {
   if ( mModelType == modelType )
     return;
@@ -615,20 +629,6 @@ QString ProjectsModel::modelTypeToFlag() const
     default:
       return QLatin1String();
   }
-}
-
-QStringList ProjectsModel::projectNames() const
-{
-  QStringList projectNames;
-  const LocalProjectsList projects = mLocalProjectsManager->projects();
-
-  for ( const auto &proj : projects )
-  {
-    if ( !proj.projectName.isEmpty() && !proj.projectNamespace.isEmpty() )
-      projectNames << proj.id();
-  }
-
-  return projectNames;
 }
 
 void ProjectsModel::clearProjects()
@@ -671,12 +671,12 @@ Project ProjectsModel::projectFromId( const QString &projectId ) const
       return project;
     }
   }
-  return Project();
+  return {};
 }
 
 QModelIndex ProjectsModel::projectModelIndexFromId( const QString &projectId ) const
 {
-  int row = projectIndexFromId( projectId );
+  const int row = projectIndexFromId( projectId );
   return index( row );
 }
 
@@ -685,7 +685,7 @@ bool ProjectsModel::isLoading() const
   return mModelIsLoading;
 }
 
-void ProjectsModel::setModelIsLoading( bool state )
+void ProjectsModel::setModelIsLoading( const bool state )
 {
   mModelIsLoading = state;
   emit isLoadingChanged( mModelIsLoading );

--- a/app/projectsmodel.h
+++ b/app/projectsmodel.h
@@ -11,9 +11,7 @@
 #define PROJECTSMODEL_H
 
 #include <QAbstractListModel>
-#include <memory>
 
-#include "inputconfig.h"
 #include "project.h"
 #include "merginapi.h"
 #include "synchronizationmanager.h"
@@ -21,24 +19,29 @@
 class LocalProjectsManager;
 
 /**
- * \brief The ProjectsModel class holds projects (both local and mergin). Model loads local projects from LocalProjectsManager that hold them
-   during runtime. Remote (Mergin) projects are fetched from MerginAPI calling listProjects or listProjectsByName (based on the type of the model).
+ * \brief The ProjectsModel class holds projects (both local and mergin). Model loads local projects from
+ * LocalProjectsManager that hold them during runtime. Remote (Mergin) projects are fetched from MerginAPI
+ * calling listProjects or listProjectsByName (based on the type of the model).
  *
- * The main job of the model is to merge projects coming from MerginAPI and LocalProjectsManager. By merging it means Each time new response is received from MerginAPI, model erases
- * old remembered projects and fetches new. Merge logic depends on the model type (described below).
+ * The main job of the model is to merge projects coming from MerginAPI and LocalProjectsManager. By merging it means
+ * each time new response is received from MerginAPI, model erases old remembered projects and fetches new.
+ * Merge logic depends on the model type (described below).
  *
  * Model can have different types that affect handling of the projects.
- *  - LocalProjectsModel always keeps all local projects and seek their mergin part when listProjectsByNameFinished
- *  - Workspace-, and PublicProjectsModel does the opposite, keeps all mergin projects and seeks their local part in projects from LocalProjectsManager
+ *  - LocalProjectsModel always keeps all local projects and seeks their mergin part when listProjectsByNameFinished
+ *  - Workspace-, and PublicProjectsModel does the opposite, keeps all mergin projects and seeks their local part
+ *    in projects from LocalProjectsManager
  *  - EmptyProjectsModel is default state
  *
- *  To avoid overriding of requests, model remembers last sent request ID and upon receiving signal from MerginAPI about listProjectsFinished, it firsts compares
- *  the remembered ID with returned ID. If they do not match, response is ignored.
+ *  To avoid overriding of requests, model remembers last sent request ID and upon receiving signal from MerginAPI
+ *  about listProjectsFinished, it firsts compares the remembered ID with returned ID. If they do not match, response
+ *  is ignored.
  *
  *  Model also support pagination. To fetch another page call fetchAnotherPage.
  *
- *  This is a QML type with 3 required properties (pointer to merginApi, pointer to localProjectsManager and modelType). Without these properties model does nothing.
- *  After setting all of these properties, model is initialized, starts listening to various signals and offers data.
+ *  This is a QML type with 3 required properties (pointer to merginApi, pointer to localProjectsManager and modelType).
+ *  Without these properties model does nothing. After setting all of these properties, model is initialized,
+ *  starts listening to various signals and offers data.
  */
 class ProjectsModel : public QAbstractListModel
 {
@@ -69,7 +72,8 @@ class ProjectsModel : public QAbstractListModel
     /**
      * \brief The ProjectModelTypes enum:
      * - LocalProjectsModel always keeps all local projects and seek their mergin part when listProjectsByNameFinished
-     * - Workspace-, and PublicProjectsModel does the opposite, keeps all mergin projects and seeks their local part in projects from LocalProjectsManager
+     * - Workspace-, and PublicProjectsModel does the opposite, keeps all mergin projects and seeks their local part
+     *  in projects from LocalProjectsManager
      * - EmptyProjectsModel is default state
      */
     enum ProjectModelTypes
@@ -88,10 +92,10 @@ class ProjectsModel : public QAbstractListModel
       DiscardPrevious
     };
 
-    ProjectsModel( QObject *parent = nullptr );
-    ~ProjectsModel() override {};
+    explicit ProjectsModel( QObject *parent = nullptr );
+    ~ProjectsModel() override = default;
 
-    // From Qt 5.15 we can use REQUIRED keyword here, that will ensure object will be always instantiated from QML with these mandatory properties
+    // From Qt 5.15 we can use REQUIRED keyword here, that will ensure object will always be instantiated from QML with these mandatory properties
     Q_PROPERTY( MerginApi *merginApi READ merginApi WRITE setMerginApi NOTIFY merginApiChanged )
     Q_PROPERTY( ProjectModelTypes modelType READ modelType WRITE setModelType NOTIFY modelTypeChanged )
     Q_PROPERTY( SynchronizationManager *syncManager READ syncManager WRITE setSyncManager NOTIFY syncManagerChanged )
@@ -116,17 +120,21 @@ class ProjectsModel : public QAbstractListModel
     //! lists projects, either fetch more or get first, search expression
     Q_INVOKABLE void listProjects( const QString &searchExpression = QString(), int page = 1 );
 
-    //! lists projects via listProjectsByName API, used in LocalProjectsModel
-    Q_INVOKABLE void listProjectsByName();
+    /**
+     * Lists projects via listProjectsByName API, used in LocalProjectsModel. If projectIds is empty fetches all local
+     * projects else fetches only specified projects.
+     * \param projectIds List of project IDs to fetch, by default empty
+     */
+    Q_INVOKABLE void fetchProjectsByProjectId( const QStringList &projectIds = QStringList() );
 
     //! Syncs specified project - upload or update
     Q_INVOKABLE void syncProject( const QString &projectId );
 
     //! Stops running project upload or update
-    Q_INVOKABLE void stopProjectSync( const QString &projectId );
+    Q_INVOKABLE void stopProjectSync( const QString &projectId ) const;
 
     //! Forwards call to LocalProjectsManager to remove local project
-    Q_INVOKABLE void removeLocalProject( const QString &projectId );
+    Q_INVOKABLE void removeLocalProject( const QString &projectId ) const;
 
     //! Migrates local project to mergin
     Q_INVOKABLE void migrateProject( const QString &projectId );
@@ -155,22 +163,22 @@ class ProjectsModel : public QAbstractListModel
 
   public slots:
     // MerginAPI - project list signals
-    void onListProjectsFinished( const MerginProjectsList &merginProjects, int projectsCount, int page, QString requestId );
-    void onListProjectsByNameFinished( const MerginProjectsList &merginProjects, QString requestId );
+    void onListProjectsFinished( const MerginProjectsList &merginProjects, int projectsCount, int page, const QString &requestId );
+    void onListProjectsByNameFinished( const MerginProjectsList &merginProjects, const QString &requestId );
 
-    // Synchonization signals
-    void onProjectSyncStarted( const QString &projectFullName );
-    void onProjectSyncCancelled( const QString &projectFullName );
-    void onProjectSyncProgressChanged( const QString &projectFullName, qreal progress );
-    void onProjectSyncFinished( const QString &projectFullName, bool successfully, int newVersion );
+    // Synchronization signals
+    void onProjectSyncStarted( const QString &projectId );
+    void onProjectSyncCancelled( const QString &projectId );
+    void onProjectSyncProgressChanged( const QString &projectId, qreal progress );
+    void onProjectSyncFinished( const QString &projectId, bool successfully, int newVersion );
 
-    void onProjectDetachedFromMergin( const QString &projectFullName );
-    void onProjectAttachedToMergin( const QString &projectFullName );
+    void onProjectDetachedFromMergin( const QString &projectId );
+    void onProjectAttachedToMergin( const QString &projectId );
 
     // LocalProjectsManager signals
-    void onProjectAdded( const LocalProject &project );
-    void onAboutToRemoveProject( const LocalProject &project );
-    void onProjectDataChanged( const LocalProject &project );
+    void onProjectAdded( const LocalProject &localProject );
+    void onAboutToRemoveProject( const LocalProject &localProject );
+    void onProjectDataChanged( const LocalProject &localProject );
 
     void onAuthChanged();
 
@@ -201,7 +209,6 @@ class ProjectsModel : public QAbstractListModel
     void setModelIsLoading( bool state );
 
     QString modelTypeToFlag() const;
-    QStringList projectNames() const;
     void clearProjects();
     void loadLocalProjects();
     void initializeProjectsModel();

--- a/app/projectsmodel.h
+++ b/app/projectsmodel.h
@@ -165,6 +165,7 @@ class ProjectsModel : public QAbstractListModel
     // MerginAPI - project list signals
     void onListProjectsFinished( const MerginProjectsList &merginProjects, int projectsCount, int page, const QString &requestId );
     void onListProjectsByNameFinished( const MerginProjectsList &merginProjects, const QString &requestId );
+    void onRefetchBrokenProjectsFinished( const MerginProjectsList &merginProjects );
 
     // Synchronization signals
     void onProjectSyncStarted( const QString &projectId );
@@ -203,7 +204,7 @@ class ProjectsModel : public QAbstractListModel
     void activeProjectIdChanged( QString projectId );
 
   private:
-
+    QStringList filterBrokenProjects( const MerginProjectsList &list );
     int projectIndexFromId( const QString &projectId ) const;
 
     void setModelIsLoading( bool state );

--- a/app/projectsproxymodel.cpp
+++ b/app/projectsproxymodel.cpp
@@ -37,7 +37,7 @@ ProjectsModel *ProjectsProxyModel::projectSourceModel() const
   return mModel;
 }
 
-void ProjectsProxyModel::setActiveProjectAlwaysFirst( bool value )
+void ProjectsProxyModel::setActiveProjectAlwaysFirst( const bool value )
 {
   mActiveProjectAlwaysFirst = value;
   invalidate();
@@ -48,7 +48,7 @@ bool ProjectsProxyModel::activeProjectAlwaysFirst() const
   return mActiveProjectAlwaysFirst;
 }
 
-void ProjectsProxyModel::setSearchExpression( QString searchExpression )
+void ProjectsProxyModel::setSearchExpression( const QString &searchExpression )
 {
   if ( mSearchExpression == searchExpression )
     return;
@@ -64,7 +64,7 @@ void ProjectsProxyModel::setProjectSourceModel( ProjectsModel *sourceModel )
     return;
 
   mModel = sourceModel;
-  QObject::connect( mModel, &ProjectsModel::modelInitialized, this, &ProjectsProxyModel::initialize );
+  connect( mModel, &ProjectsModel::modelInitialized, this, &ProjectsProxyModel::initialize );
 }
 
 bool ProjectsProxyModel::lessThan( const QModelIndex &left, const QModelIndex &right ) const
@@ -73,14 +73,14 @@ bool ProjectsProxyModel::lessThan( const QModelIndex &left, const QModelIndex &r
   {
     if ( mActiveProjectAlwaysFirst )
     {
-      bool lProjectIsActive = mModel->data( left, ProjectsModel::ProjectIsActiveProject ).toBool();
-      bool rProjectIsActive = mModel->data( right, ProjectsModel::ProjectIsActiveProject ).toBool();
+      const bool lProjectIsActive = mModel->data( left, ProjectsModel::ProjectIsActiveProject ).toBool();
+      const bool rProjectIsActive = mModel->data( right, ProjectsModel::ProjectIsActiveProject ).toBool();
       if ( lProjectIsActive || rProjectIsActive )
         return lProjectIsActive;
     }
 
-    bool lProjectIsMergin = mModel->data( left, ProjectsModel::ProjectIsMergin ).toBool();
-    bool rProjectIsMergin = mModel->data( right, ProjectsModel::ProjectIsMergin ).toBool();
+    const bool lProjectIsMergin = mModel->data( left, ProjectsModel::ProjectIsMergin ).toBool();
+    const bool rProjectIsMergin = mModel->data( right, ProjectsModel::ProjectIsMergin ).toBool();
 
     /**
      * Ordering of local projects: first non-mergin projects (using folder name),
@@ -89,8 +89,8 @@ bool ProjectsProxyModel::lessThan( const QModelIndex &left, const QModelIndex &r
 
     if ( !lProjectIsMergin && !rProjectIsMergin )
     {
-      QString lProjectFullName = mModel->data( left, ProjectsModel::ProjectFullName ).toString();
-      QString rProjectFullName = mModel->data( right, ProjectsModel::ProjectFullName ).toString();
+      const QString lProjectFullName = mModel->data( left, ProjectsModel::ProjectFullName ).toString();
+      const QString rProjectFullName = mModel->data( right, ProjectsModel::ProjectFullName ).toString();
 
       return lProjectFullName.compare( rProjectFullName, Qt::CaseInsensitive ) < 0;
     }
@@ -105,10 +105,10 @@ bool ProjectsProxyModel::lessThan( const QModelIndex &left, const QModelIndex &r
   }
 
   // comparing 2 mergin projects
-  QString lNamespace = mModel->data( left, ProjectsModel::ProjectNamespace ).toString();
-  QString lProjectName = mModel->data( left, ProjectsModel::ProjectName ).toString();
-  QString rNamespace = mModel->data( right, ProjectsModel::ProjectNamespace ).toString();
-  QString rProjectName = mModel->data( right, ProjectsModel::ProjectName ).toString();
+  const QString lNamespace = mModel->data( left, ProjectsModel::ProjectNamespace ).toString();
+  const QString lProjectName = mModel->data( left, ProjectsModel::ProjectName ).toString();
+  const QString rNamespace = mModel->data( right, ProjectsModel::ProjectNamespace ).toString();
+  const QString rProjectName = mModel->data( right, ProjectsModel::ProjectName ).toString();
 
   if ( lNamespace == rNamespace )
   {

--- a/app/projectsproxymodel.h
+++ b/app/projectsproxymodel.h
@@ -10,17 +10,16 @@
 #ifndef PROJECTSPROXYMODEL_H
 #define PROJECTSPROXYMODEL_H
 
-#include <QObject>
 #include <QSortFilterProxyModel>
 
-#include "inputconfig.h"
 #include "projectsmodel.h"
 
 /**
  * \brief The ProjectsProxyModel class used as a proxy filter/sort model for the \see ProjectsModel class.
  *
- * ProjectsProxyModel is a QML type with required property of projectSourceModel. Without source model, this model does nothing (is not initialized).
- * After setting source model, this model starts sorting and allows filtering (search) from view.
+ * ProjectsProxyModel is a QML type with required property of projectSourceModel. Without source model, this model does
+ * nothing (is not initialized). After setting source model, this model starts sorting and allows filtering (search)
+ * from view.
  */
 class ProjectsProxyModel : public QSortFilterProxyModel
 {
@@ -42,7 +41,7 @@ class ProjectsProxyModel : public QSortFilterProxyModel
     bool activeProjectAlwaysFirst() const;
 
   public slots:
-    void setSearchExpression( QString searchExpression );
+    void setSearchExpression( const QString &searchExpression );
     void setProjectSourceModel( ProjectsModel *sourceModel );
 
   signals:

--- a/app/projectwizard.h
+++ b/app/projectwizard.h
@@ -10,50 +10,47 @@
 #ifndef PROJECTWIZARD_H
 #define PROJECTWIZARD_H
 
-#include <QObject>
-
-#include "inputconfig.h"
 #include "fieldsmodel.h"
 #include "qgsfieldmodel.h"
 #include "qgsvectorlayer.h"
 #include "qgsmapsettings.h"
-#include <qgssinglesymbolrenderer.h>
 
 /**
- * Controller for creating new Input project.
+ * Controller for creating new Mergin Maps project.
  */
 class ProjectWizard : public QObject
 {
     Q_OBJECT
   public:
     explicit ProjectWizard( const QString &dataDir, QObject *parent = nullptr );
-    ~ProjectWizard() = default;
+    ~ProjectWizard() override = default;
 
     /**
-     * Creates a new project in unique directory named accoridng project name.
+     * Creates a new project in unique directory named according to project name.
      * \param projectName Project's name for newly created project.
      * \param fieldsModel Fields configuration model for a new project
      */
-    Q_INVOKABLE void createProject( QString const &projectName, FieldsModel *fieldsModel );
+    Q_INVOKABLE void createProject( QString const &projectName, const FieldsModel *fieldsModel );
 
   public slots:
     //! To append "mapcanvas" property to project file required to correctly show a project.
-    void writeMapCanvasSetting( QDomDocument &doc );
+    void writeMapCanvasSetting( QDomDocument &doc ) const;
 
   signals:
     /**
-      * Emitted after a project has been craeted.
+      * Emitted after a project has been created.
      */
     void projectCreationFailed( const QString &message );
     void projectCreated( const QString &projectDir, const QString &projectName );
     void notifySuccess( const QString &message );
   private:
     QgsVectorLayer *createGpkgLayer( QString const &projectDir, QList<FieldConfiguration> const &fieldsConfig );
-    QgsFields createFields( const QList<FieldConfiguration> fieldsConfig ) const;
+    QgsFields createFields( const QList<FieldConfiguration> &fieldsConfig ) const;
     QgsSingleSymbolRenderer *surveyLayerRenderer();
-    QVariant::Type parseType( const QString &type ) const;
+
+    QMetaType::Type parseType( const QString &type ) const;
     QString widgetToType( const QString &widgetType ) const;
-    QString findWidgetTypeByFieldName( const QString name, const QList<FieldConfiguration> fieldsConfig ) const;
+    QString findWidgetTypeByFieldName( const QString &name, const QList<FieldConfiguration> &fieldsConfig ) const;
 
     QString mDataDir;
     std::unique_ptr<QgsMapSettings> mSettings = nullptr;

--- a/app/qml/main.qml
+++ b/app/qml/main.qml
@@ -907,17 +907,17 @@ ApplicationWindow {
     target: __syncManager
     enabled: stateManager.state === "map"
 
-    function onSyncStarted( projectFullName )
+    function onSyncStarted( projectId )
     {
-      if ( projectFullName === __activeProject.projectFullName() )
+      if ( projectId === __activeProject.projectId() )
       {
         syncButton.iconRotateAnimationRunning = true
       }
     }
 
-    function onSyncFinished( projectFullName, success )
+    function onSyncFinished( projectId, success )
     {
-      if ( projectFullName === __activeProject.projectFullName() )
+      if ( projectId === __activeProject.projectId() )
       {
         syncButton.iconRotateAnimationRunning = false
 
@@ -931,17 +931,17 @@ ApplicationWindow {
       }
     }
 
-    function onSyncCancelled( projectFullName )
+    function onSyncCancelled( projectId )
     {
-      if ( projectFullName === __activeProject.projectFullName() )
+      if ( projectId === __activeProject.projectId() )
       {
         syncButton.iconRotateAnimationRunning = false
       }
     }
 
-    function onSyncError( projectFullName, errorType, willRetry, errorMessage )
+    function onSyncError( projectId, errorType, willRetry, errorMessage )
     {
-      if ( projectFullName === __activeProject.projectFullName() )
+      if ( projectId === __activeProject.projectId() )
       {
         if ( errorType === MM.SyncError.NotAMerginProject )
         {
@@ -975,10 +975,10 @@ ApplicationWindow {
 
   Connections {
     target: __merginApi
-    function onNetworkErrorOccurred( message, topic, httpCode, projectFullName ) {
+    function onNetworkErrorOccurred( message, httpCode, _ ) {
       if ( stateManager.state === "projects" )
       {
-        var msg = message ? message : qsTr( "Failed to communicate with server. Try improving your network connection." )
+        const msg = message ? message : qsTr("Failed to communicate with server. Try improving your network connection.");
         __notificationModel.addError( msg )
       }
     }
@@ -1003,9 +1003,9 @@ ApplicationWindow {
       syncButton.iconRotateAnimationRunning = false
     }
 
-    function onProjectDataChanged( projectFullName ) {
+    function onProjectDataChanged( _, projectId ) {
       //! if current project has been updated, refresh canvas
-      if ( projectFullName === projectController.activeProjectId ) {
+      if ( projectId === projectController.activeProjectId ) {
         map.mapSettings.extentChanged()
       }
     }
@@ -1017,17 +1017,17 @@ ApplicationWindow {
       }
     }
 
-    function onMissingAuthorizationError( projectFullName )
+    function onMissingAuthorizationError( projectId )
     {
-      if ( projectFullName === __activeProject.projectFullName() && !__merginApi.userAuth.isUsingSso() )
+      if ( projectId === __activeProject.projectId() && !__merginApi.userAuth.isUsingSso() )
       {
         missingAuthDialog.open()
       }
     }
 
-    function onProjectAlreadyOnLatestVersion( projectFullName )
+    function onProjectAlreadyOnLatestVersion( projectId )
     {
-      if ( projectFullName === __activeProject.projectFullName() )
+      if ( projectId === __activeProject.projectId() )
       {
         __notificationModel.addSuccess( qsTr( "Up to date" ) )
       }

--- a/app/test/testmaptools.cpp
+++ b/app/test/testmaptools.cpp
@@ -352,7 +352,7 @@ void TestMapTools::testMeasuring()
 
   QVERIFY( measurementTool->recordedGeometry().wkbType() == Qgis::WkbType::Polygon );
 
-  QgsGeometry polygonGeometry = QgsGeometry::fromPolygonXY( QList<QList<QgsPointXY>> () << points );
+  QgsGeometry polygonGeometry = QgsGeometry::fromPolygonXY( QList<QList<QgsPointXY >> () << points );
   double expectedArea = distanceArea.measureArea( polygonGeometry );
   QCOMPARE( measurementTool->area(), expectedArea );
 

--- a/app/test/testmerginapi.cpp
+++ b/app/test/testmerginapi.cpp
@@ -227,12 +227,12 @@ void TestMerginApi::testDownloadProjectSpecChars()
 
   // create an empty project on the server
   QSignalSpy spy( mApi, &MerginApi::projectCreated );
-  mApi->createProject( projectNamespace, projectName, true );
+  mApi->createProject( projectNamespace, projectName, TODO, true );
   QVERIFY( spy.wait( TestUtils::SHORT_REPLY ) );
   QCOMPARE( spy.count(), 1 );
   QCOMPARE( spy.takeFirst().at( 1 ).toBool(), true );
   // make MerginApi aware of the project and its directory
-  mApi->localProjectsManager().addMerginProject( projectDir, projectNamespace, projectName );
+  mApi->localProjectsManager().addMerginProject( projectDir, projectNamespace, projectName, TODO );
 
   // Copy data
   QString sourcePath = mTestDataPath + "/" + TestMerginApi::TEST_PROJECT_NAME + "/";
@@ -274,7 +274,7 @@ void TestMerginApi::testCancelDownloadProject()
   QSignalSpy spy5( mApi, &MerginApi::syncProjectFinished );
   mApi->pullProject( mWorkspaceName, projectName );
   QCOMPARE( mApi->transactions().count(), 1 );
-  mApi->cancelPull( MerginApi::getFullProjectName( mWorkspaceName, projectName ) );
+  mApi->cancelPull( TODO );
 
   // no need to wait for the signal here - as we call abort() the reply's finished() signal is immediately emitted
   QCOMPARE( spy5.count(), 1 );
@@ -293,7 +293,7 @@ void TestMerginApi::testCancelDownloadProject()
   QCOMPARE( spy6.count(), 1 );
 
   QSignalSpy spy7( mApi, &MerginApi::syncProjectFinished );
-  mApi->cancelPull( MerginApi::getFullProjectName( mWorkspaceName, projectName ) );
+  mApi->cancelPull( TODO );
 
   // no need to wait for the signal here - as we call abort() the reply's finished() signal is immediately emitted
   QCOMPARE( spy7.count(), 1 );
@@ -318,7 +318,7 @@ void TestMerginApi::testCreateProjectTwice()
   QVERIFY( !_findProjectByName( projectNamespace, projectName, projects ).isValid() );
 
   QSignalSpy spy( mApi, &MerginApi::projectCreated );
-  mApi->createProject( projectNamespace, projectName, true );
+  mApi->createProject( projectNamespace, projectName, TODO, true );
   QVERIFY( spy.wait( TestUtils::SHORT_REPLY ) );
   QCOMPARE( spy.count(), 1 );
   QCOMPARE( spy.takeFirst().at( 1 ).toBool(), true );
@@ -331,7 +331,7 @@ void TestMerginApi::testCreateProjectTwice()
 
   // Create again, expecting error
   QSignalSpy spy2( mApi, &MerginApi::networkErrorOccurred );
-  mApi->createProject( projectNamespace, projectName, true );
+  mApi->createProject( projectNamespace, projectName, TODO, true );
   QVERIFY( spy2.wait( TestUtils::SHORT_REPLY ) );
   QCOMPARE( spy2.count(), 1 );
 
@@ -380,7 +380,7 @@ void TestMerginApi::testCreateDeleteProject()
   QVERIFY( !_findProjectByName( projectNamespace, projectName, projects ).isValid() );
 
   QSignalSpy spy( mApi, &MerginApi::projectCreated );
-  mApi->createProject( projectNamespace, projectName, true );
+  mApi->createProject( projectNamespace, projectName, TODO, true );
   QVERIFY( spy.wait( TestUtils::SHORT_REPLY ) );
   QCOMPARE( spy.count(), 1 );
   QCOMPARE( spy.takeFirst().at( 1 ).toBool(), true );
@@ -408,7 +408,7 @@ void TestMerginApi::testUploadProject()
   deleteRemoteProjectNow( mApi, projectNamespace, projectName );
 
   QSignalSpy spy0( mApiExtra, &MerginApi::projectCreated );
-  mApiExtra->createProject( projectNamespace, projectName, true );
+  mApiExtra->createProject( projectNamespace, projectName, TODO, true );
   QVERIFY( spy0.wait( TestUtils::LONG_REPLY ) );
   QCOMPARE( spy0.count(), 1 );
   QCOMPARE( spy0.takeFirst().at( 1 ).toBool(), true );
@@ -418,7 +418,7 @@ void TestMerginApi::testUploadProject()
 
   // copy project's test data to the new project directory
   QVERIFY( InputUtils::cpDir( mTestDataPath + "/" + TEST_PROJECT_NAME, projectDir ) );
-  mApi->localProjectsManager().addMerginProject( projectDir, projectNamespace, projectName );
+  mApi->localProjectsManager().addMerginProject( projectDir, projectNamespace, projectName, TODO );
 
   // project info does not have any version information yet
   Project project0 = mLocalProjectsModel->projectFromId( MerginApi::getFullProjectName( projectNamespace, projectName ) );
@@ -1593,7 +1593,7 @@ void TestMerginApi::testMigrateDetachProject()
 
   // detach project
   QString projectNamespace = mWorkspaceName;
-  mApi->detachProjectFromMergin( projectNamespace, projectName );
+  mApi->detachProjectFromMergin( projectNamespace );
   // TEST if is NOT mergin project
   QVERIFY( !QFileInfo::exists( projectDir + "/.mergin/" ) );
 }
@@ -2624,7 +2624,7 @@ void TestMerginApi::createRemoteProject( MerginApi *api, const QString &projectN
 
   // create a project
   QSignalSpy spy( api, &MerginApi::projectCreated );
-  api->createProject( projectNamespace, projectName, true );
+  api->createProject( projectNamespace, projectName, TODO, true );
   QVERIFY( spy.wait( TestUtils::SHORT_REPLY ) );
   QCOMPARE( spy.count(), 1 );
   QCOMPARE( spy.takeFirst().at( 1 ).toBool(), true );
@@ -2634,7 +2634,7 @@ void TestMerginApi::createRemoteProject( MerginApi *api, const QString &projectN
   InputUtils::cpDir( sourcePath, projectDir );
 
   // make MerginApi aware of the project and its directory
-  api->localProjectsManager().addMerginProject( projectDir, projectNamespace, projectName );
+  api->localProjectsManager().addMerginProject( projectDir, projectNamespace, projectName, TODO );
 
   // Upload data
   QSignalSpy spy3( api, &MerginApi::syncProjectFinished );
@@ -2668,7 +2668,7 @@ QString TestMerginApi::projectIdFromProjectFullName( MerginApi *api, const QStri
 
   QString projectFullName = api->getFullProjectName( projectNamespace, projectName );
 
-  QNetworkReply *r = api->getProjectInfo( projectFullName );
+  QNetworkReply *r = api->getProjectInfo( projectFullName, TODO );
   Q_ASSERT( r );
   QSignalSpy spy( r, &QNetworkReply::finished );
   spy.wait( TestUtils::SHORT_REPLY );

--- a/app/test/testmerginapi.h
+++ b/app/test/testmerginapi.h
@@ -160,7 +160,8 @@ class TestMerginApi: public QObject
     void testUploadProject();
 
     /**
-     * Test creates new project on server. Tries to upload and download bigger file (multiple chunks).
+     * Test creates new project on server. Tries to upload a file that needs to be split into multiple chunks
+     * and then also downloads it correctly again in a clean new download.
      */
     void testMultiChunkUploadDownload();
 

--- a/app/test/testmerginapi.h
+++ b/app/test/testmerginapi.h
@@ -13,19 +13,16 @@
 #include <QObject>
 #include <QSignalSpy>
 
-#include "inputconfig.h"
-#include <qgsvectorlayer.h>
-#include <merginapi.h>
-#include <projectsmodel.h>
+#include "qgsvectorlayer.h"
+#include "merginapi.h"
+#include "projectsmodel.h"
 #include "project.h"
-
-#include <qgsapplication.h>
 
 class MockReply : public QNetworkReply
 {
   public:
-    explicit MockReply( const QNetworkRequest &request, QNetworkAccessManager::Operation operation,
-                        QObject *parent = nullptr, QNetworkReply::NetworkError errorCode = QNetworkReply::NoError )
+    explicit MockReply( const QNetworkRequest &request, const QNetworkAccessManager::Operation operation,
+                        QObject *parent = nullptr, const QNetworkReply::NetworkError errorCode = QNetworkReply::NoError )
       : QNetworkReply( parent )
     {
       setRequest( request );
@@ -39,12 +36,12 @@ class MockReply : public QNetworkReply
       }
 
       QMetaObject::invokeMethod( this, "finished", Qt::QueuedConnection );
-      open( QIODevice::ReadOnly );
+      QIODevice::open( QIODevice::ReadOnly );
     }
 
     void abort() override {}
 
-    qint64 readData( char *data, qint64 maxlen ) override
+    qint64 readData( char *data, const qint64 maxlen ) override
     {
       Q_UNUSED( data );
       Q_UNUSED( maxlen );
@@ -66,14 +63,14 @@ class MockNetworkManager : public QNetworkAccessManager
       , mErrorCode( QNetworkReply::NoError )
     {}
 
-    void setShouldFail( bool shouldFail, QNetworkReply::NetworkError errorCode = QNetworkReply::NoError )
+    void setShouldFail( const bool shouldFail, const QNetworkReply::NetworkError errorCode = QNetworkReply::NoError )
     {
       mShouldFail = shouldFail;
       mErrorCode = errorCode;
     }
 
   protected:
-    QNetworkReply *createRequest( Operation op, const QNetworkRequest &request, QIODevice *outgoingData = nullptr ) override
+    QNetworkReply *createRequest( const Operation op, const QNetworkRequest &request, QIODevice *outgoingData = nullptr ) override
     {
       if ( mShouldFail )
       {
@@ -93,7 +90,7 @@ class TestMerginApi: public QObject
     Q_OBJECT
   public:
     explicit TestMerginApi( MerginApi *api );
-    ~TestMerginApi();
+    ~TestMerginApi() override;
 
     static const QString TEST_PROJECT_NAME;
     static const QString TEST_EMPTY_FILE_NAME;
@@ -104,63 +101,384 @@ class TestMerginApi: public QObject
     void initTestCase();
     void cleanupTestCase();
 
+    /**
+     * Test first deletes the test project on server if it exists and the creates a new empty project.
+     */
     void testListProject();
+
+    /**
+     * Test creates new project on server and then fetches it by \code listProjectsByName \endcode API.
+     */
     void testListProjectsByName();
+
+    /**
+     * Test creates a project on server, downloads the project from a scratch using \code pullProject \endcode API
+     * and checks the integrity of local project.
+     */
     void testDownloadProject();
+
+    /**
+     * Test creates new project on server, defines network errors and mocks them via \a MockNetworkManager.
+     */
     void testDownloadWithNetworkError();
+
+    /**
+     * Test creates new project on server and tries to download it. Two network errors are mocked from, which
+     * should the process recover.
+     */
     void testDownloadWithNetworkErrorRecovery();
+
+    /**
+     * Test creates new project on server and tries to upload and download files with special characters in name.
+     */
     void testDownloadProjectSpecChars();
+
+    /**
+     * Test creates new project on server and cancels download before API is called and then after API is called.
+     */
     void testCancelDownloadProject();
+
+    /**
+     * Test creates new project on server and then tries to create the same one again.
+     */
     void testCreateProjectTwice();
+
+    /**
+     * Test tries to delete non-existent project from server.
+     */
     void testDeleteNonExistingProject();
+
+    /**
+     * Test creates new project on server and deletes it.
+     */
     void testCreateDeleteProject();
+
+    /**
+     * Test creates new project on server and tries to upload data to server. First it gets canceled right away,
+     * secondly it gets canceled when data starts to get uploaded, thirdly it gets uploaded.
+     */
     void testUploadProject();
+
+    /**
+     * Test creates new project on server. Tries to upload and download bigger file (multiple chunks).
+     */
     void testMultiChunkUploadDownload();
+
+    /**
+     * Test creates new project on server. Tries to upload and download empty file.
+     */
     void testEmptyFileUploadDownload();
+
+    /**
+     * Test creates new project on server. Downloads it, adds a file, uploads it, deletes local copy
+     * and downloads it again.
+     */
     void testPushAddedFile();
+
+    /**
+     * Test creates new project on server. Downloads it, removes a file, uploads it, deletes local copy
+     * and downloads it again.
+     */
     void testPushRemovedFile();
+
+    /**
+     * Test creates new project on server. Downloads it, modifies a file, uploads it, deletes local copy
+     * and downloads it again.
+     */
     void testPushModifiedFile();
+
+    /**
+     * Test creates new project on server. Downloads it, uploads it back without changes.
+     */
     void testPushNoChanges();
+
+    /**
+     * Test creates new project on server. Downloads it, new file is created on server, checks the server version,
+     * downloads the newer version.
+     */
     void testUpdateAddedFile();
+
+    /**
+     * Test creates new project on server. Downloads it, file is removed on server, checks the server version,
+     * downloads the newer version.
+     */
     void testUpdateRemovedFiles();
+
+    /**
+     * Test creates new project on server. Downloads it, file is removed on server, but also modified locally,
+     * checks the server version, downloads the newer version. In the end we keep the modified version.
+     */
     void testUpdateRemovedVsModifiedFiles();
+
+    /**
+     * This test downloads a project, makes a local update of a file, in the meanwhile it does remote update of
+     * the same file to create a conflict. Finally, it tries to upload the local change to test the code
+     * responsible for conflict resolution (renames the local file).
+     */
     void testConflictRemoteUpdateLocalUpdate();
+
+    /**
+     * This test downloads a project, creates a new file in the meanwhile it creates the same file on
+     * the server to create a conflict. Finally, it tries to upload the local change to test the code
+     * responsible for conflict resolution (renames the local file).
+     */
     void testConflictRemoteAddLocalAdd();
+
+    /**
+     * This test simulates creation of edit conflict when two clients are trying to update the same attribute.
+     * Edit conflict file should be created inside project folder and synced to server
+     */
     void testEditConflictScenario();
+
+    /**
+     * This test triggers the situation when the request to upload a project first needs to do an update and
+     * only afterwards it uploads changes.
+     */
     void testUploadWithUpdate();
+
+    /**
+     * This test creates a new project on server, downloads it, afterwards makes changes to gpkg and uploads it.
+     */
     void testDiffUpload();
+
+    /**
+     * This test creates a new project on server, downloads it, afterwards makes changes to gpkg in nested
+     * subdirectory and uploads it.
+     */
     void testDiffSubdirsUpload();
+
+    /**
+     * This test creates a new project on server, downloads it. Another device downloads it too and uploads modified
+     * version of gpkg. Newer version is downloaded again.
+     */
     void testDiffUpdateBasic();
+
+    /**
+     * This test creates a new project on server, downloads it. Another device downloads it too and uploads modified
+     * version of gpkg. Newer version is downloaded again and local changes are rebased on top of the server's change.
+     */
     void testDiffUpdateWithRebase();
+
+    /**
+     * This test creates a new project on server, downloads it. Another device downloads it too and uploads modified
+     * version of gpkg. Newer version is downloaded again and local changes are rebased on top of the server's change.
+     * \note Test case where the local change is something that geodiff does not support and thus cannot rebase
+     * the changes (should create a conflict file instead).
+     */
     void testDiffUpdateWithRebaseFailed();
+
+    /**
+     * Test case where we download initial version (v1), then there will be two versions with diffs (v2 and v3),
+     * afterwards we try to update the local project.
+     */
     void testUpdateWithDiffs();
+
+    /**
+     * When updating from v3 to v4, it is expected that we will get references to diffs for v2-v3 and v3-v4.
+     * There was a bug where we always ignored the first one. But it could happen that there is no update in v2-v3,
+     * and we ended up ignoring v3-v4, ending up with broken base files.
+     *
+     * 1. [extra] create project, upload .gpkg (v1)
+     * 2. [extra] upload a new file (v2)
+     * 3. [main]  download project (v2)
+     * 4. [extra] upload updated .gpkg (v3)
+     * 5. [main]  update from v2 to v3
+     */
     void testUpdateWithMissedVersion();
+
+    /**
+     * Test creates a local project and uploads it to the server.
+     */
     void testMigrateProject();
+
+    /**
+     * When a new project is migrated to Mergin, creating base files for diffable files was omitted. Therefore,
+     * sync was not properly working resulting into having a conflict file. Test covers creating a new project,
+     * migrating it to Mergin and both sides sync.
+     *
+     * 1. [main] create project with .gpkg (v1) file
+     * 2. [main] migrate the project to mergin
+     * 3. [extra] download the project and make changes to .gpkg (v2)
+     * 4. [main] sync the project (v2), should be valid without conflicts
+     * 5. [main] make changes to .gpkg (v3) and sync
+     * 6. [extra] sync the project (v3), should be valid without conflicts
+     */
     void testMigrateProjectAndSync();
+
+    /**
+     * Test creates local project, uploads it to server and then removes from server, but keeps the local part.
+     */
     void testMigrateDetachProject();
+
+    /**
+     * Case: Clients have the following configuration: selective sync on, selective-sync-dir empty
+     * (project dir by default)
+     *
+     * Action 1: Client 1 uploads some images and Client 2 sync without downloading the images
+     *
+     * Action 2: Client 2 uploads an image and do not remove not-synced images. Client 1 syncs without downloading
+     * the image, still having own images.
+     */
     void testSelectiveSync();
+
+    /**
+     * Case: Downloading project with config.
+     *
+     * We have the following scenario:
+     * {
+     *   "input-selective-sync": true,
+     *   "input-selective-sync-dir": "photos" // having subfolder
+     * }
+     *
+     * Action 1: Client 1 creates project with mergin-config and uploads some images,
+     *           Client 2 should sync without downloading the images.
+     *
+     * Action 2: Client 2 uploads two images, one in "photos" subdirectory and second in project root.
+     *           Client 1 should sync without downloading the image in "photos" subdirectory and should still have
+     *           own images (they should not be deleted even though Client 2 did not have them when syncing)
+     */
     void testSelectiveSyncSubfolder();
+
+    /**
+     * Case: Have a project with photos without mergin config, add it when both clients are using project already to simulate
+     *       users that add mergin config to existing projects.
+     *
+     * Procedure: Create project with photos, sync it to both clients, then let Client 1 add mergin config together with several
+     *            pictures and see if the new pictures are NOT synced.
+     */
     void testSelectiveSyncAddConfigToExistingProject();
+
+    /**
+     * Case: Remove mergin-config from an existing project with photos.
+     *
+     * We will create another API client that will serve as a server mirror, it will not use selective sync,
+     * but will simulate as if someone manipulated project from browser via Mergin
+     */
     void testSelectiveSyncRemoveConfig();
+
+    /**
+     * Case: Disable selective sync in mergin-config in an existing project with photos and selective sync previously enabled.
+     *
+     * We will create another API client that will serve as a server mirror, it will not use selective sync,
+     * but will simulate as if someone manipulated project from browser via Mergin
+     */
     void testSelectiveSyncDisabledInConfig();
+
+    /**
+     * Case: Change selective sync folder in mergin-config in an existing project with photos and selective sync enabled.
+     *
+     * We will create another API client that will serve as a server mirror, it will not use selective sync,
+     * but will simulate as if someone manipulated project from browser via Mergin
+     */
     void testSelectiveSyncChangeSyncFolder();
+
+    /**
+     * Case: Test what happens when someone uploads not valid config file (not valid json)
+     *
+     * We will create another API client that will serve as a server mirror, it will not use selective sync,
+     * but will simulate as if someone manipulated project from browser via Mergin
+     */
     void testSelectiveSyncCorruptedFormat();
+
+    /**
+     * 1. instantiate sync manager
+     * 2. create remote project & download it
+     * 3. add some data
+     * 4. sync it via manager
+     * 5. check if all signals are called
+     */
     void testSynchronizationViaManager();
+
+    /**
+     * 1. copy test project to temp
+     * 2. allow autosync controller
+     * 3. load the project
+     * 4. make some changes in the project
+     * 5. make sure autosync controller triggers that data has changed
+     */
     void testAutosync();
+
+    /**
+     * 1. copy test project to temp
+     * 2. load it
+     * 3. create autosync controller
+     * 4. sign out
+     * 5. make some changes in the project
+     * 6. make sure autosync controller has correct failure state
+     * 7. sign back in
+     * \todo Will be added with incremental requests
+     */
     void testAutosyncFailure();
+
+    /**
+     * Test creates new project on server and downloads it. Then project role is changed locally and again
+     * fetched from server.
+     */
     void testUpdateProjectMetadataRole();
+
+    /**
+     * Test tries to load \a MerginConfig from file.
+     */
     void testMerginConfigFromFile();
+
+    /**
+     * Test creates \a MerginConfig with selective sync enabled. Two variants are tested, files included in sync and
+     * files not included in sync.
+     */
     void testHasLocalChangesWithSelectiveSyncEnabled();
+
+    /**
+     * Test multiple scenarios to register local changes.
+     * 1. Empty metadata and no local files, selective sync not supported
+     * 2. Metadata has files and no local files, selective sync not supported
+     * 3. Metadata files equals local files, selective sync supported
+     * 4. Local files differs from metadata, selective sync supported
+     */
     void testHasLocalProjectChanges();
+
     void testOfflineCache();
+
+    /**
+     * Test creates new user and deletes it.
+     */
     void testRegisterAndDelete();
+
+    /**
+     * Test creates new user, new workspace and tries to delete the user (expects to fail).
+     */
     void testCreateWorkspace();
+
+    // mergin functions
+
+    /**
+     * Test creates \a MerginConfig and checks if Mergin API parses it correctly.
+     */
     void testExcludeFromSync();
+
+    /**
+     * Test querying server config.
+     */
     void testServerType();
+
+    /**
+     * Test setting server type.
+     */
     void testServerUpgrade();
-    void testServerError();
+
+    /**
+     * Test parsing server errors.
+     */
+    void testServerError() const;
+
+    /**
+     * Test registration checks.
+     */
     void testRegistration();
-    void testParseVersion();
+
+    /**
+     * Test parsing version string.
+     */
+    void testParseVersion() const;
     void testApiRoot();
 
   private:
@@ -176,7 +494,7 @@ class TestMerginApi: public QObject
     MerginApi *mApiExtra = nullptr;
     LocalProjectsManager *mLocalProjectsExtra = nullptr;
 
-    MerginProjectsList getProjectList( QString tag = "created" );
+    MerginProjectsList getProjectList( const QString &tag = "created" );
     MerginProjectsList projectListFromSpy( QSignalSpy &spy );
     int serverVersionFromSpy( QSignalSpy &spy );
 
@@ -194,23 +512,23 @@ class TestMerginApi: public QObject
 
     /**
      * Immediately deletes a project on the server
-     * If project does not exists, it does nothing.
+     * If project does not exist, it does nothing.
      */
     void deleteRemoteProjectNow( MerginApi *api, const QString &projectNamespace, const QString &projectName );
 
     //! Downloads a remote project to the local drive, extended version also sets server version
-    void downloadRemoteProject( MerginApi *api, const QString &projectNamespace, const QString &projectName, int &serverVersion );
-    void downloadRemoteProject( MerginApi *api, const QString &projectNamespace, const QString &projectName );
+    void downloadRemoteProject( MerginApi *api, const QString &projectFullName, const QString &projectId, int &serverVersion );
+    void downloadRemoteProject( MerginApi *api, const QString &projectFullName, const QString &projectId );
 
     //! Uploads any local changes in the local project to the remote project, extended version also sets server version
-    void uploadRemoteProject( MerginApi *api, const QString &projectNamespace, const QString &projectName, int &serverVersion );
-    void uploadRemoteProject( MerginApi *api, const QString &projectNamespace, const QString &projectName );
+    void uploadRemoteProject( MerginApi *api, const QString &projectFullName, const QString &projectId, int &serverVersion );
+    void uploadRemoteProject( MerginApi *api, const QString &projectFullName, const QString &projectId );
 
     //! Deletes a project from the local drive
-    void deleteLocalProject( MerginApi *api, const QString &projectNamespace, const QString &projectName );
+    void deleteLocalProject( const MerginApi *api, const QString &projectId );
 
     //! Recursively deletes directory and its content.
-    void deleteLocalDir( MerginApi *api, const QString &dirPath );
+    void deleteLocalDir( const MerginApi *api, const QString &dirPath );
 
     //! Write all of "data" as the content to the given filename
     void writeFileContent( const QString &filename, const QByteArray &data );
@@ -218,7 +536,7 @@ class TestMerginApi: public QObject
     QByteArray readFileContent( const QString &filename );
 
     //! Creates local project in given project directory
-    void createLocalProject( const QString projectDir );
+    void createLocalProject( const QString &projectDir );
 
     //! Creates json file based on params in path. Returns true is successful, false otherwise
     bool createJsonFile( const QString &path, const QVariantMap &params );

--- a/app/test/testmodels.cpp
+++ b/app/test/testmodels.cpp
@@ -304,16 +304,19 @@ void TestModels::testProjectsModel()
   Project p0;
   p0.local.projectNamespace = QStringLiteral( "namespace" );
   p0.local.projectName = QStringLiteral( "project_B" );
+  p0.local.projectId = CoreUtils::uuidWithoutBraces( QUuid::createUuid() );
   p0.local.projectDir = QStringLiteral( "project_B_dir" );
 
   Project p1;
   p1.local.projectNamespace = QStringLiteral( "namespace" );
   p1.local.projectName = QStringLiteral( "project_A" );
+  p1.local.projectId = CoreUtils::uuidWithoutBraces( QUuid::createUuid() );
   p1.local.projectDir = QStringLiteral( "project_A_dir" );
 
   Project p2;
   p2.local.projectNamespace = QStringLiteral( "namespace" );
   p2.local.projectName = QStringLiteral( "project_C" );
+  p2.local.projectId = CoreUtils::uuidWithoutBraces( QUuid::createUuid() );
   p2.local.projectDir = QStringLiteral( "project_C_dir" );
 
   ProjectsModel model;

--- a/app/test/testmodels.cpp
+++ b/app/test/testmodels.cpp
@@ -15,6 +15,7 @@
 #include "valuerelationfeaturesmodel.h"
 #include "projectsmodel.h"
 #include "projectsproxymodel.h"
+#include "coreutils.h"
 
 #include <QtTest/QtTest>
 

--- a/app/test/testutils.cpp
+++ b/app/test/testutils.cpp
@@ -300,14 +300,3 @@ void TestUtils::testIsValidUrl()
   QVERIFY( !InputUtils::isValidUrl( "http://exa mple.com" ) );
   QVERIFY( !InputUtils::isValidUrl( "" ) ); // empty url is considered valid by QUrl but not by us
 }
-
-template <typename T>
-T TestUtils::findProjectByName( const QString &projectFullName, const QList<T> &projects )
-{
-  for ( T project : projects )
-  {
-    if ( project.fullName() == projectFullName )
-      return project;
-  }
-  return T();
-}

--- a/app/test/testutils.h
+++ b/app/test/testutils.h
@@ -12,7 +12,6 @@
 
 #include <QString>
 
-#include "project.h"
 #include "qgsproject.h"
 
 class MerginApi;
@@ -66,7 +65,15 @@ namespace TestUtils
    * Function returns the project with same fullname. Expected types to pass are \a MerginProject & \a LocalProject.
    */
   template <typename T>
-  T findProjectByName( const QString &projectFullName, const QList<T> &projects );
+  T findProjectByName( const QString &projectFullName, const QList<T> &projects )
+  {
+    for ( T project : projects )
+    {
+      if ( project.fullName() == projectFullName )
+        return project;
+    }
+    return T();
+  };
 }
 
 #define COMPARENEAR(actual, expected, epsilon) \

--- a/app/test/testutils.h
+++ b/app/test/testutils.h
@@ -11,17 +11,16 @@
 #define TESTUTILS_H
 
 #include <QString>
-#include <qtestcase.h>
 
-#include "inputconfig.h"
+#include "project.h"
 #include "qgsproject.h"
 
 class MerginApi;
 
 namespace TestUtils
 {
-  const int SHORT_REPLY = 5000;
-  const int LONG_REPLY = 90000;
+  constexpr int SHORT_REPLY = 5000;
+  constexpr int LONG_REPLY = 90000;
 
   //! authorize user and select the active workspace
   void authorizeUser( MerginApi *api, const QString &username, const QString &password );
@@ -38,7 +37,7 @@ namespace TestUtils
   void merginGetAuthCredentials( MerginApi *api, QString &apiRoot, QString &username, QString &password );
 
   //! Whether we need to auth again
-  bool needsToAuthorizeAgain( MerginApi *api, const QString &username );
+  bool needsToAuthorizeAgain( const MerginApi *api, const QString &username );
 
   QString generateUsername();
   QString generateEmail();
@@ -62,6 +61,12 @@ namespace TestUtils
   void testIsPositionTrackingLayer();
   void testMapLayerFromName();
   void testIsValidUrl();
+
+  /**
+   * Function returns the project with same fullname. Expected types to pass are \a MerginProject & \a LocalProject.
+   */
+  template <typename T>
+  T findProjectByName( const QString &projectFullName, const QList<T> &projects );
 }
 
 #define COMPARENEAR(actual, expected, epsilon) \

--- a/app/test/testutilsfunctions.cpp
+++ b/app/test/testutilsfunctions.cpp
@@ -823,7 +823,7 @@ void TestUtilsFunctions::testParsePositionUpdates()
   // example: "10 20 30 40\n" -> QgsPoint( x:10, y:20, z:30, m:40 )
   //
 
-  QList<std::pair<QString, QList<QgsPoint>>> testcases =
+  QList<std::pair<QString, QList<QgsPoint >>> testcases =
   {
     { QString(), QList<QgsPoint>() },
     { "", QList<QgsPoint>() },

--- a/app/variablesmanager.cpp
+++ b/app/variablesmanager.cpp
@@ -19,9 +19,9 @@ VariablesManager::VariablesManager( MerginApi *merginApi, QObject *parent )
   apiRootChanged();
   setUserVariables();
 
-  QObject::connect( mMerginApi, &MerginApi::apiRootChanged, this, &VariablesManager::apiRootChanged );
-  QObject::connect( mMerginApi, &MerginApi::userInfoChanged, this, &VariablesManager::setUserVariables );
-  QObject::connect( mMerginApi, &MerginApi::projectDataChanged, this, &VariablesManager::setVersionVariable );
+  connect( mMerginApi, &MerginApi::apiRootChanged, this, &VariablesManager::apiRootChanged );
+  connect( mMerginApi, &MerginApi::userInfoChanged, this, &VariablesManager::setUserVariables );
+  connect( mMerginApi, &MerginApi::projectDataChanged, this, &VariablesManager::setVersionVariable );
 }
 
 VariablesManager::~VariablesManager() = default;
@@ -112,8 +112,10 @@ void VariablesManager::setUserVariables()
   QgsExpressionContextUtils::setGlobalVariable( QStringLiteral( "mergin_full_name" ),  mMerginApi->userInfo()->name() );
 }
 
-void VariablesManager::setVersionVariable( const QString &projectFullName )
+void VariablesManager::setVersionVariable( const QString &projectFullName, const QString &projectId )
 {
+  Q_UNUSED( projectId );
+
   if ( !mCurrentProject )
     return;
 
@@ -191,7 +193,7 @@ void VariablesManager::setProjectVariables()
   {
     QgsExpressionContextUtils::setProjectVariable( mCurrentProject, QStringLiteral( "mergin_project_version" ), metadata.version );
     QgsExpressionContextUtils::setProjectVariable( mCurrentProject, QStringLiteral( "mergin_project_name" ),  metadata.name );
-    QgsExpressionContextUtils::setProjectVariable( mCurrentProject, QStringLiteral( "mergin_project_full_name" ),  mMerginApi->getFullProjectName( metadata.projectNamespace,  metadata.name ) );
+    QgsExpressionContextUtils::setProjectVariable( mCurrentProject, QStringLiteral( "mergin_project_full_name" ),  CoreUtils::getFullProjectName( metadata.projectNamespace,  metadata.name ) );
     QgsExpressionContextUtils::setProjectVariable( mCurrentProject, QStringLiteral( "mm_project_version" ), metadata.version );
     QgsExpressionContextUtils::setProjectVariable( mCurrentProject, QStringLiteral( "mm_project_name" ),  metadata.name );
     QgsExpressionContextUtils::setProjectVariable( mCurrentProject, QStringLiteral( "mm_project_full_name" ),  mMerginApi->getFullProjectName( metadata.projectNamespace,  metadata.name ) );

--- a/app/variablesmanager.cpp
+++ b/app/variablesmanager.cpp
@@ -9,6 +9,7 @@
 
 #include "variablesmanager.h"
 
+#include "coreutils.h"
 #include "qgsexpressioncontextutils.h"
 #include "inputexpressionfunctions.h"
 

--- a/app/variablesmanager.cpp
+++ b/app/variablesmanager.cpp
@@ -196,7 +196,7 @@ void VariablesManager::setProjectVariables()
     QgsExpressionContextUtils::setProjectVariable( mCurrentProject, QStringLiteral( "mergin_project_full_name" ),  CoreUtils::getFullProjectName( metadata.projectNamespace,  metadata.name ) );
     QgsExpressionContextUtils::setProjectVariable( mCurrentProject, QStringLiteral( "mm_project_version" ), metadata.version );
     QgsExpressionContextUtils::setProjectVariable( mCurrentProject, QStringLiteral( "mm_project_name" ),  metadata.name );
-    QgsExpressionContextUtils::setProjectVariable( mCurrentProject, QStringLiteral( "mm_project_full_name" ),  mMerginApi->getFullProjectName( metadata.projectNamespace,  metadata.name ) );
+    QgsExpressionContextUtils::setProjectVariable( mCurrentProject, QStringLiteral( "mm_project_full_name" ),  CoreUtils::getFullProjectName( metadata.projectNamespace,  metadata.name ) );
   }
   else
   {

--- a/app/variablesmanager.h
+++ b/app/variablesmanager.h
@@ -65,7 +65,7 @@ class VariablesManager : public QObject
   private slots:
     void apiRootChanged();
     void setUserVariables();
-    void setVersionVariable( const QString &projectFullName );
+    void setVersionVariable( const QString &projectFullName, const QString &projectId );
 
   private:
     MerginApi *mMerginApi = nullptr;

--- a/core/coreutils.cpp
+++ b/core/coreutils.cpp
@@ -130,8 +130,8 @@ void CoreUtils::log( const QString &topic, const QString &info )
   QString logFilePath;
   QByteArray data;
   data.append(
-    QString( "%1 %2: %3\n" ).arg( QDateTime().currentDateTimeUtc().toString( Qt::ISODateWithMs ) ).arg( topic )
-    .arg( info ).toUtf8() );
+        QString( "%1 %2: %3\n" ).arg( QDateTime().currentDateTimeUtc().toString( Qt::ISODateWithMs ) ).arg( topic )
+        .arg( info ).toUtf8() );
   appendLog( data, sLogFile );
 }
 

--- a/core/coreutils.h
+++ b/core/coreutils.h
@@ -14,8 +14,6 @@
 #define STR(x)  STR1(x)
 
 #include <QObject>
-#include <QtGlobal>
-#include <QUuid>
 
 
 class CoreUtils
@@ -28,12 +26,11 @@ class CoreUtils
     static QString appVersion();
     static QString appVersionCode();
 
-    static QString localizedDateFromUTFString( QString timestamp );
+    static QString localizedDateFromUTFString( const QString &timestamp );
     static bool removeDir( const QString &projectDir );
 
     /**
      * Returns name of temporary file indicating first time download of project is in progress
-     * \param projectName
      */
     static QString downloadInProgressFilePath( const QString &projectDir );
 
@@ -86,10 +83,10 @@ class CoreUtils
     static void log( const QString &topic, const QString &info );
 
     //! Checks whether file path has a QGIS project suffix (qgs or qgz)
-    static bool hasProjectFileExtension( const QString filePath );
+    static bool hasProjectFileExtension( const QString &filePath );
 
     /**
-     * Check whether given project/user name is valid
+     * Check whether given project/username is valid
      */
     static bool isValidName( const QString &name );
 
@@ -121,19 +118,33 @@ class CoreUtils
     static QString getTotalDeviceStorage();
 
     /**
-     * Converts bytes to human readable size (e.g. 1GB, 500MB)
+     * Converts bytes to human-readable size (e.g. 1GB, 500MB)
      */
     static QString bytesToHumanSize( double bytes );
 
     /**
      * Returns path to project metadata file for a given project directory
      */
-    static QString getProjectMetadataPath( QString projectDir );
+    static QString getProjectMetadataPath( const QString &projectDir );
 
     /**
      * Updates a value in a JSON file at the specified top-level key
      */
     static bool replaceValueInJson( const QString &filePath, const QString &key, const QJsonValue &value );
+
+    /**
+     * Creates the full project name, which essentially means joining \a projectNamespace and \a projectName with "/"
+     */
+    static QString getFullProjectName( const QString &projectNamespace, const QString &projectName );
+
+    /**
+    * Sets projectNamespace and projectName from sourceString - url or any string from which takes last (name)
+    * and the previous of last (namespace) substring after splitting sourceString with slash.
+    * \param sourceString QString either url or fullname of a project
+    * \param projectNamespace QString to be set as namespace, might not change original value
+    * \param projectName QString to be set to name of a project
+    */
+    static bool extractProjectName( const QString &sourceString, QString &projectNamespace, QString &projectName );
 
     /**
      * We do some very basic checks if the string looks like email.

--- a/core/localprojectsmanager.cpp
+++ b/core/localprojectsmanager.cpp
@@ -83,21 +83,6 @@ LocalProject LocalProjectsManager::projectFromProjectId( const QString &projectI
   return {};
 }
 
-LocalProject LocalProjectsManager::projectFromMerginName( const QString &projectFullName ) const
-{
-  for ( const LocalProject &info : mProjects.values() )
-  {
-    if ( info.fullName() == projectFullName )
-      return info;
-  }
-  return {};
-}
-
-LocalProject LocalProjectsManager::projectFromMerginName( const QString &projectNamespace, const QString &projectName ) const
-{
-  return projectFromMerginName( CoreUtils::getFullProjectName( projectNamespace, projectName ) );
-}
-
 void LocalProjectsManager::addLocalProject( const QString &projectDir, const QString &projectName )
 {
   addProject( projectDir, QString(), projectName, LocalProject::generateProjectId() );

--- a/core/localprojectsmanager.cpp
+++ b/core/localprojectsmanager.cpp
@@ -157,9 +157,8 @@ void LocalProjectsManager::updateLocalVersion( const QString &projectId, const i
 {
   if ( mProjects.contains( projectId ) )
   {
-    LocalProject project = mProjects.value( projectId );
-    project.localVersion = version;
-    emit localProjectDataChanged( project );
+    mProjects[ projectId ].localVersion = version;
+    emit localProjectDataChanged( mProjects.value( projectId ) );
   }
 }
 
@@ -167,9 +166,8 @@ void LocalProjectsManager::updateNamespace( const QString &projectId, const QStr
 {
   if ( mProjects.contains( projectId ) )
   {
-    LocalProject project = mProjects.value( projectId );
-    project.projectNamespace = projectNamespace;
-    emit localProjectDataChanged( project );
+    mProjects[ projectId ].projectNamespace = projectNamespace;
+    emit localProjectDataChanged( mProjects.value( projectId ) );
   }
 }
 

--- a/core/localprojectsmanager.cpp
+++ b/core/localprojectsmanager.cpp
@@ -38,98 +38,95 @@ void LocalProjectsManager::reloadDataDir()
       info.projectName = metadata.name;
       info.projectNamespace = metadata.projectNamespace;
       info.localVersion = metadata.version;
+      info.projectId = metadata.projectId;
     }
     else
     {
       info.projectName = folderName;
+      info.projectId = LocalProject::generateProjectId();
     }
 
-    mProjects << info;
+    mProjects.insert( info.projectId, info );
   }
 
-  QString msg = QString( "Found %1 local projects in %2" ).arg( mProjects.size() ).arg( mDataDir );
+  const QString msg = QString( "Found %1 local projects in %2" ).arg( mProjects.size() ).arg( mDataDir );
   CoreUtils::log( "Local projects", msg );
   emit dataDirReloaded();
 }
 
 LocalProject LocalProjectsManager::projectFromDirectory( const QString &projectDir ) const
 {
-  for ( const LocalProject &info : mProjects )
+  for ( const LocalProject &info : mProjects.values() )
   {
     if ( info.projectDir == projectDir )
       return info;
   }
-  return LocalProject();
+  return {};
 }
 
 LocalProject LocalProjectsManager::projectFromProjectFilePath( const QString &projectFilePath ) const
 {
-  for ( const LocalProject &info : mProjects )
+  for ( const LocalProject &info : mProjects.values() )
   {
     if ( info.qgisProjectFilePath == projectFilePath )
       return info;
   }
-  return LocalProject();
+  return {};
 }
 
 LocalProject LocalProjectsManager::projectFromProjectId( const QString &projectId ) const
 {
-  for ( const LocalProject &info : mProjects )
+  if ( mProjects.contains( projectId ) )
   {
-    if ( info.id() == projectId )
-      return info;
+    return mProjects.value( projectId );
   }
-  return LocalProject();
+  return {};
 }
 
 LocalProject LocalProjectsManager::projectFromMerginName( const QString &projectFullName ) const
 {
-  for ( const LocalProject &info : mProjects )
+  for ( const LocalProject &info : mProjects.values() )
   {
-    if ( info.id() == projectFullName )
+    if ( info.fullName() == projectFullName )
       return info;
   }
-  return LocalProject();
+  return {};
 }
 
 LocalProject LocalProjectsManager::projectFromMerginName( const QString &projectNamespace, const QString &projectName ) const
 {
-  return projectFromMerginName( MerginApi::getFullProjectName( projectNamespace, projectName ) );
+  return projectFromMerginName( CoreUtils::getFullProjectName( projectNamespace, projectName ) );
 }
 
 void LocalProjectsManager::addLocalProject( const QString &projectDir, const QString &projectName )
 {
-  addProject( projectDir, QString(), projectName );
+  addProject( projectDir, QString(), projectName, LocalProject::generateProjectId() );
 }
 
-void LocalProjectsManager::addMerginProject( const QString &projectDir, const QString &projectNamespace, const QString &projectName )
+void LocalProjectsManager::addMerginProject( const QString &projectDir, const QString &projectNamespace, const QString &projectName, const QString &projectId )
 {
-  addProject( projectDir, projectNamespace, projectName );
+  addProject( projectDir, projectNamespace, projectName, projectId );
 }
 
 void LocalProjectsManager::removeLocalProject( const QString &projectId )
 {
-  for ( int i = 0; i < mProjects.count(); ++i )
+  if ( mProjects.contains( projectId ) )
   {
-    if ( mProjects[i].id() == projectId )
-    {
-      emit aboutToRemoveLocalProject( mProjects[i] );
+    const LocalProject project = mProjects.value( projectId );
+    emit aboutToRemoveLocalProject( project );
 
-      CoreUtils::removeDir( mProjects[i].projectDir );
-      mProjects.removeAt( i );
-
-      return;
-    }
+    CoreUtils::removeDir( project.projectDir );
+    mProjects.remove( projectId );
   }
 }
 
 bool LocalProjectsManager::projectIsValid( const QString &path ) const
 {
-  for ( int i = 0; i < mProjects.count(); ++i )
+  for ( LocalProject &project : mProjects.values() )
   {
-    if ( mProjects[i].qgisProjectFilePath == path )
+    if ( project.qgisProjectFilePath == path )
     {
-      return mProjects[i].projectError.isEmpty();
+      return project.projectError.isEmpty();
     }
   }
   return false;
@@ -137,66 +134,57 @@ bool LocalProjectsManager::projectIsValid( const QString &path ) const
 
 QString LocalProjectsManager::projectId( const QString &path ) const
 {
-  for ( int i = 0; i < mProjects.count(); ++i )
+  for ( LocalProject &project : mProjects.values() )
   {
-    if ( mProjects[i].qgisProjectFilePath == path )
+    if ( project.qgisProjectFilePath == path )
     {
-      return mProjects[i].id();
+      return project.id();
     }
   }
-  return QString();
+  return {};
 }
 
 QString LocalProjectsManager::projectName( const QString &projectId ) const
 {
-  LocalProject project = projectFromProjectId( projectId );
+  const LocalProject project = projectFromProjectId( projectId );
 
   if ( project.isValid() )
   {
-    return MerginApi::getFullProjectName( project.projectNamespace, project.projectName );
+    return CoreUtils::getFullProjectName( project.projectNamespace, project.projectName );
   }
 
-  return QString();
+  return {};
 }
 
-QString LocalProjectsManager::projectChanges( const QString &projectId )
+QString LocalProjectsManager::projectChanges( const QString &projectId ) const
 {
-  LocalProject project = projectFromProjectId( projectId );
+  const LocalProject project = projectFromProjectId( projectId );
 
   if ( project.isValid() )
   {
     return MerginApi::localProjectChanges( project.projectDir ).dump();
   }
 
-  return QString();
+  return {};
 }
 
-void LocalProjectsManager::updateLocalVersion( const QString &projectDir, int version )
+void LocalProjectsManager::updateLocalVersion( const QString &projectId, const int version )
 {
-  for ( int i = 0; i < mProjects.count(); ++i )
+  if ( mProjects.contains( projectId ) )
   {
-    if ( mProjects[i].projectDir == projectDir )
-    {
-      mProjects[i].localVersion = version;
-
-      emit localProjectDataChanged( mProjects[i] );
-      return;
-    }
+    LocalProject project = mProjects.value( projectId );
+    project.localVersion = version;
+    emit localProjectDataChanged( project );
   }
-  Q_ASSERT( false );  // should not happen
 }
 
-void LocalProjectsManager::updateNamespace( const QString &projectDir, const QString &projectNamespace )
+void LocalProjectsManager::updateNamespace( const QString &projectId, const QString &projectNamespace )
 {
-  for ( int i = 0; i < mProjects.count(); ++i )
+  if ( mProjects.contains( projectId ) )
   {
-    if ( mProjects[i].projectDir == projectDir )
-    {
-      mProjects[i].projectNamespace = projectNamespace;
-
-      emit localProjectDataChanged( mProjects[i] );
-      return;
-    }
+    LocalProject project = mProjects.value( projectId );
+    project.projectNamespace = projectNamespace;
+    emit localProjectDataChanged( project );
   }
 }
 
@@ -208,7 +196,7 @@ QString LocalProjectsManager::findQgisProjectFile( const QString &projectDir, QS
     // download failed or copying from .temp to project dir failed (app was probably closed meanwhile)
 
     err = tr( "Download failed, remove and retry" );
-    return QString();
+    return {};
   }
 
   QList<QString> foundProjectFiles;
@@ -235,17 +223,33 @@ QString LocalProjectsManager::findQgisProjectFile( const QString &projectDir, QS
     err = tr( "Failed to find a QGIS project file" );
   }
 
-  return QString();
+  return {};
 }
 
-void LocalProjectsManager::addProject( const QString &projectDir, const QString &projectNamespace, const QString &projectName )
+void LocalProjectsManager::updateProjectId( const QString &oldProjectId, const QString &newProjectId )
+{
+  if ( mProjects.contains( oldProjectId ) )
+  {
+    // updating values just in LocalProjectsManager is not enough we also update ProjectsModel and ActiveProject
+    LocalProject project = mProjects.value( oldProjectId );
+    emit aboutToRemoveLocalProject( project );
+    mProjects.remove( oldProjectId );
+    project.projectId = newProjectId;
+    mProjects.insert( newProjectId, project );
+    emit localProjectAdded( project );
+    emit localProjectDataChanged( project );
+  }
+}
+
+void LocalProjectsManager::addProject( const QString &projectDir, const QString &projectNamespace, const QString &projectName, const QString &projectId )
 {
   LocalProject project;
   project.projectDir = projectDir;
   project.qgisProjectFilePath = findQgisProjectFile( projectDir, project.projectError );
   project.projectName = projectName;
   project.projectNamespace = projectNamespace;
+  project.projectId = projectId;
 
-  mProjects << project;
+  mProjects.insert( projectId, project );
   emit localProjectAdded( project );
 }

--- a/core/localprojectsmanager.h
+++ b/core/localprojectsmanager.h
@@ -34,9 +34,6 @@ class LocalProjectsManager : public QObject
     LocalProject projectFromProjectFilePath( const QString &projectFilePath ) const;
     LocalProject projectFromProjectId( const QString &projectId ) const;
 
-    LocalProject projectFromMerginName( const QString &projectFullName ) const;
-    LocalProject projectFromMerginName( const QString &projectNamespace, const QString &projectName ) const;
-
     //! Adds entry about newly created project
     void addLocalProject( const QString &projectDir, const QString &projectName );
 

--- a/core/localprojectsmanager.h
+++ b/core/localprojectsmanager.h
@@ -10,7 +10,6 @@
 #ifndef LOCALPROJECTSMANAGER_H
 #define LOCALPROJECTSMANAGER_H
 
-#include <QObject>
 #include "project.h"
 
 /**
@@ -29,7 +28,7 @@ class LocalProjectsManager : public QObject
 
     QString dataDir() const { return mDataDir; }
 
-    LocalProjectsList projects() const { return mProjects; }
+    LocalProjectsDict projects() const { return mProjects; }
 
     LocalProject projectFromDirectory( const QString &projectDir ) const;
     LocalProject projectFromProjectFilePath( const QString &projectFilePath ) const;
@@ -42,7 +41,7 @@ class LocalProjectsManager : public QObject
     void addLocalProject( const QString &projectDir, const QString &projectName );
 
     //! Adds entry for downloaded project
-    void addMerginProject( const QString &projectDir, const QString &projectNamespace, const QString &projectName );
+    void addMerginProject( const QString &projectDir, const QString &projectNamespace, const QString &projectName, const QString &projectId );
 
     //! Should forget about that project (it has been removed already)
     Q_INVOKABLE void removeLocalProject( const QString &projectId );
@@ -57,16 +56,19 @@ class LocalProjectsManager : public QObject
      * Returns changes of a project specified by projectId in the form :
      * (pending changes, features in layer survey: 10 addition, 3 updates, 1 deletion. 10 new files)
      */
-    Q_INVOKABLE QString projectChanges( const QString &projectId );
+    Q_INVOKABLE QString projectChanges( const QString &projectId ) const;
 
     //! after successful update/upload - both server and local version are the same
-    void updateLocalVersion( const QString &projectDir, int version );
+    void updateLocalVersion( const QString &projectId, int version );
 
     //! Updates project's namespace
-    void updateNamespace( const QString &projectDir, const QString &projectNamespace );
+    void updateNamespace( const QString &projectId, const QString &projectNamespace );
 
-    //! Finds all QGIS project files and set the err variable if any occured.
+    //! Finds all QGIS project files and set the err variable if any occurred.
     QString findQgisProjectFile( const QString &projectDir, QString &err );
+
+    //! Updates project's ID
+    void updateProjectId( const QString &oldProjectId, const QString &newProjectId );
 
   signals:
     void localProjectAdded( const LocalProject &project );
@@ -76,10 +78,10 @@ class LocalProjectsManager : public QObject
     void dataDirReloaded();
 
   private:
-    void addProject( const QString &projectDir, const QString &projectNamespace, const QString &projectName );
+    void addProject( const QString &projectDir, const QString &projectNamespace, const QString &projectName, const QString &projectId );
 
     QString mDataDir;   //!< directory with all local projects
-    LocalProjectsList mProjects;
+    LocalProjectsDict mProjects;
 };
 
 

--- a/core/merginapi.cpp
+++ b/core/merginapi.cpp
@@ -9,7 +9,6 @@
 
 #include "merginapi.h"
 
-#include <QtNetwork>
 #include <QJsonDocument>
 #include <QJsonObject>
 #include <QJsonArray>
@@ -34,6 +33,7 @@
 #include "merginerrortypes.h"
 
 #include <geodiff.h>
+#include <qurlquery.h>
 
 const QString MerginApi::sMetadataFile = QStringLiteral( "/.mergin/mergin.json" );
 const QString MerginApi::sMetadataFolder = QStringLiteral( ".mergin" );
@@ -61,10 +61,9 @@ MerginApi::MerginApi( LocalProjectsManager &localProjects, QObject *parent )
   , mWorkspaceInfo( new MerginWorkspaceInfo )
   , mSubscriptionInfo( new MerginSubscriptionInfo )
   , mUserAuth( new MerginUserAuth )
-  , mManager( new QNetworkAccessManager( this ) )
 {
   // load cached data if there are any
-  QSettings cache;
+  const QSettings cache;
   if ( cache.contains( QStringLiteral( "Input/apiRoot" ) ) )
   {
     loadCache();
@@ -77,12 +76,12 @@ MerginApi::MerginApi( LocalProjectsManager &localProjects, QObject *parent )
 
   qRegisterMetaType<Transactions>();
 
-  QObject::connect( this, &MerginApi::authChanged, this, &MerginApi::saveAuthData );
-  QObject::connect( this, &MerginApi::apiRootChanged, this, &MerginApi::pingMergin );
-  QObject::connect( this, &MerginApi::apiRootChanged, this, &MerginApi::getServerConfig );
-  QObject::connect( this, &MerginApi::pingMerginFinished, this, &MerginApi::checkMerginVersion );
-  QObject::connect( this, &MerginApi::workspaceCreated, this, &MerginApi::getUserInfo );
-  QObject::connect( this, &MerginApi::serverTypeChanged, this, [this]()
+  connect( this, &MerginApi::authChanged, this, &MerginApi::saveAuthData );
+  connect( this, &MerginApi::apiRootChanged, this, &MerginApi::pingMergin );
+  connect( this, &MerginApi::apiRootChanged, this, &MerginApi::getServerConfig );
+  connect( this, &MerginApi::pingMerginFinished, this, &MerginApi::checkMerginVersion );
+  connect( this, &MerginApi::workspaceCreated, this, &MerginApi::getUserInfo );
+  connect( this, &MerginApi::serverTypeChanged, this, [this]
   {
     if ( mUserAuth->hasAuthData() )
     {
@@ -90,16 +89,16 @@ MerginApi::MerginApi( LocalProjectsManager &localProjects, QObject *parent )
       getUserInfo();
     }
   } );
-  QObject::connect( this, &MerginApi::processInvitationFinished, this, &MerginApi::getUserInfo );
-  QObject::connect( this, &MerginApi::getWorkspaceInfoFinished, this, &MerginApi::getServiceInfo );
-  QObject::connect( mUserInfo, &MerginUserInfo::userInfoChanged, this, &MerginApi::userInfoChanged );
-  QObject::connect( mUserInfo, &MerginUserInfo::activeWorkspaceChanged, this, &MerginApi::activeWorkspaceChanged );
-  QObject::connect( mUserInfo, &MerginUserInfo::activeWorkspaceChanged, this, &MerginApi::getWorkspaceInfo );
-  QObject::connect( mUserInfo, &MerginUserInfo::hasWorkspacesChanged, this, &MerginApi::hasWorkspacesChanged );
-  QObject::connect( mSubscriptionInfo, &MerginSubscriptionInfo::subscriptionInfoChanged, this, &MerginApi::subscriptionInfoChanged );
-  QObject::connect( mSubscriptionInfo, &MerginSubscriptionInfo::planProductIdChanged, this, &MerginApi::onPlanProductIdChanged );
-  QObject::connect( mUserAuth, &MerginUserAuth::authChanged, this, &MerginApi::authChanged );
-  QObject::connect( mUserAuth, &MerginUserAuth::authChanged, this, [this]()
+  connect( this, &MerginApi::processInvitationFinished, this, &MerginApi::getUserInfo );
+  connect( this, &MerginApi::getWorkspaceInfoFinished, this, &MerginApi::getServiceInfo );
+  connect( mUserInfo, &MerginUserInfo::userInfoChanged, this, &MerginApi::userInfoChanged );
+  connect( mUserInfo, &MerginUserInfo::activeWorkspaceChanged, this, &MerginApi::activeWorkspaceChanged );
+  connect( mUserInfo, &MerginUserInfo::activeWorkspaceChanged, this, &MerginApi::getWorkspaceInfo );
+  connect( mUserInfo, &MerginUserInfo::hasWorkspacesChanged, this, &MerginApi::hasWorkspacesChanged );
+  connect( mSubscriptionInfo, &MerginSubscriptionInfo::subscriptionInfoChanged, this, &MerginApi::subscriptionInfoChanged );
+  connect( mSubscriptionInfo, &MerginSubscriptionInfo::planProductIdChanged, this, &MerginApi::onPlanProductIdChanged );
+  connect( mUserAuth, &MerginUserAuth::authChanged, this, &MerginApi::authChanged );
+  connect( mUserAuth, &MerginUserAuth::authChanged, this, [this]
   {
     if ( mUserAuth->hasValidToken() )
     {
@@ -120,14 +119,14 @@ MerginApi::MerginApi( LocalProjectsManager &localProjects, QObject *parent )
 
   if ( mUserAuth->hasAuthData() )
   {
-    QObject::connect( this, &MerginApi::pingMerginFinished, this, &MerginApi::getUserInfo, Qt::SingleShotConnection );
-    QObject::connect( this, &MerginApi::userInfoReplyFinished, this, &MerginApi::getWorkspaceInfo, Qt::SingleShotConnection );
+    connect( this, &MerginApi::pingMerginFinished, this, &MerginApi::getUserInfo, Qt::SingleShotConnection );
+    connect( this, &MerginApi::userInfoReplyFinished, this, &MerginApi::getWorkspaceInfo, Qt::SingleShotConnection );
   }
 }
 
 void MerginApi::loadCache()
 {
-  QSettings settings;
+  const QSettings settings;
   setApiRoot( settings.value( QStringLiteral( "Input/apiRoot" ) ).toString() );
   int serverType = settings.value( QStringLiteral( "Input/serverType" ) ).toInt();
 
@@ -159,7 +158,7 @@ MerginSubscriptionInfo *MerginApi::subscriptionInfo() const
 
 QString MerginApi::listProjects( const QString &searchExpression, const QString &flag, const int page )
 {
-  bool authorize = flag != "public";
+  const bool authorize = flag != "public";
 
   if ( ( authorize && !validateAuth() ) || mApiVersionStatus != MerginApiStatus::OK )
   {
@@ -206,13 +205,13 @@ QString MerginApi::listProjects( const QString &searchExpression, const QString 
   QUrl url( mApiRoot + QStringLiteral( "/v1/project/paginated" ) );
   url.setQuery( query );
 
-  // Even if the authorization is not required, it can be include to fetch more results
+  // Even if the authorization is not required, it can be included to fetch more results
   QNetworkRequest request = getDefaultRequest( mUserAuth->hasAuthData() );
   request.setUrl( url );
 
   QString requestId = CoreUtils::uuidWithoutBraces( QUuid::createUuid() );
 
-  QNetworkReply *reply = mManager->get( request );
+  const QNetworkReply *reply = mManager->get( request );
   CoreUtils::log( "list projects", QStringLiteral( "Requesting: " ) + url.toString() );
   connect( reply, &QNetworkReply::finished, this, [this, requestId]() {this->listProjectsReplyFinished( requestId );} );
 
@@ -227,17 +226,16 @@ QString MerginApi::listProjectsByName( const QStringList &projectNames )
     return QLatin1String();
   }
 
-  const int listProjectsByNameApiLimit = 50;
+  constexpr int maxProjectRequests = 50;
   QStringList projectNamesToRequest( projectNames );
 
-  if ( projectNamesToRequest.count() > listProjectsByNameApiLimit )
+  if ( projectNamesToRequest.count() > maxProjectRequests )
   {
-    CoreUtils::log( "list projects by name", QStringLiteral( "Too many local projects: " ) + QString::number( projectNames.count(), 'f', 0 ) );
-    const int projectsToRemoveCount = projectNames.count() - listProjectsByNameApiLimit;
-    QString msg = tr( "Please remove some projects as the app currently\nonly allows up to %1 downloaded projects." ).arg( listProjectsByNameApiLimit );
+    CoreUtils::log( "list projects by name", QStringLiteral( "Too many local projects: " ) + QString::number( static_cast<int>( projectNames.count() ), 'f', 0 ) );
+    const QString msg = tr( "Please remove some projects as the app currently\nonly allows up to %1 downloaded projects." ).arg( maxProjectRequests );
     notifyInfo( msg );
-    projectNamesToRequest.erase( projectNamesToRequest.begin() + listProjectsByNameApiLimit, projectNamesToRequest.end() );
-    Q_ASSERT( projectNamesToRequest.count() == listProjectsByNameApiLimit );
+    projectNamesToRequest.erase( projectNamesToRequest.begin() + maxProjectRequests, projectNamesToRequest.end() );
+    Q_ASSERT( projectNamesToRequest.count() == maxProjectRequests );
   }
 
   // Authentification is optional in this case, as there might be public projects without the need to be logged in.
@@ -248,31 +246,32 @@ QString MerginApi::listProjectsByName( const QStringList &projectNames )
   // construct JSON body
   QJsonDocument body;
   QJsonObject projects;
-  QJsonArray projectsArr = QJsonArray::fromStringList( projectNamesToRequest );
+  const QJsonArray projectsArr = QJsonArray::fromStringList( projectNamesToRequest );
 
   projects.insert( "projects", projectsArr );
   body.setObject( projects );
 
-  QUrl url( mApiRoot + QStringLiteral( "/v1/project/by_names" ) );
+  const QUrl url( mApiRoot + QStringLiteral( "/v1/project/by_names" ) );
 
   QNetworkRequest request = getDefaultRequest( true );
   request.setUrl( url );
-  request.setRawHeader( "Content-type", "application/json" );
 
   QString requestId = CoreUtils::uuidWithoutBraces( QUuid::createUuid() );
 
-  QNetworkReply *reply = mManager->post( request, body.toJson() );
+  const QNetworkReply *reply = mManager->get( request );
   CoreUtils::log( "list projects by name", QStringLiteral( "Requesting: " ) + url.toString() );
-  connect( reply, &QNetworkReply::finished, this, [this, requestId]() {this->listProjectsByNameReplyFinished( requestId );} );
+  connect( reply, &QNetworkReply::finished, this, [this, requestId] {this->listProjectsByNameReplyFinished( requestId );} );
 
   return requestId;
 }
 
 
-void MerginApi::downloadNextItem( const QString &projectFullName )
+void MerginApi::downloadNextItem( const QString &projectId )
 {
-  Q_ASSERT( mTransactionalStatus.contains( projectFullName ) );
-  TransactionStatus &transaction = mTransactionalStatus[projectFullName];
+  Q_ASSERT( mTransactionalStatus.contains( projectId ) );
+  TransactionStatus &transaction = mTransactionalStatus[projectId];
+  const MerginProjectMetadata project = MerginProjectMetadata::fromJson( transaction.projectMetadata );
+  const QString projectFullName = CoreUtils::getFullProjectName( project.projectNamespace, project.name );
 
   Q_ASSERT( !transaction.downloadQueue.isEmpty() );
 
@@ -280,7 +279,7 @@ void MerginApi::downloadNextItem( const QString &projectFullName )
 
   QUrl url( mApiRoot + QStringLiteral( "/v1/project/raw/" ) + projectFullName );
   QUrlQuery query;
-  // Handles special chars in a filePath (e.g prevents to convert "+" sign into a space)
+  // Handles special chars in a filePath (e.g. prevents to convert "+" sign in to a space)
   query.addQueryItem( "file", item.filePath.toUtf8().toPercentEncoding() );
   query.addQueryItem( "version", QStringLiteral( "v%1" ).arg( item.version ) );
   if ( item.downloadDiff )
@@ -289,8 +288,8 @@ void MerginApi::downloadNextItem( const QString &projectFullName )
 
   QNetworkRequest request = getDefaultRequest();
   request.setUrl( url );
-  request.setAttribute( static_cast<QNetworkRequest::Attribute>( AttrProjectFullName ), projectFullName );
   request.setAttribute( static_cast<QNetworkRequest::Attribute>( AttrTempFileName ), item.tempFileName );
+  request.setAttribute( static_cast<QNetworkRequest::Attribute>( AttrProjectId ), projectId );
 
   QString range;
   if ( item.rangeFrom != -1 && item.rangeTo != -1 )
@@ -300,7 +299,7 @@ void MerginApi::downloadNextItem( const QString &projectFullName )
   }
 
   QNetworkReply *reply = mManager->get( request );
-  connect( reply, &QNetworkReply::finished, this, [this, item]() { downloadItemReplyFinished( item ); } );
+  connect( reply, &QNetworkReply::finished, this, [this, item] { downloadItemReplyFinished( item ); } );
 
   transaction.replyPullItems.insert( reply );
 
@@ -308,21 +307,21 @@ void MerginApi::downloadNextItem( const QString &projectFullName )
                   ( !range.isEmpty() ? " Range: " + range : QString() ) );
 }
 
-void MerginApi::removeProjectsTempFolder( const QString &projectNamespace, const QString &projectName )
+void MerginApi::removeProjectsTempFolder( const QString &projectNamespace, const QString &projectName ) const
 {
   if ( projectNamespace.isEmpty() || projectName.isEmpty() )
-    return; // otherwise we could remove enitre users temp or entire .temp
+    return; // otherwise we could remove entire users temp or entire .temp
 
-  QString path = getTempProjectDir( getFullProjectName( projectNamespace, projectName ) );
+  const QString path = getTempProjectDir( CoreUtils::getFullProjectName( projectNamespace, projectName ) );
   QDir( path ).removeRecursively();
 }
 
-QNetworkRequest MerginApi::getDefaultRequest( bool withAuth )
+QNetworkRequest MerginApi::getDefaultRequest( const bool withAuth ) const
 {
   QNetworkRequest request;
-  QString info = CoreUtils::appInfo();
+  const QString info = CoreUtils::appInfo();
   request.setRawHeader( "User-Agent", QByteArray( info.toUtf8() ) );
-  QString deviceId = CoreUtils::deviceUuid();
+  const QString deviceId = CoreUtils::deviceUuid();
   request.setRawHeader( "X-Device-Id", QByteArray( deviceId.toUtf8() ) );
   if ( withAuth )
   {
@@ -354,7 +353,7 @@ bool MerginApi::supportsSelectiveSync() const
   return mSupportsSelectiveSync;
 }
 
-void MerginApi::setSupportsSelectiveSync( bool supportsSelectiveSync )
+void MerginApi::setSupportsSelectiveSync( const bool supportsSelectiveSync )
 {
   mSupportsSelectiveSync = supportsSelectiveSync;
 }
@@ -364,7 +363,7 @@ bool MerginApi::apiSupportsSubscriptions() const
   return mApiSupportsSubscriptions;
 }
 
-void MerginApi::setApiSupportsSubscriptions( bool apiSupportsSubscriptions )
+void MerginApi::setApiSupportsSubscriptions( const bool apiSupportsSubscriptions )
 {
   if ( mApiSupportsSubscriptions != apiSupportsSubscriptions )
   {
@@ -389,22 +388,24 @@ QString MerginApi::getApiKey( const QString &serverName )
   return "not-secret-key";
 }
 
-void MerginApi::downloadItemReplyFinished( DownloadQueueItem item )
+void MerginApi::downloadItemReplyFinished( const DownloadQueueItem &item )
 {
   QNetworkReply *r = qobject_cast<QNetworkReply *>( sender() );
   Q_ASSERT( r );
-  QString projectFullName = r->request().attribute( static_cast<QNetworkRequest::Attribute>( AttrProjectFullName ) ).toString();
-  QString tempFileName = r->request().attribute( static_cast<QNetworkRequest::Attribute>( AttrTempFileName ) ).toString();
-  Q_ASSERT( mTransactionalStatus.contains( projectFullName ) );
-  TransactionStatus &transaction = mTransactionalStatus[projectFullName];
+  const QString tempFileName = r->request().attribute( static_cast<QNetworkRequest::Attribute>( AttrTempFileName ) ).toString();
+  const QString projectId = r->request().attribute( static_cast<QNetworkRequest::Attribute>( AttrProjectId ) ).toString();
+  Q_ASSERT( mTransactionalStatus.contains( projectId ) );
+  TransactionStatus &transaction = mTransactionalStatus[projectId];
   Q_ASSERT( transaction.replyPullItems.contains( r ) );
+  const MerginProjectMetadata project = MerginProjectMetadata::fromJson( transaction.projectMetadata );
+  const QString projectFullName = CoreUtils::getFullProjectName( project.projectNamespace, project.name );
 
   if ( r->error() == QNetworkReply::NoError )
   {
-    QByteArray data = r->readAll();
+    const QByteArray data = r->readAll();
     CoreUtils::log( "pull " + projectFullName, QStringLiteral( "Downloaded item (%1 bytes)" ).arg( data.size() ) );
-    QString tempFolder = getTempProjectDir( projectFullName );
-    QString tempFilePath = tempFolder + "/" + tempFileName;
+    const QString tempFolder = getTempProjectDir( projectFullName );
+    const QString tempFilePath = tempFolder + "/" + tempFileName;
     createPathIfNotExists( tempFilePath );
     // save to a tmp file, assemble at the end
     QFile file( tempFilePath );
@@ -418,7 +419,7 @@ void MerginApi::downloadItemReplyFinished( DownloadQueueItem item )
       CoreUtils::log( "pull " + projectFullName, "Failed to open for writing: " + file.fileName() );
     }
     transaction.transferedSize += data.size();
-    emit syncProjectStatusChanged( projectFullName, transaction.transferedSize / transaction.totalSize );
+    emit syncProjectStatusChanged( projectId, transaction.transferedSize / transaction.totalSize );
     transaction.replyPullItems.remove( r );
 
     r->deleteLater();
@@ -426,13 +427,12 @@ void MerginApi::downloadItemReplyFinished( DownloadQueueItem item )
     if ( !transaction.downloadQueue.isEmpty() )
     {
       // one request finished, let's start another one
-      downloadNextItem( projectFullName );
+      downloadNextItem( projectId );
     }
-
     else if ( transaction.replyPullItems.isEmpty() )
     {
       // nothing else to download and all requests are finished, we're done
-      finalizeProjectPull( projectFullName );
+      finalizeProjectPull( projectId );
     }
     else
     {
@@ -444,12 +444,12 @@ void MerginApi::downloadItemReplyFinished( DownloadQueueItem item )
     transaction.retryCount++;
     transaction.downloadQueue.append( item );
 
-    CoreUtils::log( "pull " + projectFullName, QStringLiteral( "Retrying download (attempt %1 of %2)" ).arg( transaction.retryCount )
-                    .arg( transaction.MAX_RETRY_COUNT ) );
+    CoreUtils::log( "pull " + projectFullName, QStringLiteral( "Retrying download (attempt %1 of %2)" )
+                    .arg( transaction.retryCount ).arg( transaction.MAX_RETRY_COUNT ) );
 
-    downloadNextItem( projectFullName );
+    downloadNextItem( projectId );
 
-    emit downloadItemRetried( projectFullName, transaction.retryCount );
+    emit downloadItemRetried( projectId, transaction.retryCount );
     transaction.replyPullItems.remove( r );
     r->deleteLater();
   }
@@ -469,10 +469,10 @@ void MerginApi::downloadItemReplyFinished( DownloadQueueItem item )
     if ( !transaction.pullItemsAborting )
     {
       // the first failed request will abort all the other pending requests too, and finish pull with error
-      abortPullItems( projectFullName );
+      abortPullItems( projectId );
       // signal a networking error - we may retry
-      int httpCode = r->attribute( QNetworkRequest::HttpStatusCodeAttribute ).toInt();
-      emit networkErrorOccurred( serverMsg, QStringLiteral( "Mergin API error: downloadFile" ), httpCode, projectFullName );
+      const int httpCode = r->attribute( QNetworkRequest::HttpStatusCodeAttribute ).toInt();
+      emit networkErrorOccurred( serverMsg, httpCode, projectId );
     }
     else
     {
@@ -481,10 +481,12 @@ void MerginApi::downloadItemReplyFinished( DownloadQueueItem item )
   }
 }
 
-void MerginApi::abortPullItems( const QString &projectFullName )
+void MerginApi::abortPullItems( const QString &projectId )
 {
-  Q_ASSERT( mTransactionalStatus.contains( projectFullName ) );
-  TransactionStatus &transaction = mTransactionalStatus[projectFullName];
+  Q_ASSERT( mTransactionalStatus.contains( projectId ) );
+  TransactionStatus &transaction = mTransactionalStatus[projectId];
+  const MerginProjectMetadata project = MerginProjectMetadata::fromJson( transaction.projectMetadata );
+  const QString projectFullName = CoreUtils::getFullProjectName( project.projectNamespace, project.name );
 
   transaction.pullItemsAborting = true;
 
@@ -501,7 +503,7 @@ void MerginApi::abortPullItems( const QString &projectFullName )
     QDir( transaction.projectDir ).removeRecursively();
   }
 
-  finishProjectSync( projectFullName, false );
+  finishProjectSync( projectFullName, projectId, false );
 }
 
 void MerginApi::cacheServerConfig()
@@ -509,15 +511,18 @@ void MerginApi::cacheServerConfig()
   QNetworkReply *r = qobject_cast<QNetworkReply *>( sender() );
   Q_ASSERT( r );
 
-  QString projectFullName = r->request().attribute( static_cast<QNetworkRequest::Attribute>( AttrProjectFullName ) ).toString();
+  const QString projectId = r->request().attribute( static_cast<QNetworkRequest::Attribute>( AttrProjectId ) ).toString();
 
-  Q_ASSERT( mTransactionalStatus.contains( projectFullName ) );
-  TransactionStatus &transaction = mTransactionalStatus[projectFullName];
+  Q_ASSERT( mTransactionalStatus.contains( projectId ) );
+  TransactionStatus &transaction = mTransactionalStatus[projectId];
   Q_ASSERT( r == transaction.replyPullServerConfig );
+
+  const MerginProjectMetadata project = MerginProjectMetadata::fromJson( transaction.projectMetadata );
+  const QString projectFullName = CoreUtils::getFullProjectName( project.projectNamespace, project.name );
 
   if ( r->error() == QNetworkReply::NoError )
   {
-    QByteArray data = r->readAll();
+    const QByteArray data = r->readAll();
 
     CoreUtils::log( "pull " + projectFullName, QStringLiteral( "Downloaded mergin config (%1 bytes)" ).arg( data.size() ) );
     transaction.config = MerginConfig::fromJson( data );
@@ -525,7 +530,7 @@ void MerginApi::cacheServerConfig()
     transaction.replyPullServerConfig->deleteLater();
     transaction.replyPullServerConfig = nullptr;
 
-    prepareDownloadConfig( projectFullName, true );
+    prepareDownloadConfig( projectId, true );
   }
   else
   {
@@ -547,23 +552,23 @@ void MerginApi::cacheServerConfig()
       CoreUtils::removeDir( transaction.projectDir );
     }
 
-    int httpCode = r->attribute( QNetworkRequest::HttpStatusCodeAttribute ).toInt();
-    emit networkErrorOccurred( serverMsg, QStringLiteral( "Mergin API error: downloadFile" ), httpCode, projectFullName );
+    const int httpCode = r->attribute( QNetworkRequest::HttpStatusCodeAttribute ).toInt();
+    emit networkErrorOccurred( serverMsg, httpCode, projectId );
 
-    finishProjectSync( projectFullName, false );
+    finishProjectSync( projectFullName, projectId, false );
   }
 }
 
 
-void MerginApi::pushFile( const QString &projectFullName, const QString &transactionUUID, MerginFile file, int chunkNo )
+void MerginApi::pushFile( const QString &projectFullName, const QString &projectId, const QString &transactionUUID, const MerginFile &file, const int chunkNo )
 {
   if ( !validateAuth() || mApiVersionStatus != MerginApiStatus::OK )
   {
     return;
   }
 
-  Q_ASSERT( mTransactionalStatus.contains( projectFullName ) );
-  TransactionStatus &transaction = mTransactionalStatus[projectFullName];
+  Q_ASSERT( mTransactionalStatus.contains( projectId ) );
+  TransactionStatus &transaction = mTransactionalStatus[projectId];
 
   QString chunkID = file.chunks.at( chunkNo );
 
@@ -583,10 +588,11 @@ void MerginApi::pushFile( const QString &projectFullName, const QString &transac
   }
 
   QNetworkRequest request = getDefaultRequest();
-  QUrl url( mApiRoot + QStringLiteral( "/v1/project/push/chunk/%1/%2" ).arg( transactionUUID, chunkID ) );
+  const QUrl url( mApiRoot + QStringLiteral( "/v1/project/push/chunk/%1/%2" ).arg( transactionUUID, chunkID ) );
   request.setUrl( url );
   request.setRawHeader( "Content-Type", "application/octet-stream" );
   request.setAttribute( static_cast<QNetworkRequest::Attribute>( AttrProjectFullName ), projectFullName );
+  request.setAttribute( static_cast<QNetworkRequest::Attribute>( AttrProjectId ), projectId );
 
   Q_ASSERT( !transaction.replyPushFile );
   transaction.replyPushFile = mManager->post( request, data );
@@ -595,21 +601,22 @@ void MerginApi::pushFile( const QString &projectFullName, const QString &transac
   CoreUtils::log( "push " + projectFullName, QStringLiteral( "Uploading item: " ) + url.toString() );
 }
 
-void MerginApi::pushStart( const QString &projectFullName, const QByteArray &json )
+void MerginApi::pushStart( const QString &projectFullName, const QString &projectId, const QByteArray &json )
 {
   if ( !validateAuth() || mApiVersionStatus != MerginApiStatus::OK )
   {
     return;
   }
 
-  Q_ASSERT( mTransactionalStatus.contains( projectFullName ) );
-  TransactionStatus &transaction = mTransactionalStatus[projectFullName];
+  Q_ASSERT( mTransactionalStatus.contains( projectId ) );
+  TransactionStatus &transaction = mTransactionalStatus[projectId];
 
   QNetworkRequest request = getDefaultRequest();
-  QUrl url( mApiRoot + QStringLiteral( "/v1/project/push/%1" ).arg( projectFullName ) );
+  const QUrl url( mApiRoot + QStringLiteral( "/v1/project/push/%1" ).arg( projectFullName ) );
   request.setUrl( url );
   request.setRawHeader( "Content-Type", "application/json" );
   request.setAttribute( static_cast<QNetworkRequest::Attribute>( AttrProjectFullName ), projectFullName );
+  request.setAttribute( static_cast<QNetworkRequest::Attribute>( AttrProjectId ), projectId );
 
   Q_ASSERT( !transaction.replyPushStart );
   transaction.replyPushStart = mManager->post( request, json );
@@ -618,19 +625,20 @@ void MerginApi::pushStart( const QString &projectFullName, const QByteArray &jso
   CoreUtils::log( "push " + projectFullName, QStringLiteral( "Starting push request: " ) + url.toString() );
 }
 
-void MerginApi::cancelPush( const QString &projectFullName )
+void MerginApi::cancelPush( const QString &projectId )
 {
   if ( !validateAuth() || mApiVersionStatus != MerginApiStatus::OK )
   {
     return;
   }
 
-  if ( !mTransactionalStatus.contains( projectFullName ) )
+  if ( !mTransactionalStatus.contains( projectId ) )
     return;
 
-  CoreUtils::log( "push " + projectFullName, QStringLiteral( "User requested cancel" ) );
+  const TransactionStatus &transaction = mTransactionalStatus[projectId];
+  const QString projectFullName = mLocalProjects.projectFromProjectId( projectId ).fullName();
 
-  TransactionStatus &transaction = mTransactionalStatus[projectFullName];
+  CoreUtils::log( "push " + projectFullName, QStringLiteral( "User requested cancel" ) );
 
   // There is an open transaction, abort it followed by calling cancelUpload again.
   if ( transaction.replyPushProjectInfo )
@@ -645,20 +653,20 @@ void MerginApi::cancelPush( const QString &projectFullName )
   }
   else if ( transaction.replyPushFile )
   {
-    QString transactionUUID = transaction.transactionUUID;  // copy transaction uuid as the transaction object will be gone after abort
+    const QString transactionUUID = transaction.transactionUUID;  // copy transaction uuid as the transaction object will be gone after abort
     CoreUtils::log( "push " + projectFullName, QStringLiteral( "Aborting upload file" ) );
     transaction.replyPushFile->abort();  // will trigger pushFileReplyFinished slot and emit sync finished
 
     // also need to cancel the transaction
-    sendPushCancelRequest( projectFullName, transactionUUID );
+    sendPushCancelRequest( projectFullName, projectId, transactionUUID );
   }
   else if ( transaction.replyPushFinish )
   {
-    QString transactionUUID = transaction.transactionUUID;  // copy transaction uuid as the transaction object will be gone after abort
+    const QString transactionUUID = transaction.transactionUUID;  // copy transaction uuid as the transaction object will be gone after abort
     CoreUtils::log( "push " + projectFullName, QStringLiteral( "Aborting upload finish" ) );
     transaction.replyPushFinish->abort();  // will trigger pushFinishReplyFinished slot and emit sync finished
 
-    sendPushCancelRequest( projectFullName, transactionUUID );
+    sendPushCancelRequest( projectFullName, projectId, transactionUUID );
   }
   else
   {
@@ -667,27 +675,28 @@ void MerginApi::cancelPush( const QString &projectFullName )
 }
 
 
-void MerginApi::sendPushCancelRequest( const QString &projectFullName, const QString &transactionUUID )
+void MerginApi::sendPushCancelRequest( const QString &projectFullName, const QString &projectId, const QString &transactionUUID )
 {
   QNetworkRequest request = getDefaultRequest();
-  QUrl url( mApiRoot + QStringLiteral( "/v1/project/push/cancel/%1" ).arg( transactionUUID ) );
+  const QUrl url( mApiRoot + QStringLiteral( "/v1/project/push/cancel/%1" ).arg( transactionUUID ) );
   request.setUrl( url );
   request.setRawHeader( "Content-Type", "application/json" );
-  request.setAttribute( static_cast<QNetworkRequest::Attribute>( AttrProjectFullName ), projectFullName );
+  request.setAttribute( static_cast<QNetworkRequest::Attribute>( AttrProjectId ), projectId );
 
-  QNetworkReply *reply = mManager->post( request, QByteArray() );
+  const QNetworkReply *reply = mManager->post( request, QByteArray() );
   connect( reply, &QNetworkReply::finished, this, &MerginApi::pushCancelReplyFinished );
   CoreUtils::log( "push " + projectFullName, QStringLiteral( "Requesting upload transaction cancel: " ) + url.toString() );
 }
 
-void MerginApi::cancelPull( const QString &projectFullName )
+void MerginApi::cancelPull( const QString &projectId )
 {
-  if ( !mTransactionalStatus.contains( projectFullName ) )
+  if ( !mTransactionalStatus.contains( projectId ) )
     return;
 
+  const QString projectFullName = mLocalProjects.projectFromProjectId( projectId ).fullName();
   CoreUtils::log( "pull " + projectFullName, QStringLiteral( "User requested cancel" ) );
 
-  TransactionStatus &transaction = mTransactionalStatus[projectFullName];
+  const TransactionStatus &transaction = mTransactionalStatus[projectId];
 
   if ( transaction.replyPullProjectInfo )
   {
@@ -704,7 +713,7 @@ void MerginApi::cancelPull( const QString &projectFullName )
   else if ( !transaction.replyPullItems.isEmpty() )
   {
     // we're already downloading some files
-    abortPullItems( projectFullName );
+    abortPullItems( projectId );
   }
   else
   {
@@ -712,21 +721,22 @@ void MerginApi::cancelPull( const QString &projectFullName )
   }
 }
 
-void MerginApi::pushFinish( const QString &projectFullName, const QString &transactionUUID )
+void MerginApi::pushFinish( const QString &projectFullName, const QString &projectId, const QString &transactionUUID )
 {
   if ( !validateAuth() || mApiVersionStatus != MerginApiStatus::OK )
   {
     return;
   }
 
-  Q_ASSERT( mTransactionalStatus.contains( projectFullName ) );
-  TransactionStatus &transaction = mTransactionalStatus[projectFullName];
+  Q_ASSERT( mTransactionalStatus.contains( projectId ) );
+  TransactionStatus &transaction = mTransactionalStatus[projectId];
 
   QNetworkRequest request = getDefaultRequest();
-  QUrl url( mApiRoot + QStringLiteral( "/v1/project/push/finish/%1" ).arg( transactionUUID ) );
+  const QUrl url( mApiRoot + QStringLiteral( "/v1/project/push/finish/%1" ).arg( transactionUUID ) );
   request.setUrl( url );
   request.setRawHeader( "Content-Type", "application/json" );
   request.setAttribute( static_cast<QNetworkRequest::Attribute>( AttrProjectFullName ), projectFullName );
+  request.setAttribute( static_cast<QNetworkRequest::Attribute>( AttrProjectId ), projectId );
 
   Q_ASSERT( !transaction.replyPushFinish );
   transaction.replyPushFinish = mManager->post( request, QByteArray() );
@@ -735,25 +745,24 @@ void MerginApi::pushFinish( const QString &projectFullName, const QString &trans
   CoreUtils::log( "push " + projectFullName, QStringLiteral( "Requesting transaction finish: " ) + transactionUUID );
 }
 
-bool MerginApi::pullProject( const QString &projectNamespace, const QString &projectName, bool withAuth )
+bool MerginApi::pullProject( const QString &projectFullName, const QString &projectId, const bool withAuth )
 {
-  QString projectFullName = getFullProjectName( projectNamespace, projectName );
   bool pullHasStarted = false;
 
   CoreUtils::log( "pull " + projectFullName, "### Starting ###" );
 
-  QNetworkReply *reply = getProjectInfo( projectFullName, withAuth );
+  QNetworkReply *reply = getProjectInfo( projectFullName, projectId, withAuth );
   if ( reply )
   {
     CoreUtils::log( "pull " + projectFullName, QStringLiteral( "Requesting project info: " ) + reply->request().url().toString() );
 
-    Q_ASSERT( !mTransactionalStatus.contains( projectFullName ) );
-    mTransactionalStatus.insert( projectFullName, TransactionStatus() );
-    mTransactionalStatus[projectFullName].replyPullProjectInfo = reply;
-    mTransactionalStatus[projectFullName].configAllowed = mSupportsSelectiveSync;
-    mTransactionalStatus[projectFullName].type = TransactionStatus::Pull;
+    Q_ASSERT( !mTransactionalStatus.contains( projectId ) );
+    mTransactionalStatus.insert( projectId, TransactionStatus() );
+    mTransactionalStatus[projectId].replyPullProjectInfo = reply;
+    mTransactionalStatus[projectId].configAllowed = mSupportsSelectiveSync;
+    mTransactionalStatus[projectId].type = TransactionStatus::Pull;
 
-    emit syncProjectStatusChanged( projectFullName, 0 );
+    emit syncProjectStatusChanged( projectId, 0 );
 
     connect( reply, &QNetworkReply::finished, this, &MerginApi::pullInfoReplyFinished );
     pullHasStarted = true;
@@ -766,27 +775,26 @@ bool MerginApi::pullProject( const QString &projectNamespace, const QString &pro
   return pullHasStarted;
 }
 
-bool MerginApi::pushProject( const QString &projectNamespace, const QString &projectName, bool isInitialPush )
+bool MerginApi::pushProject( const QString &projectFullName, const QString &projectId, const bool isInitialPush )
 {
-  QString projectFullName = getFullProjectName( projectNamespace, projectName );
   bool pushHasStarted = false;
 
   CoreUtils::log( "push " + projectFullName, "### Starting ###" );
 
-  QNetworkReply *reply = getProjectInfo( projectFullName );
+  QNetworkReply *reply = getProjectInfo( projectFullName, projectId );
   if ( reply )
   {
     CoreUtils::log( "push " + projectFullName, QStringLiteral( "Requesting project info: " ) + reply->request().url().toString() );
 
     // create entry about pending upload for the project
-    Q_ASSERT( !mTransactionalStatus.contains( projectFullName ) );
-    mTransactionalStatus.insert( projectFullName, TransactionStatus() );
-    mTransactionalStatus[projectFullName].replyPushProjectInfo = reply;
-    mTransactionalStatus[projectFullName].isInitialPush = isInitialPush;
-    mTransactionalStatus[projectFullName].configAllowed = mSupportsSelectiveSync;
-    mTransactionalStatus[projectFullName].type = TransactionStatus::Push;
+    Q_ASSERT( !mTransactionalStatus.contains( projectId ) );
+    mTransactionalStatus.insert( projectId, TransactionStatus() );
+    mTransactionalStatus[projectId].replyPushProjectInfo = reply;
+    mTransactionalStatus[projectId].isInitialPush = isInitialPush;
+    mTransactionalStatus[projectId].configAllowed = mSupportsSelectiveSync;
+    mTransactionalStatus[projectId].type = TransactionStatus::Push;
 
-    emit syncProjectStatusChanged( projectFullName, 0 );
+    emit syncProjectStatusChanged( projectId, 0 );
 
     connect( reply, &QNetworkReply::finished, this, &MerginApi::pushInfoReplyFinished );
     pushHasStarted = true;
@@ -813,8 +821,8 @@ void MerginApi::authorize( const QString &login, const QString &password )
   mUserAuth->blockSignals( false );
 
   QNetworkRequest request = getDefaultRequest( false );
-  QString urlString = mApiRoot + QStringLiteral( "/v1/auth/login" );
-  QUrl url( urlString );
+  const QString urlString = mApiRoot + QStringLiteral( "/v1/auth/login" );
+  const QUrl url( urlString );
   request.setUrl( url );
   request.setRawHeader( "Content-Type", "application/json" );
 
@@ -823,9 +831,9 @@ void MerginApi::authorize( const QString &login, const QString &password )
   jsonObject.insert( QStringLiteral( "login" ), login );
   jsonObject.insert( QStringLiteral( "password" ), mUserAuth->password() );
   jsonDoc.setObject( jsonObject );
-  QByteArray json = jsonDoc.toJson( QJsonDocument::Compact );
+  const QByteArray json = jsonDoc.toJson( QJsonDocument::Compact );
 
-  QNetworkReply *reply = mManager->post( request, json );
+  const QNetworkReply *reply = mManager->post( request, json );
   connect( reply, &QNetworkReply::finished, this, &MerginApi::authorizeFinished );
   CoreUtils::log( "auth", QStringLiteral( "Requesting authorization: " ) + url.toString() );
 }
@@ -952,7 +960,7 @@ void MerginApi::ssoConnectionsReplyFinished()
 
 void MerginApi::registerUser( const QString &email,
                               const QString &password,
-                              bool acceptedTOC )
+                              const bool acceptedTOC )
 {
   // Some very basic checks, so we do not validate everything
   if ( !CoreUtils::isValidEmail( email ) )
@@ -978,15 +986,15 @@ void MerginApi::registerUser( const QString &email,
 
   if ( !acceptedTOC )
   {
-    QString msg = tr( "Please accept Terms and Privacy Policy" );
+    const QString msg = tr( "Please accept Terms and Privacy Policy" );
     emit registrationFailed( msg, RegistrationError::RegistrationErrorType::TOC );
     return;
   }
 
   // request
   QNetworkRequest request = getDefaultRequest( false );
-  QString urlString = mApiRoot + QStringLiteral( "/v1/auth/register" );
-  QUrl url( urlString );
+  const QString urlString = mApiRoot + QStringLiteral( "/v1/auth/register" );
+  const QUrl url( urlString );
   request.setUrl( url );
   request.setRawHeader( "Content-Type", "application/json" );
 
@@ -996,18 +1004,18 @@ void MerginApi::registerUser( const QString &email,
   jsonObject.insert( QStringLiteral( "password" ), password );
   jsonObject.insert( QStringLiteral( "api_key" ), getApiKey( mApiRoot ) );
   jsonDoc.setObject( jsonObject );
-  QByteArray json = jsonDoc.toJson( QJsonDocument::Compact );
-  QNetworkReply *reply = mManager->post( request, json );
-  connect( reply, &QNetworkReply::finished, this, [ = ]() { this->registrationFinished( email, password ); } );
+  const QByteArray json = jsonDoc.toJson( QJsonDocument::Compact );
+  const QNetworkReply *reply = mManager->post( request, json );
+  connect( reply, &QNetworkReply::finished, this, [ = ] { this->registrationFinished( email, password ); } );
   CoreUtils::log( "auth", QStringLiteral( "Requesting registration: " ) + url.toString() );
 }
 
-void MerginApi::postRegisterUser( const QString &marketingChannel, const QString &industry, bool wantsNewsletter )
+void MerginApi::postRegisterUser( const QString &marketingChannel, const QString &industry, const bool wantsNewsletter )
 {
   // Some very basic checks, so we do not validate everything
   if ( marketingChannel.isEmpty() || industry.isEmpty() )
   {
-    QString msg = tr( "Marketing source cannot be empty" );
+    const QString msg = tr( "Marketing source cannot be empty" );
     emit postRegistrationFailed( msg );
     return;
   }
@@ -1015,14 +1023,14 @@ void MerginApi::postRegisterUser( const QString &marketingChannel, const QString
   // Some very basic checks, so we do not validate everything
   if ( industry.isEmpty() )
   {
-    QString msg = tr( "Industry cannot be empty" );
+    const QString msg = tr( "Industry cannot be empty" );
     emit postRegistrationFailed( msg );
     return;
   }
   // request
   QNetworkRequest request = getDefaultRequest( false );
-  QString urlString = mApiRoot + QStringLiteral( "/v1/post-register" );
-  QUrl url( urlString );
+  const QString urlString = mApiRoot + QStringLiteral( "/v1/post-register" );
+  const QUrl url( urlString );
   request.setUrl( url );
   request.setRawHeader( "Content-Type", "application/json" );
 
@@ -1032,9 +1040,9 @@ void MerginApi::postRegisterUser( const QString &marketingChannel, const QString
   jsonObject.insert( QStringLiteral( "marketing_channel" ), marketingChannel );
   jsonObject.insert( QStringLiteral( "subscribe" ), wantsNewsletter );
   jsonDoc.setObject( jsonObject );
-  QByteArray json = jsonDoc.toJson( QJsonDocument::Compact );
-  QNetworkReply *reply = mManager->post( request, json );
-  connect( reply, &QNetworkReply::finished, this, [ = ]() { this->postRegistrationFinished(); } );
+  const QByteArray json = jsonDoc.toJson( QJsonDocument::Compact );
+  const QNetworkReply *reply = mManager->post( request, json );
+  connect( reply, &QNetworkReply::finished, this, [ = ] { this->postRegistrationFinished(); } );
   CoreUtils::log( "auth", QStringLiteral( "Requesting post-registration: " ) + url.toString() );
 }
 
@@ -1061,10 +1069,10 @@ void MerginApi::getUserInfo()
   }
 
   QNetworkRequest request = getDefaultRequest( true );
-  QUrl url( urlString );
+  const QUrl url( urlString );
   request.setUrl( url );
 
-  QNetworkReply *reply = mManager->get( request );
+  const QNetworkReply *reply = mManager->get( request );
   CoreUtils::log( "user info", QStringLiteral( "Requesting user info: " ) + url.toString() );
   connect( reply, &QNetworkReply::finished, this, &MerginApi::getUserInfoFinished );
 }
@@ -1086,12 +1094,12 @@ void MerginApi::getWorkspaceInfo()
     return;
   }
 
-  QString urlString = mApiRoot + QStringLiteral( "/v1/workspace/%1" ).arg( mUserInfo->activeWorkspaceId() );
+  const QString urlString = mApiRoot + QStringLiteral( "/v1/workspace/%1" ).arg( mUserInfo->activeWorkspaceId() );
   QNetworkRequest request = getDefaultRequest();
-  QUrl url( urlString );
+  const QUrl url( urlString );
   request.setUrl( url );
 
-  QNetworkReply *reply = mManager->get( request );
+  const QNetworkReply *reply = mManager->get( request );
   CoreUtils::log( "workspace info", QStringLiteral( "Requesting workspace info: " ) + url.toString() );
   connect( reply, &QNetworkReply::finished, this, &MerginApi::getWorkspaceInfoReplyFinished );
 }
@@ -1125,10 +1133,10 @@ void MerginApi::getServiceInfo()
   }
 
   QNetworkRequest request = getDefaultRequest( true );
-  QUrl url( urlString );
+  const QUrl url( urlString );
   request.setUrl( url );
 
-  QNetworkReply *reply = mManager->get( request );
+  const QNetworkReply *reply = mManager->get( request );
 
   connect( reply, &QNetworkReply::finished, this, &MerginApi::getServiceInfoReplyFinished );
 
@@ -1144,22 +1152,22 @@ void MerginApi::getServiceInfoReplyFinished()
   {
     CoreUtils::log( "Service info", QStringLiteral( "Success" ) );
 
-    QJsonDocument doc = QJsonDocument::fromJson( r->readAll() );
+    const QJsonDocument doc = QJsonDocument::fromJson( r->readAll() );
     if ( doc.isObject() )
     {
-      QJsonObject docObj = doc.object();
+      const QJsonObject docObj = doc.object();
       mSubscriptionInfo->setFromJson( docObj );
     }
   }
   else
   {
     QString serverMsg = extractServerErrorMsg( r->readAll() );
-    QString message = QStringLiteral( "Network API error: %1(): %2. %3" ).arg( QStringLiteral( "getServiceInfo" ), r->errorString(), serverMsg );
+    const QString message = QStringLiteral( "Network API error: %1(): %2. %3" ).arg( QStringLiteral( "getServiceInfo" ), r->errorString(), serverMsg );
     CoreUtils::log( "Service info", QStringLiteral( "FAILED - %1" ).arg( message ) );
 
     mSubscriptionInfo->clear();
 
-    int httpCode = r->attribute( QNetworkRequest::HttpStatusCodeAttribute ).toInt();
+    const int httpCode = r->attribute( QNetworkRequest::HttpStatusCodeAttribute ).toInt();
     if ( httpCode == 404 )
     {
       // no such API on the server, do not emit anything
@@ -1170,7 +1178,7 @@ void MerginApi::getServiceInfoReplyFinished()
     }
     else
     {
-      emit networkErrorOccurred( serverMsg, QStringLiteral( "Mergin API error: getServiceInfo" ) );
+      emit networkErrorOccurred( serverMsg );
     }
   }
 
@@ -1204,21 +1212,21 @@ void MerginApi::clearAuth()
   CoreUtils::log( QStringLiteral( "Auth" ), QStringLiteral( "Cleared auth and user data cache" ) );
 }
 
-QString MerginApi::resetPasswordUrl()
+QString MerginApi::resetPasswordUrl() const
 {
   if ( !mApiRoot.isEmpty() )
   {
-    QUrl base( mApiRoot );
+    const QUrl base( mApiRoot );
     return base.resolved( QUrl( "login/reset" ) ).toString();
   }
   return QString();
 }
 
-bool MerginApi::createProject( const QString &projectNamespace, const QString &projectName, bool isPublic )
+bool MerginApi::createProject( const QString &projectNamespace, const QString &projectName, const QString &projectId, const bool isPublic )
 {
   if ( !validateAuth() )
   {
-    emit missingAuthorizationError( projectName );
+    emit missingAuthorizationError( projectId );
     return false;
   }
 
@@ -1227,48 +1235,47 @@ bool MerginApi::createProject( const QString &projectNamespace, const QString &p
     return false;
   }
 
-  QString projectFullName = getFullProjectName( projectNamespace, projectName );
-
   QNetworkRequest request = getDefaultRequest();
-  QUrl url( mApiRoot + QString( "/v1/project/%1" ).arg( projectNamespace ) );
+  const QUrl url( mApiRoot + QString( "/v1/project/%1" ).arg( projectNamespace ) );
   request.setUrl( url );
   request.setRawHeader( "Content-Type", "application/json" );
   request.setRawHeader( "Accept", "application/json" );
-  request.setAttribute( static_cast<QNetworkRequest::Attribute>( AttrProjectFullName ), projectFullName );
+  request.setAttribute( static_cast<QNetworkRequest::Attribute>( AttrProjectId ), projectId );
+  request.setAttribute( static_cast<QNetworkRequest::Attribute>( AttrProjectFullName ),
+                        CoreUtils::getFullProjectName( projectNamespace, projectName ) );
 
   QJsonDocument jsonDoc;
   QJsonObject jsonObject;
   jsonObject.insert( QStringLiteral( "name" ), projectName );
   jsonObject.insert( QStringLiteral( "public" ), isPublic );
   jsonDoc.setObject( jsonObject );
-  QByteArray json = jsonDoc.toJson( QJsonDocument::Compact );
+  const QByteArray json = jsonDoc.toJson( QJsonDocument::Compact );
 
-  QNetworkReply *reply = mManager->post( request, json );
+  const QNetworkReply *reply = mManager->post( request, json );
   connect( reply, &QNetworkReply::finished, this, &MerginApi::createProjectFinished );
-  CoreUtils::log( "create " + projectFullName, QStringLiteral( "Requesting project creation: " ) + url.toString() );
+  CoreUtils::log( "create " + CoreUtils::getFullProjectName( projectNamespace, projectName ),
+                  QStringLiteral( "Requesting project creation: " ) + url.toString() );
 
   return true;
 }
 
-void MerginApi::deleteProject( const QString &projectNamespace, const QString &projectName, bool informUser )
+void MerginApi::deleteProject( const QString &projectId, bool informUser )
 {
   if ( !validateAuth() || mApiVersionStatus != MerginApiStatus::OK )
   {
     return;
   }
 
-  QString projectFullName = getFullProjectName( projectNamespace, projectName );
-
   QNetworkRequest request = getDefaultRequest();
-  QUrl url( mApiRoot + QStringLiteral( "/v1/project/%1" ).arg( projectFullName ) );
+  const QUrl url( mApiRoot + QStringLiteral( "/v2/projects/%1" ).arg( projectId ) );
   request.setUrl( url );
-  request.setAttribute( static_cast<QNetworkRequest::Attribute>( AttrProjectFullName ), projectFullName );
-  QNetworkReply *reply = mManager->deleteResource( request );
-  connect( reply, &QNetworkReply::finished, this, [this, informUser]() { this->deleteProjectFinished( informUser );} );
-  CoreUtils::log( "delete " + projectFullName, QStringLiteral( "Requesting project deletion: " ) + url.toString() );
+  request.setAttribute( static_cast<QNetworkRequest::Attribute>( AttrProjectId ), projectId );
+  const QNetworkReply *reply = mManager->deleteResource( request );
+  connect( reply, &QNetworkReply::finished, this, [this, informUser] { this->deleteProjectFinished( informUser );} );
+  CoreUtils::log( "delete " + projectId, QStringLiteral( "Requesting immediate project deletion: " ) + url.toString() );
 }
 
-void MerginApi::saveAuthData()
+void MerginApi::saveAuthData() const
 {
   QSettings settings;
   settings.beginGroup( "Input/" );
@@ -1283,51 +1290,72 @@ void MerginApi::createProjectFinished()
   QNetworkReply *r = qobject_cast<QNetworkReply *>( sender() );
   Q_ASSERT( r );
 
-  QString projectFullName = r->request().attribute( static_cast<QNetworkRequest::Attribute>( AttrProjectFullName ) ).toString();
-
-  QString projectNamespace, projectName;
-  extractProjectName( projectFullName, projectNamespace, projectName );
+  const QString projectId = r->request().attribute( static_cast<QNetworkRequest::Attribute>( AttrProjectId ) ).toString();
+  const QString projectFullName = r->request().attribute( static_cast<QNetworkRequest::Attribute>( AttrProjectFullName ) ).toString();
 
   if ( r->error() == QNetworkReply::NoError )
   {
     CoreUtils::log( "create " + projectFullName, QStringLiteral( "Success" ) );
-    emit projectCreated( projectFullName, true );
-
 
     // Upload data if createProject has been called for a local project with empty namespace (case of migrating a project)
-    for ( const LocalProject &info : mLocalProjects.projects() )
+    if ( mLocalProjects.projects().contains( projectId ) )
     {
-      if ( info.projectName == projectName && info.projectNamespace.isEmpty() )
-      {
-        mLocalProjects.updateNamespace( info.projectDir, projectNamespace );
-        emit projectAttachedToMergin( projectFullName, projectName );
+      // we remove the process saved under the old ID and pushProject will insert new process with new ID
+      emit projectCreated( projectId, false );
 
-        QDir projectDir( info.projectDir );
-        if ( projectDir.exists() && !projectDir.isEmpty() )
+      const QNetworkReply *reply = getProjectInfo( projectFullName, projectId );
+      connect( reply, &QNetworkReply::finished, this, [ this, projectId, projectFullName ]
+      {
+        QNetworkReply *reply = qobject_cast<QNetworkReply *>( sender() );
+        Q_ASSERT( reply );
+
+        if ( reply->error() == QNetworkReply::NoError )
         {
-          pushProject( projectNamespace, projectName, true );
+          const QByteArray data = reply->readAll();
+          const MerginProjectMetadata serverProject = MerginProjectMetadata::fromJson( data );
+
+          mLocalProjects.updateProjectId( projectId, serverProject.projectId );
+          mLocalProjects.updateNamespace( serverProject.projectId, serverProject.projectNamespace );
+          emit projectAttachedToMergin( serverProject.projectId );
+
+          const LocalProject info = mLocalProjects.projectFromProjectId( serverProject.projectId );
+          const QDir projectDir( info.projectDir );
+          if ( projectDir.exists() && !projectDir.isEmpty() )
+          {
+            pushProject( projectFullName, projectId, true );
+          }
         }
-      }
+        else
+        {
+          CoreUtils::log( "create " + projectFullName, QString( "Failed to get new ID for project %1" ).arg( projectFullName ) );
+        }
+
+        reply->deleteLater();
+      } );
+    }
+    else
+    {
+      emit projectCreated( projectId, true );
     }
   }
   else
   {
-    QByteArray data = r->readAll();
-    QString code = extractServerErrorCode( data );
+    const QByteArray data = r->readAll();
+    const QString code = extractServerErrorCode( data );
     QString serverMsg = extractServerErrorMsg( data );
-    QString message = QStringLiteral( "FAILED - %1: %2" ).arg( r->errorString(), serverMsg );
-    int httpCode = r->attribute( QNetworkRequest::HttpStatusCodeAttribute ).toInt();
-    bool showLimitReachedDialog = EnumHelper::isEqual( code, ErrorCode::ProjectsLimitHit );
-    bool userMissingPermissions = ( httpCode == 403 );
+    const QString message = QStringLiteral( "FAILED - %1: %2" ).arg( r->errorString(), serverMsg );
+    const int httpCode = r->attribute( QNetworkRequest::HttpStatusCodeAttribute ).toInt();
+    const bool showLimitReachedDialog = EnumHelper::isEqual( code, ErrorCode::ProjectsLimitHit );
+    const bool userMissingPermissions = ( httpCode == 403 );
 
     CoreUtils::log( "create " + projectFullName, message );
 
-    emit projectCreated( projectFullName, false );
+    emit projectCreated( projectId, false );
 
     if ( showLimitReachedDialog )
     {
       int maxProjects = 0;
-      QVariant maxProjectVariant = extractServerErrorValue( data, "projects_quota" );
+      const QVariant maxProjectVariant = extractServerErrorValue( data, "projects_quota" );
       if ( maxProjectVariant.isValid() )
         maxProjects = maxProjectVariant.toInt();
       emit projectLimitReached( maxProjects, serverMsg );
@@ -1341,35 +1369,34 @@ void MerginApi::createProjectFinished()
     {
       emit notifyError( tr( "Couldn't create the project. Please try again later or contact support if the problem persists." ) );
       emit projectCreationFailed();
-      emit networkErrorOccurred( serverMsg, QStringLiteral( "Mergin API error: createProject" ), httpCode, projectName );
+      emit networkErrorOccurred( serverMsg, QStringLiteral( "Mergin API error: createProject" ), httpCode, projectId );
     }
   }
   r->deleteLater();
 }
 
-void MerginApi::deleteProjectFinished( bool informUser )
+void MerginApi::deleteProjectFinished( const bool informUser )
 {
   QNetworkReply *r = qobject_cast<QNetworkReply *>( sender() );
   Q_ASSERT( r );
 
-  QString projectFullName = r->request().attribute( static_cast<QNetworkRequest::Attribute>( AttrProjectFullName ) ).toString();
+  const QString projectId = r->request().attribute( static_cast<QNetworkRequest::Attribute>( AttrProjectId ) ).toString();
 
   if ( r->error() == QNetworkReply::NoError )
   {
-    CoreUtils::log( "delete " + projectFullName, QStringLiteral( "Success" ) );
+    CoreUtils::log( "delete " + projectId, QStringLiteral( "Success" ) );
 
     if ( informUser )
       emit notifySuccess( QStringLiteral( "Project deleted" ) );
 
-    emit serverProjectDeleted( projectFullName, true );
   }
   else
   {
     QString serverMsg = extractServerErrorMsg( r->readAll() );
-    CoreUtils::log( "delete " + projectFullName, QStringLiteral( "FAILED - %1. %2" ).arg( r->errorString(), serverMsg ) );
-    emit serverProjectDeleted( projectFullName, false );
-    emit networkErrorOccurred( serverMsg, QStringLiteral( "Mergin API error: deleteProject" ) );
+    CoreUtils::log( "delete " + projectId, QStringLiteral( "FAILED - %1. %2" ).arg( r->errorString(), serverMsg ) );
+    emit networkErrorOccurred( serverMsg );
   }
+
   r->deleteLater();
 }
 
@@ -1382,10 +1409,10 @@ void MerginApi::authorizeFinished()
   {
     CoreUtils::log( "auth", QStringLiteral( "Success" ) );
     const QByteArray data = r->readAll();
-    QJsonDocument doc = QJsonDocument::fromJson( data );
+    const QJsonDocument doc = QJsonDocument::fromJson( data );
     if ( doc.isObject() )
     {
-      QJsonObject docObj = doc.object();
+      const QJsonObject docObj = doc.object();
       mUserAuth->setFromJson( docObj );
     }
     else
@@ -1402,8 +1429,8 @@ void MerginApi::authorizeFinished()
   else
   {
     QString serverMsg = extractServerErrorMsg( r->readAll() );
-    QVariant statusCode = r->attribute( QNetworkRequest::HttpStatusCodeAttribute );
-    int status = statusCode.toInt();
+    const QVariant statusCode = r->attribute( QNetworkRequest::HttpStatusCodeAttribute );
+    const int status = statusCode.toInt();
     CoreUtils::log( "Auth", QStringLiteral( "FAILED - %1. %2 (%3)" ).arg( r->errorString(), serverMsg, QString::number( status ) ) );
 
     if ( status == 401 )
@@ -1425,7 +1452,7 @@ void MerginApi::authorizeFinished()
       // keep login and password
       // this is problem with internet connection or server
       // so do not force user to input login credentials again
-      emit networkErrorOccurred( serverMsg, QStringLiteral( "Mergin API error: authorize" ) );
+      emit networkErrorOccurred( serverMsg );
     }
 
     // in case of any error, just clean token and request new one
@@ -1447,7 +1474,7 @@ void MerginApi::registrationFinished( const QString &login, const QString &passw
   if ( r->error() == QNetworkReply::NoError )
   {
     CoreUtils::log( "register", QStringLiteral( "Success" ) );
-    QString msg = tr( "Registration successful" );
+    const QString msg = tr( "Registration successful" );
     emit notifySuccess( msg );
 
     if ( !login.isEmpty() && !password.isEmpty() ) // log in immediately
@@ -1506,7 +1533,7 @@ void MerginApi::registrationFinished( const QString &login, const QString &passw
     {
       const QString msg = QStringLiteral( "Mergin API error: register" );
       emit registrationFailed( msg, RegistrationError::RegistrationErrorType::OTHER );
-      emit networkErrorOccurred( serverMsg, msg );
+      emit networkErrorOccurred( serverMsg );
     }
   }
   r->deleteLater();
@@ -1526,9 +1553,7 @@ void MerginApi::postRegistrationFinished()
   {
     QString serverMsg = extractServerErrorMsg( r->readAll() );
     CoreUtils::log( "post-register", QStringLiteral( "FAILED - %1. %2" ).arg( r->errorString(), serverMsg ) );
-    QVariant statusCode = r->attribute( QNetworkRequest::HttpStatusCodeAttribute );
-    int status = statusCode.toInt();
-    emit postRegistrationFailed( QStringLiteral( "Post-registation failed %1" ).arg( serverMsg ) );
+    emit postRegistrationFailed( QStringLiteral( "Post-registration failed %1" ).arg( serverMsg ) );
   }
   emit notifySuccess( tr( "Workspace created" ) );
   r->deleteLater();
@@ -1545,10 +1570,10 @@ void MerginApi::pingMerginReplyFinished()
   if ( r->error() == QNetworkReply::NoError )
   {
     CoreUtils::log( "ping", QStringLiteral( "Success" ) );
-    QJsonDocument doc = QJsonDocument::fromJson( r->readAll() );
+    const QJsonDocument doc = QJsonDocument::fromJson( r->readAll() );
     if ( doc.isObject() )
     {
-      QJsonObject obj = doc.object();
+      const QJsonObject obj = doc.object();
       apiVersion = obj.value( QStringLiteral( "version" ) ).toString();
       serverSupportsSubscriptions = obj.value( QStringLiteral( "subscriptions_enabled" ) ).toBool();
     }
@@ -1577,11 +1602,11 @@ void MerginApi::onPlanProductIdChanged()
   }
 }
 
-QNetworkReply *MerginApi::getProjectInfo( const QString &projectFullName, bool withAuth )
+QNetworkReply *MerginApi::getProjectInfo( const QString &projectFullName, const QString &projectId, const bool withAuth )
 {
   if ( withAuth && !validateAuth() )
   {
-    emit missingAuthorizationError( projectFullName );
+    emit missingAuthorizationError( projectId );
     return nullptr;
   }
 
@@ -1591,7 +1616,7 @@ QNetworkReply *MerginApi::getProjectInfo( const QString &projectFullName, bool w
   }
 
   int sinceVersion = -1;
-  LocalProject projectInfo = mLocalProjects.projectFromMerginName( projectFullName );
+  const LocalProject projectInfo = mLocalProjects.projectFromProjectId( projectId );
   if ( projectInfo.isValid() )
   {
     // let's also fetch the recent history of diffable files
@@ -1603,12 +1628,51 @@ QNetworkReply *MerginApi::getProjectInfo( const QString &projectFullName, bool w
   if ( sinceVersion != -1 )
     query.addQueryItem( QStringLiteral( "since" ), QStringLiteral( "v%1" ).arg( sinceVersion ) );
 
-  QUrl url( mApiRoot + QStringLiteral( "/v1/project/%1" ).arg( projectFullName ) );
+  QUrl url{};
+  url.setUrl( mApiRoot + QStringLiteral( "/v1/project/%1" ).arg( projectFullName ) );
   url.setQuery( query );
 
   QNetworkRequest request = getDefaultRequest( withAuth );
   request.setUrl( url );
+  request.setAttribute( static_cast<QNetworkRequest::Attribute>( AttrProjectId ), projectId );
   request.setAttribute( static_cast<QNetworkRequest::Attribute>( AttrProjectFullName ), projectFullName );
+
+  return mManager->get( request );
+}
+
+QNetworkReply *MerginApi::getProjectDetails( const QString &projectId, const bool withAuth )
+{
+  if ( withAuth && !validateAuth() )
+  {
+    emit missingAuthorizationError( projectId );
+    return nullptr;
+  }
+
+  if ( mApiVersionStatus != MerginApiStatus::OK )
+  {
+    return nullptr;
+  }
+
+  int sinceVersion = -1;
+  const LocalProject projectInfo = mLocalProjects.projectFromProjectId( projectId );
+  if ( projectInfo.isValid() )
+  {
+    // let's also fetch the recent history of diffable files
+    // (the "since" is inclusive, so if we are on v2, we want to use since=v3 which will include v2->v3, v3->v4, ...)
+    sinceVersion = projectInfo.localVersion + 1;
+  }
+
+  QUrlQuery query;
+  if ( sinceVersion != -1 )
+    query.addQueryItem( QStringLiteral( "since" ), QStringLiteral( "v%1" ).arg( sinceVersion ) );
+
+  QUrl url{};
+  url.setUrl( mApiRoot + QStringLiteral( "/v1/project/by_uuid/%1" ).arg( projectId ) );
+  url.setQuery( query );
+
+  QNetworkRequest request = getDefaultRequest( withAuth );
+  request.setUrl( url );
+  request.setAttribute( static_cast<QNetworkRequest::Attribute>( AttrProjectId ), projectId );
 
   return mManager->get( request );
 }
@@ -1640,7 +1704,7 @@ bool MerginApi::validateAuth()
   return true;
 }
 
-void MerginApi::checkMerginVersion( QString apiVersion, bool serverSupportsSubscriptions, QString msg )
+void MerginApi::checkMerginVersion( const QString &apiVersion, const bool serverSupportsSubscriptions, const QString &msg )
 {
   setApiSupportsSubscriptions( serverSupportsSubscriptions );
 
@@ -1649,7 +1713,7 @@ void MerginApi::checkMerginVersion( QString apiVersion, bool serverSupportsSubsc
     int major = -1;
     int minor = -1;
 
-    bool validVersion = parseVersion( apiVersion, major, minor );
+    const bool validVersion = parseVersion( apiVersion, major, minor );
 
     if ( !validVersion )
     {
@@ -1672,25 +1736,9 @@ void MerginApi::checkMerginVersion( QString apiVersion, bool serverSupportsSubsc
   }
 }
 
-bool MerginApi::extractProjectName( const QString &sourceString, QString &projectNamespace, QString &name )
-{
-  QStringList parts = sourceString.split( "/" );
-  if ( parts.length() > 1 )
-  {
-    projectNamespace = parts.at( parts.length() - 2 );
-    name = parts.last();
-    return true;
-  }
-  else
-  {
-    name = sourceString;
-    return false;
-  }
-}
-
 QString MerginApi::extractServerErrorCode( const QByteArray &data )
 {
-  QVariant code = extractServerErrorValue( data, QStringLiteral( "code" ) );
+  const QVariant code = extractServerErrorValue( data, QStringLiteral( "code" ) );
   if ( code.isValid() )
     return code.toString();
   return QString();
@@ -1698,13 +1746,13 @@ QString MerginApi::extractServerErrorCode( const QByteArray &data )
 
 QVariant MerginApi::extractServerErrorValue( const QByteArray &data, const QString &key )
 {
-  QJsonDocument doc = QJsonDocument::fromJson( data );
+  const QJsonDocument doc = QJsonDocument::fromJson( data );
   if ( doc.isObject() )
   {
-    QJsonObject obj = doc.object();
+    const QJsonObject obj = doc.object();
     if ( obj.contains( key ) )
     {
-      QJsonValue val = obj.value( key );
+      const QJsonValue val = obj.value( key );
       return val.toVariant();
     }
   }
@@ -1715,13 +1763,13 @@ QVariant MerginApi::extractServerErrorValue( const QByteArray &data, const QStri
 QString MerginApi::extractServerErrorMsg( const QByteArray &data )
 {
   QString serverMsg = "[can't parse server error]";
-  QJsonDocument doc = QJsonDocument::fromJson( data );
+  const QJsonDocument doc = QJsonDocument::fromJson( data );
   if ( doc.isObject() )
   {
-    QJsonObject obj = doc.object();
+    const QJsonObject obj = doc.object();
     if ( obj.contains( QStringLiteral( "detail" ) ) )
     {
-      QJsonValue vDetail = obj.value( "detail" );
+      const QJsonValue vDetail = obj.value( "detail" );
       if ( vDetail.isString() )
       {
         serverMsg = vDetail.toString();
@@ -1733,10 +1781,10 @@ QString MerginApi::extractServerErrorMsg( const QByteArray &data )
     }
     else if ( obj.contains( QStringLiteral( "name" ) ) )
     {
-      QJsonValue val = obj.value( "name" );
+      const QJsonValue val = obj.value( "name" );
       if ( val.isArray() )
       {
-        QJsonArray errors = val.toArray();
+        const QJsonArray errors = val.toArray();
         QStringList messages;
         for ( auto it = errors.constBegin(); it != errors.constEnd(); ++it )
         {
@@ -1760,17 +1808,17 @@ QString MerginApi::extractServerErrorMsg( const QByteArray &data )
 }
 
 
-LocalProject MerginApi::getLocalProject( const QString &projectFullName )
+LocalProject MerginApi::getLocalProject( const QString &projectId ) const
 {
-  return mLocalProjects.projectFromMerginName( projectFullName );
+  return mLocalProjects.projectFromProjectId( projectId );
 }
 
 ProjectDiff MerginApi::localProjectChanges( const QString &projectDir )
 {
-  MerginProjectMetadata projectMetadata = MerginProjectMetadata::fromCachedJson( projectDir + "/" + sMetadataFile );
-  QList<MerginFile> localFiles = getLocalProjectFiles( projectDir + "/" );
+  const MerginProjectMetadata projectMetadata = MerginProjectMetadata::fromCachedJson( projectDir + "/" + sMetadataFile );
+  const QList<MerginFile> localFiles = getLocalProjectFiles( projectDir + "/" );
 
-  MerginConfig config = MerginConfig::fromFile( projectDir + "/" + sMerginConfigFile );
+  const MerginConfig config = MerginConfig::fromFile( projectDir + "/" + sMerginConfigFile );
 
   return compareProjectFiles( projectMetadata.files, projectMetadata.files, localFiles, projectDir, config.isValid, config );
 }
@@ -1797,8 +1845,8 @@ bool MerginApi::parseVersion( const QString &version, int &major, int &minor )
 
 bool MerginApi::hasLocalProjectChanges( const QString &projectDir, bool supportsSelectiveSync )
 {
-  MerginProjectMetadata projectMetadata = MerginProjectMetadata::fromCachedJson( projectDir + "/" + sMetadataFile );
-  QList<MerginFile> localFiles = getLocalProjectFiles( projectDir + "/" );
+  const MerginProjectMetadata projectMetadata = MerginProjectMetadata::fromCachedJson( projectDir + "/" + sMetadataFile );
+  const QList<MerginFile> localFiles = getLocalProjectFiles( projectDir + "/" );
 
   MerginConfig config;
   if ( supportsSelectiveSync )
@@ -1809,14 +1857,9 @@ bool MerginApi::hasLocalProjectChanges( const QString &projectDir, bool supports
   return hasLocalChanges( projectMetadata.files, localFiles, projectDir, config );
 }
 
-QString MerginApi::getTempProjectDir( const QString &projectFullName )
+QString MerginApi::getTempProjectDir( const QString &projectFullName ) const
 {
   return mDataDir + "/" + TEMP_FOLDER + projectFullName;
-}
-
-QString MerginApi::getFullProjectName( QString projectNamespace, QString projectName ) // TODO: move to inpututils?
-{
-  return QString( "%1/%2" ).arg( projectNamespace ).arg( projectName );
 }
 
 MerginApiStatus::VersionStatus MerginApi::apiVersionStatus() const
@@ -1840,32 +1883,18 @@ void MerginApi::pingMergin()
   setApiVersionStatus( MerginApiStatus::PENDING );
 
   QNetworkRequest request = getDefaultRequest( false );
-  QUrl url( mApiRoot + QStringLiteral( "/ping" ) );
+  const QUrl url( mApiRoot + QStringLiteral( "/ping" ) );
   request.setUrl( url );
 
-  QNetworkReply *reply = mManager->get( request );
+  const QNetworkReply *reply = mManager->get( request );
   CoreUtils::log( "ping", QStringLiteral( "Requesting: " ) + url.toString() );
   connect( reply, &QNetworkReply::finished, this, &MerginApi::pingMerginReplyFinished );
 }
 
-void MerginApi::migrateProjectToMergin( const QString &projectName, const QString &projectNamespace )
-{
-  CoreUtils::log( "migrate project", projectName );
-  if ( projectNamespace.isEmpty() )
-  {
-    createProject( mUserInfo->username(), projectName );
-  }
-  else
-  {
-    createProject( projectNamespace, projectName );
-  }
-}
-
-void MerginApi::detachProjectFromMergin( const QString &projectNamespace, const QString &projectName, bool informUser )
+void MerginApi::detachProjectFromMergin( const QString &projectId, const bool informUser )
 {
   // Remove mergin folder
-  QString projectFullName = getFullProjectName( projectNamespace, projectName );
-  LocalProject projectInfo = mLocalProjects.projectFromMerginName( projectFullName );
+  const LocalProject projectInfo = mLocalProjects.projectFromProjectId( projectId );
 
   if ( projectInfo.isValid() )
   {
@@ -1879,7 +1908,7 @@ void MerginApi::detachProjectFromMergin( const QString &projectNamespace, const 
   if ( informUser )
     emit notifySuccess( tr( "Project detached from the server" ) );
 
-  emit projectDetached( projectFullName );
+  emit projectDetached( projectId );
 }
 
 QString MerginApi::apiRoot() const
@@ -1936,7 +1965,7 @@ QList<MerginFile> MerginApi::getLocalProjectFiles( const QString &projectPath )
     merginFiles.append( file );
   }
 
-  qint64 elapsed = timer.elapsed();
+  const qint64 elapsed = timer.elapsed();
   if ( elapsed > 100 )
   {
     CoreUtils::log( "Local File", QStringLiteral( "It took %1 ms to create MerginFiles for %2 local files for %3." ).arg( elapsed ).arg( localFiles.count() ).arg( projectPath ) );
@@ -1944,7 +1973,7 @@ QList<MerginFile> MerginApi::getLocalProjectFiles( const QString &projectPath )
   return merginFiles;
 }
 
-void MerginApi::listProjectsReplyFinished( QString requestId )
+void MerginApi::listProjectsReplyFinished( const QString &requestId )
 {
   QNetworkReply *r = qobject_cast<QNetworkReply *>( sender() );
   Q_ASSERT( r );
@@ -1955,11 +1984,11 @@ void MerginApi::listProjectsReplyFinished( QString requestId )
 
   if ( r->error() == QNetworkReply::NoError )
   {
-    QUrlQuery query( r->request().url().query() );
+    const QUrlQuery query( r->request().url().query() );
     requestedPage = query.queryItemValue( "page" ).toInt();
 
-    QByteArray data = r->readAll();
-    QJsonDocument doc = QJsonDocument::fromJson( data );
+    const QByteArray data = r->readAll();
+    const QJsonDocument doc = QJsonDocument::fromJson( data );
 
     if ( doc.isObject() )
     {
@@ -1972,8 +2001,8 @@ void MerginApi::listProjectsReplyFinished( QString requestId )
   else
   {
     QString serverMsg = extractServerErrorMsg( r->readAll() );
-    QString message = QStringLiteral( "Network API error: %1(): %2. %3" ).arg( QStringLiteral( "listProjects" ), r->errorString(), serverMsg );
-    emit networkErrorOccurred( serverMsg, QStringLiteral( "Mergin API error: listProjects" ) );
+    const QString message = QStringLiteral( "Network API error: %1(): %2. %3" ).arg( QStringLiteral( "listProjects" ), r->errorString(), serverMsg );
+    emit networkErrorOccurred( serverMsg );
     CoreUtils::log( "list projects", QStringLiteral( "FAILED - %1" ).arg( message ) );
 
     emit listProjectsFailed();
@@ -1984,7 +2013,7 @@ void MerginApi::listProjectsReplyFinished( QString requestId )
   emit listProjectsFinished( projectList, projectCount, requestedPage, requestId );
 }
 
-void MerginApi::listProjectsByNameReplyFinished( QString requestId )
+void MerginApi::listProjectsByNameReplyFinished( const QString &requestId )
 {
   QNetworkReply *r = qobject_cast<QNetworkReply *>( sender() );
   Q_ASSERT( r );
@@ -1993,16 +2022,16 @@ void MerginApi::listProjectsByNameReplyFinished( QString requestId )
 
   if ( r->error() == QNetworkReply::NoError )
   {
-    QByteArray data = r->readAll();
-    QJsonDocument json = QJsonDocument::fromJson( data );
+    const QByteArray data = r->readAll();
+    const QJsonDocument json = QJsonDocument::fromJson( data );
     projectList = parseProjectsFromJson( json );
     CoreUtils::log( "list projects by name", QStringLiteral( "Success - got %1 projects" ).arg( projectList.count() ) );
   }
   else
   {
     QString serverMsg = extractServerErrorMsg( r->readAll() );
-    QString message = QStringLiteral( "Network API error: %1(): %2. %3" ).arg( QStringLiteral( "listProjectsByName" ), r->errorString(), serverMsg );
-    emit networkErrorOccurred( serverMsg, QStringLiteral( "Mergin API error: listProjectsByName" ) );
+    const QString message = QStringLiteral( "Network API error: %1(): %2. %3" ).arg( QStringLiteral( "listProjectsByName" ), r->errorString(), serverMsg );
+    emit networkErrorOccurred( serverMsg );
     CoreUtils::log( "list projects by name", QStringLiteral( "FAILED - %1" ).arg( message ) );
 
     emit listProjectsFailed();
@@ -2018,7 +2047,7 @@ void MerginApi::finalizeProjectPullCopy( const QString &projectFullName, const Q
 {
   CoreUtils::log( "pull " + projectFullName, QStringLiteral( "Copying new content of " ) + filePath );
 
-  QString dest = projectDir + "/" + filePath;
+  const QString dest = projectDir + "/" + filePath;
   createPathIfNotExists( dest );
 
   QFile f( dest );
@@ -2042,25 +2071,25 @@ void MerginApi::finalizeProjectPullCopy( const QString &projectFullName, const Q
 
   f.close();
 
-  // if diffable, copy to .mergin dir so we have a basefile
-  if ( MerginApi::isFileDiffable( filePath ) )
+  // if diffable, copy to .mergin dir so we have a base file
+  if ( isFileDiffable( filePath ) )
   {
-    QString basefile = projectDir + "/.mergin/" + filePath;
-    createPathIfNotExists( basefile );
+    const QString baseFile = projectDir + "/.mergin/" + filePath;
+    createPathIfNotExists( baseFile );
 
-    if ( !QFile::remove( basefile ) )
+    if ( !QFile::remove( baseFile ) )
     {
-      CoreUtils::log( "pull " + projectFullName, "failed to remove old basefile for: " + filePath );
+      CoreUtils::log( "pull " + projectFullName, "failed to remove old base file for: " + filePath );
     }
-    if ( !QFile::copy( dest, basefile ) )
+    if ( !QFile::copy( dest, baseFile ) )
     {
-      CoreUtils::log( "pull " + projectFullName, "failed to copy new basefile for: " + filePath );
+      CoreUtils::log( "pull " + projectFullName, "failed to copy new base file for: " + filePath );
     }
   }
 }
 
 
-bool MerginApi::finalizeProjectPullApplyDiff( const QString &projectFullName, const QString &projectDir, const QString &tempDir, const QString &filePath, const QList<DownloadQueueItem> &items )
+bool MerginApi::finalizeProjectPullApplyDiff( const QString &projectFullName, const QString &projectId, const QString &projectDir, const QString &tempDir, const QString &filePath, const QList<DownloadQueueItem> &items )
 {
   CoreUtils::log( "pull " + projectFullName, QStringLiteral( "Applying diff to " ) + filePath );
 
@@ -2070,28 +2099,28 @@ bool MerginApi::finalizeProjectPullApplyDiff( const QString &projectFullName, co
 
   QString src = tempDir + "/" + CoreUtils::uuidWithoutBraces( QUuid::createUuid() );
   QString dest = projectDir + "/" + filePath;
-  QString basefile = projectDir + "/.mergin/" + filePath;
+  QString baseFile = projectDir + "/.mergin/" + filePath;
 
-  LocalProject info = mLocalProjects.projectFromMerginName( projectFullName );
+  LocalProject info = mLocalProjects.projectFromProjectId( projectId );
 
   // add conflict files to project dir so they can be synced
-  QString conflictfile = CoreUtils::findUniquePath( CoreUtils::generateEditConflictFileName( dest, mUserInfo->username(), info.localVersion ) );
+  QString conflictFile = CoreUtils::findUniquePath( CoreUtils::generateEditConflictFileName( dest, mUserInfo->username(), info.localVersion ) );
 
   createPathIfNotExists( src );
   createPathIfNotExists( dest );
-  createPathIfNotExists( basefile );
+  createPathIfNotExists( baseFile );
 
   QStringList diffFiles;
   for ( const auto &item : items )
     diffFiles << tempDir + "/" + item.tempFileName;
 
   //
-  // let's first assemble server's file from our basefile + diffs
+  // let's first assemble server's file from our base file + diffs
   //
 
-  if ( !QFile::copy( basefile, src ) )
+  if ( !QFile::copy( baseFile, src ) )
   {
-    CoreUtils::log( "pull " + projectFullName, "assemble server file fail: copying failed " + basefile + " to " + src );
+    CoreUtils::log( "pull " + projectFullName, "assemble server file fail: copying failed " + baseFile + " to " + src );
 
     // TODO: this is a critical failure - we should abort pull
   }
@@ -2101,7 +2130,7 @@ bool MerginApi::finalizeProjectPullApplyDiff( const QString &projectFullName, co
     CoreUtils::log( "pull " + projectFullName, "server file assembly failed: " + filePath );
 
     // TODO: this is a critical failure - we should abort pull
-    // TODO: we could try to delete the basefile and re-download it from scratch on next sync
+    // TODO: we could try to delete the base file and re-download it from scratch on next sync
   }
   else
   {
@@ -2113,10 +2142,10 @@ bool MerginApi::finalizeProjectPullApplyDiff( const QString &projectFullName, co
   //
   bool hasConflicts = false;
 
-  bool res = GeodiffUtils::rebase( basefile,
+  bool res = GeodiffUtils::rebase( baseFile,
                                    src,
                                    dest,
-                                   conflictfile
+                                   conflictFile
                                  );
   if ( res )
   {
@@ -2129,8 +2158,8 @@ bool MerginApi::finalizeProjectPullApplyDiff( const QString &projectFullName, co
     // not good... something went wrong in rebase - we need to save the local changes
     // let's put them into a conflict file and use the server version
     hasConflicts = true;
-    LocalProject info = mLocalProjects.projectFromMerginName( projectFullName );
-    QString newDest = CoreUtils::findUniquePath( CoreUtils::generateConflictedCopyFileName( dest, mUserInfo->username(), info.localVersion ) );
+    LocalProject localProject = mLocalProjects.projectFromProjectId( projectId );
+    QString newDest = CoreUtils::findUniquePath( CoreUtils::generateConflictedCopyFileName( dest, mUserInfo->username(), localProject.localVersion ) );
     if ( !QFile::rename( dest, newDest ) )
     {
       CoreUtils::log( "pull " + projectFullName, "failed rename of conflicting file after failed geodiff rebase: " + filePath );
@@ -2142,31 +2171,33 @@ bool MerginApi::finalizeProjectPullApplyDiff( const QString &projectFullName, co
   }
 
   //
-  // finally update our basefile
+  // finally update our base file
   //
 
-  if ( !QFile::remove( basefile ) )
+  if ( !QFile::remove( baseFile ) )
   {
-    CoreUtils::log( "pull " + projectFullName, "failed removal of old basefile: " + filePath );
+    CoreUtils::log( "pull " + projectFullName, "failed removal of old base file: " + filePath );
 
     // TODO: this is a critical failure - we should abort pull
   }
-  if ( !QFile::rename( src, basefile ) )
+  if ( !QFile::rename( src, baseFile ) )
   {
-    CoreUtils::log( "pull " + projectFullName, "failed rename of basefile using new server content: " + filePath );
+    CoreUtils::log( "pull " + projectFullName, "failed rename of base file using new server content: " + filePath );
 
     // TODO: this is a critical failure - we should abort pull
   }
   return hasConflicts;
 }
 
-void MerginApi::finalizeProjectPull( const QString &projectFullName )
+void MerginApi::finalizeProjectPull( const QString &projectId )
 {
-  Q_ASSERT( mTransactionalStatus.contains( projectFullName ) );
-  TransactionStatus &transaction = mTransactionalStatus[projectFullName];
+  Q_ASSERT( mTransactionalStatus.contains( projectId ) );
+  TransactionStatus &transaction = mTransactionalStatus[projectId];
+  const MerginProjectMetadata project = MerginProjectMetadata::fromJson( transaction.projectMetadata );
+  const QString projectFullName = CoreUtils::getFullProjectName( project.projectNamespace, project.name );
 
-  QString projectDir = transaction.projectDir;
-  QString tempProjectDir = getTempProjectDir( projectFullName );
+  const QString projectDir = transaction.projectDir;
+  const QString tempProjectDir = getTempProjectDir( projectFullName );
 
   CoreUtils::log( "pull " + projectFullName, "Running update tasks" );
 
@@ -2184,7 +2215,7 @@ void MerginApi::finalizeProjectPull( const QString &projectFullName )
       {
         // move local file to conflict file
         QString origPath = projectDir + "/" + finalizationItem.filePath;
-        LocalProject info = mLocalProjects.projectFromMerginName( projectFullName );
+        const LocalProject info = mLocalProjects.projectFromProjectId( projectId );
         QString newPath = CoreUtils::findUniquePath( CoreUtils::generateConflictedCopyFileName( origPath, mUserInfo->username(), info.localVersion ) );
         if ( !QFile::rename( origPath, newPath ) )
         {
@@ -2202,7 +2233,7 @@ void MerginApi::finalizeProjectPull( const QString &projectFullName )
       {
         // applying diff can result in conflicted copy too, in this case
         // we need to update gpkgSchemaChanged flag.
-        bool res = finalizeProjectPullApplyDiff( projectFullName, projectDir, tempProjectDir, finalizationItem.filePath, finalizationItem.data );
+        const bool res = finalizeProjectPullApplyDiff( projectFullName, projectId, projectDir, tempProjectDir, finalizationItem.filePath, finalizationItem.data );
         transaction.gpkgSchemaChanged = res;
         break;
       }
@@ -2225,7 +2256,7 @@ void MerginApi::finalizeProjectPull( const QString &projectFullName )
   }
 
   // check there are no files left
-  int tmpFilesLeft = QDir( tempProjectDir ).entryList( QDir::NoDotAndDotDot ).count();
+  const int tmpFilesLeft = QDir( tempProjectDir ).entryList( QDir::NoDotAndDotDot ).count();
   if ( tmpFilesLeft )
   {
     CoreUtils::log( "pull " + projectFullName, "Some temporary files were left - this should not happen..." );
@@ -2234,19 +2265,16 @@ void MerginApi::finalizeProjectPull( const QString &projectFullName )
   QDir( tempProjectDir ).removeRecursively();
 
   // add the local project if not there yet
-  if ( !mLocalProjects.projectFromMerginName( projectFullName ).isValid() )
+  if ( !mLocalProjects.projectFromProjectId( projectId ).isValid() )
   {
-    QString projectNamespace, projectName;
-    extractProjectName( projectFullName, projectNamespace, projectName );
-
     // remove download in progress file
     if ( !QFile::remove( CoreUtils::downloadInProgressFilePath( transaction.projectDir ) ) )
-      CoreUtils::log( QStringLiteral( "sync %1" ).arg( projectFullName ), QStringLiteral( "Failed to remove download in progress file for project name %1" ).arg( projectName ) );
+      CoreUtils::log( QStringLiteral( "sync %1" ).arg( projectFullName ), QStringLiteral( "Failed to remove download in progress file for project name %1" ).arg( project.name ) );
 
-    mLocalProjects.addMerginProject( projectDir, projectNamespace, projectName );
+    mLocalProjects.addMerginProject( projectDir, project.projectNamespace, project.name, projectId );
   }
 
-  finishProjectSync( projectFullName, true );
+  finishProjectSync( projectFullName, projectId, true );
 }
 
 
@@ -2256,9 +2284,10 @@ void MerginApi::pushStartReplyFinished()
   Q_ASSERT( r );
 
   QString projectFullName = r->request().attribute( static_cast<QNetworkRequest::Attribute>( AttrProjectFullName ) ).toString();
+  QString projectId = r->request().attribute( static_cast<QNetworkRequest::Attribute>( AttrProjectId ) ).toString();
 
-  Q_ASSERT( mTransactionalStatus.contains( projectFullName ) );
-  TransactionStatus &transaction = mTransactionalStatus[projectFullName];
+  Q_ASSERT( mTransactionalStatus.contains( projectId ) );
+  TransactionStatus &transaction = mTransactionalStatus[projectId];
   Q_ASSERT( r == transaction.replyPushStart );
 
   if ( r->error() == QNetworkReply::NoError )
@@ -2283,26 +2312,26 @@ void MerginApi::pushStartReplyFinished()
       if ( transaction.transactionUUID.isEmpty() )
       {
         CoreUtils::log( "push " + projectFullName, QStringLiteral( "Fail! Could not acquire transaction ID" ) );
-        finishProjectSync( projectFullName, false );
+        finishProjectSync( projectFullName, projectId, false );
       }
 
       CoreUtils::log( "push " + projectFullName, QStringLiteral( "Push request accepted. Transaction ID: " ) + transactionUUID );
 
       MerginFile file = files.first();
-      pushFile( projectFullName, transactionUUID, file );
+      pushFile( projectFullName, projectId, transactionUUID, file );
       emit pushFilesStarted();
     }
     else  // pushing only files to be removed
     {
       // we are done here - no upload of chunks, no request to "finish"
-      // because server immediatelly creates a new version without starting a transaction to upload chunks
+      // because server immediately creates a new version without starting a transaction to upload chunks
 
       CoreUtils::log( "push " + projectFullName, QStringLiteral( "Push request accepted and no files to upload" ) );
 
       transaction.projectMetadata = data;
       transaction.version = MerginProjectMetadata::fromJson( data ).version;
 
-      finishProjectSync( projectFullName, true );
+      finishProjectSync( projectFullName, projectId, true );
     }
   }
   else
@@ -2333,19 +2362,16 @@ void MerginApi::pushStartReplyFinished()
       // remove project if it was first time sync - migration
       if ( transaction.isInitialPush )
       {
-        QString projectNamespace, projectName;
-        extractProjectName( projectFullName, projectNamespace, projectName );
-
-        detachProjectFromMergin( projectNamespace, projectName, false );
-        deleteProject( projectNamespace, projectName, false );
+        detachProjectFromMergin( projectId, false );
+        deleteProject( projectId, false );
       }
     }
     else
     {
       int httpCode = r->attribute( QNetworkRequest::HttpStatusCodeAttribute ).toInt();
-      emit networkErrorOccurred( serverMsg, QStringLiteral( "Mergin API error: pushStartReply" ), httpCode, projectFullName );
+      emit networkErrorOccurred( serverMsg, httpCode, projectId );
     }
-    finishProjectSync( projectFullName, false );
+    finishProjectSync( projectFullName, projectId, false );
   }
 }
 
@@ -2355,9 +2381,10 @@ void MerginApi::pushFileReplyFinished()
   Q_ASSERT( r );
 
   QString projectFullName = r->request().attribute( static_cast<QNetworkRequest::Attribute>( AttrProjectFullName ) ).toString();
+  QString projectId = r->request().attribute( static_cast<QNetworkRequest::Attribute>( AttrProjectId ) ).toString();
 
-  Q_ASSERT( mTransactionalStatus.contains( projectFullName ) );
-  TransactionStatus &transaction = mTransactionalStatus[projectFullName];
+  Q_ASSERT( mTransactionalStatus.contains( projectId ) );
+  TransactionStatus &transaction = mTransactionalStatus[projectId];
   Q_ASSERT( r == transaction.replyPushFile );
 
   QStringList params = ( r->url().toString().split( "/" ) );
@@ -2376,23 +2403,23 @@ void MerginApi::pushFileReplyFinished()
     int chunkNo = currentFile.chunks.indexOf( chunkID );
     if ( chunkNo < currentFile.chunks.size() - 1 )
     {
-      pushFile( projectFullName, transactionUUID, currentFile, chunkNo + 1 );
+      pushFile( projectFullName, projectId, transactionUUID, currentFile, chunkNo + 1 );
     }
     else
     {
       transaction.transferedSize += currentFile.size;
 
-      emit syncProjectStatusChanged( projectFullName, transaction.transferedSize / transaction.totalSize );
+      emit syncProjectStatusChanged( projectId, transaction.transferedSize / transaction.totalSize );
       transaction.pushQueue.removeFirst();
 
       if ( !transaction.pushQueue.isEmpty() )
       {
         MerginFile nextFile = transaction.pushQueue.first();
-        pushFile( projectFullName, transactionUUID, nextFile );
+        pushFile( projectFullName, projectId, transactionUUID, nextFile );
       }
       else
       {
-        pushFinish( projectFullName, transactionUUID );
+        pushFinish( projectFullName, projectId, transactionUUID );
       }
     }
   }
@@ -2405,12 +2432,12 @@ void MerginApi::pushFileReplyFinished()
     CoreUtils::log( "push " + projectFullName, QStringLiteral( "FAILED - %1. %2" ).arg( r->errorString(), serverMsg ) );
 
     int httpCode = r->attribute( QNetworkRequest::HttpStatusCodeAttribute ).toInt();
-    emit networkErrorOccurred( serverMsg, QStringLiteral( "Mergin API error: pushFile" ), httpCode, projectFullName );
+    emit networkErrorOccurred( serverMsg, httpCode, projectId );
 
     transaction.replyPushFile->deleteLater();
     transaction.replyPushFile = nullptr;
 
-    finishProjectSync( projectFullName, false );
+    finishProjectSync( projectFullName, projectId, false );
   }
 }
 
@@ -2419,21 +2446,22 @@ void MerginApi::pullInfoReplyFinished()
   QNetworkReply *r = qobject_cast<QNetworkReply *>( sender() );
   Q_ASSERT( r );
 
-  QString projectFullName = r->request().attribute( static_cast<QNetworkRequest::Attribute>( AttrProjectFullName ) ).toString();
+  const QString projectFullName = r->request().attribute( static_cast<QNetworkRequest::Attribute>( AttrProjectFullName ) ).toString();
+  const QString projectId = r->request().attribute( static_cast<QNetworkRequest::Attribute>( AttrProjectId ) ).toString();
 
-  Q_ASSERT( mTransactionalStatus.contains( projectFullName ) );
-  TransactionStatus &transaction = mTransactionalStatus[projectFullName];
+  Q_ASSERT( mTransactionalStatus.contains( projectId ) );
+  TransactionStatus &transaction = mTransactionalStatus[projectId];
   Q_ASSERT( r == transaction.replyPullProjectInfo );
 
   if ( r->error() == QNetworkReply::NoError )
   {
-    QByteArray data = r->readAll();
+    const QByteArray data = r->readAll();
     CoreUtils::log( "pull " + projectFullName, QStringLiteral( "Downloaded project info." ) );
 
     transaction.replyPullProjectInfo->deleteLater();
     transaction.replyPullProjectInfo = nullptr;
 
-    prepareProjectPull( projectFullName, data );
+    prepareProjectPull( projectId, data );
   }
   else
   {
@@ -2441,30 +2469,30 @@ void MerginApi::pullInfoReplyFinished()
     if ( r->error() == QNetworkReply::OperationCanceledError )
       serverMsg = sSyncCanceledMessage;
 
-    QString message = QStringLiteral( "Network API error: %1(): %2" ).arg( QStringLiteral( "projectInfo" ), r->errorString() );
+    const QString message = QStringLiteral( "Network API error: %1(): %2" ).arg( QStringLiteral( "projectInfo" ), r->errorString() );
     CoreUtils::log( "pull " + projectFullName, QStringLiteral( "FAILED - %1" ).arg( message ) );
 
-    int httpCode = r->attribute( QNetworkRequest::HttpStatusCodeAttribute ).toInt();
-    emit networkErrorOccurred( serverMsg, QStringLiteral( "Mergin API error: pullInfo" ), httpCode, projectFullName );
+    const int httpCode = r->attribute( QNetworkRequest::HttpStatusCodeAttribute ).toInt();
+    emit networkErrorOccurred( serverMsg, httpCode, projectId );
 
     transaction.replyPullProjectInfo->deleteLater();
     transaction.replyPullProjectInfo = nullptr;
 
-    finishProjectSync( projectFullName, false );
+    finishProjectSync( projectFullName, projectId, false );
   }
 }
 
-void MerginApi::prepareProjectPull( const QString &projectFullName, const QByteArray &data )
+void MerginApi::prepareProjectPull( const QString &projectId, const QByteArray &data )
 {
-  Q_ASSERT( mTransactionalStatus.contains( projectFullName ) );
-  TransactionStatus &transaction = mTransactionalStatus[projectFullName];
+  Q_ASSERT( mTransactionalStatus.contains( projectId ) );
+  TransactionStatus &transaction = mTransactionalStatus[projectId];
 
-  MerginProjectMetadata serverProject = MerginProjectMetadata::fromJson( data );
+  const MerginProjectMetadata serverProject = MerginProjectMetadata::fromJson( data );
 
   transaction.projectMetadata = data;
   transaction.version = serverProject.version;
 
-  LocalProject projectInfo = mLocalProjects.projectFromMerginName( projectFullName );
+  const LocalProject projectInfo = mLocalProjects.projectFromProjectId( projectId );
   if ( projectInfo.isValid() )
   {
     transaction.projectDir = projectInfo.projectDir;
@@ -2472,28 +2500,25 @@ void MerginApi::prepareProjectPull( const QString &projectFullName, const QByteA
     // do not continue if we are already on the latest version
     if ( projectInfo.localVersion != -1 && projectInfo.localVersion == serverProject.version )
     {
-      emit projectAlreadyOnLatestVersion( projectFullName );
-      CoreUtils::log( QStringLiteral( "Pull %1" ).arg( projectFullName ), QStringLiteral( "Project is already on the latest version: %1" ).arg( serverProject.version ) );
+      emit projectAlreadyOnLatestVersion( projectInfo.id() );
+      CoreUtils::log( QStringLiteral( "Pull %1" ).arg( projectInfo.fullName() ), QStringLiteral( "Project is already on the latest version: %1" ).arg( serverProject.version ) );
 
-      return finishProjectSync( projectFullName, false );
+      return finishProjectSync( projectInfo.fullName(), projectId, false );
     }
   }
   else
   {
-    QString projectNamespace;
-    QString projectName;
-    extractProjectName( projectFullName, projectNamespace, projectName );
-
     // remove any leftover temp files that could be created from previous unsuccessful download
-    removeProjectsTempFolder( projectNamespace, projectName );
+    removeProjectsTempFolder( serverProject.projectNamespace, serverProject.name );
 
     // project has not been downloaded yet - we need to create a directory for it
-    transaction.projectDir = CoreUtils::createUniqueProjectDirectory( mDataDir, projectName );
+    transaction.projectDir = CoreUtils::createUniqueProjectDirectory( mDataDir, serverProject.name );
     transaction.firstTimeDownload = true;
 
     // create file indicating first time download in progress
-    QString downloadInProgressFilePath = CoreUtils::downloadInProgressFilePath( transaction.projectDir );
+    const QString downloadInProgressFilePath = CoreUtils::downloadInProgressFilePath( transaction.projectDir );
     createPathIfNotExists( downloadInProgressFilePath );
+    const QString projectFullName = CoreUtils::getFullProjectName( serverProject.projectNamespace, serverProject.name );
     if ( !CoreUtils::createEmptyFile( downloadInProgressFilePath ) )
       CoreUtils::log( QStringLiteral( "pull %1" ).arg( projectFullName ), "Unable to create temporary download in progress file" );
 
@@ -2504,23 +2529,24 @@ void MerginApi::prepareProjectPull( const QString &projectFullName, const QByteA
 
   if ( transaction.configAllowed )
   {
-    prepareDownloadConfig( projectFullName );
+    prepareDownloadConfig( projectId );
   }
   else
   {
-    startProjectPull( projectFullName );
+    startProjectPull( projectId );
   }
 }
 
-void MerginApi::startProjectPull( const QString &projectFullName )
+void MerginApi::startProjectPull( const QString &projectId )
 {
-  Q_ASSERT( mTransactionalStatus.contains( projectFullName ) );
-  TransactionStatus &transaction = mTransactionalStatus[projectFullName];
+  Q_ASSERT( mTransactionalStatus.contains( projectId ) );
+  TransactionStatus &transaction = mTransactionalStatus[projectId];
 
   QList<MerginFile> localFiles = getLocalProjectFiles( transaction.projectDir + "/" );
   MerginProjectMetadata serverProject = MerginProjectMetadata::fromJson( transaction.projectMetadata );
   MerginProjectMetadata oldServerProject = MerginProjectMetadata::fromCachedJson( transaction.projectDir + "/" + sMetadataFile );
   MerginConfig oldTransactionConfig = MerginConfig::fromFile( transaction.projectDir + "/" + sMerginConfigFile );
+  const QString projectFullName = CoreUtils::getFullProjectName( serverProject.projectNamespace, serverProject.name );
 
   CoreUtils::log( "pull " + projectFullName, QStringLiteral( "Updating from version %1 to version %2" )
                   .arg( oldServerProject.version ).arg( serverProject.version ) );
@@ -2548,7 +2574,7 @@ void MerginApi::startProjectPull( const QString &projectFullName )
   {
     MerginFile file = serverProject.fileInfo( filePath );
 
-    // for diffable files - download and apply to the basefile (without rebase)
+    // for diffable files - download and apply to the base file (without rebase)
     if ( isFileDiffable( filePath ) && file.pullCanUseDiff )
     {
       QList<DownloadQueueItem> items = itemsForFileDiffs( file );
@@ -2567,7 +2593,7 @@ void MerginApi::startProjectPull( const QString &projectFullName )
   {
     MerginFile file = serverProject.fileInfo( filePath );
 
-    // for diffable files - download and apply to the basefile (will also do rebase)
+    // for diffable files - download and apply to the base file (will also do rebase)
     if ( isFileDiffable( filePath ) && file.pullCanUseDiff )
     {
       QList<DownloadQueueItem> items = itemsForFileDiffs( file );
@@ -2629,21 +2655,21 @@ void MerginApi::startProjectPull( const QString &projectFullName )
 
   if ( transaction.downloadQueue.isEmpty() )
   {
-    finalizeProjectPull( projectFullName );
+    finalizeProjectPull( projectId );
   }
   else
   {
     while ( transaction.replyPullItems.count() < 5 && !transaction.downloadQueue.isEmpty() )
     {
-      downloadNextItem( projectFullName );
+      downloadNextItem( projectId );
     }
   }
 }
 
-void MerginApi::prepareDownloadConfig( const QString &projectFullName, bool downloaded )
+void MerginApi::prepareDownloadConfig( const QString &projectId, const bool downloaded )
 {
-  Q_ASSERT( mTransactionalStatus.contains( projectFullName ) );
-  TransactionStatus &transaction = mTransactionalStatus[projectFullName];
+  Q_ASSERT( mTransactionalStatus.contains( projectId ) );
+  TransactionStatus &transaction = mTransactionalStatus[projectId];
 
   MerginProjectMetadata newServerVersion = MerginProjectMetadata::fromJson( transaction.projectMetadata );
 
@@ -2651,14 +2677,14 @@ void MerginApi::prepareDownloadConfig( const QString &projectFullName, bool down
   {
     return file.path == sMerginConfigFile;
   } );
-  bool serverContainsConfig = res != newServerVersion.files.end();
+  const bool serverContainsConfig = res != newServerVersion.files.end();
 
   if ( serverContainsConfig )
   {
     if ( !downloaded )
     {
-      // we should have server config but we do not have it yet
-      return requestServerConfig( projectFullName );
+      // we should have server config, but we do not have it yet
+      return requestServerConfig( projectId );
     }
   }
 
@@ -2669,7 +2695,7 @@ void MerginApi::prepareDownloadConfig( const QString &projectFullName, bool down
     return file.path == sMerginConfigFile;
   } );
 
-  bool previousVersionContainedConfig = ( resOld != oldServerVersion.files.end() ) && !transaction.firstTimeDownload;
+  const bool previousVersionContainedConfig = resOld != oldServerVersion.files.end() && !transaction.firstTimeDownload;
 
   if ( !transaction.config.isValid )
   {
@@ -2680,8 +2706,8 @@ void MerginApi::prepareDownloadConfig( const QString &projectFullName, bool down
   else if ( serverContainsConfig && previousVersionContainedConfig )
   {
     // config was there, check if there are changes
-    QString newChk = newServerVersion.fileInfo( sMerginConfigFile ).checksum;
-    QString oldChk = oldServerVersion.fileInfo( sMerginConfigFile ).checksum;
+    const QString newChk = newServerVersion.fileInfo( sMerginConfigFile ).checksum;
+    const QString oldChk = oldServerVersion.fileInfo( sMerginConfigFile ).checksum;
 
     if ( newChk == oldChk )
     {
@@ -2690,7 +2716,7 @@ void MerginApi::prepareDownloadConfig( const QString &projectFullName, bool down
     else
     {
       // config was changed, but what changed?
-      MerginConfig oldConfig = MerginConfig::fromFile( transaction.projectDir + "/" + MerginApi::sMerginConfigFile );
+      const MerginConfig oldConfig = MerginConfig::fromFile( transaction.projectDir + "/" + sMerginConfigFile );
 
       if ( oldConfig.selectiveSyncEnabled != transaction.config.selectiveSyncEnabled )
       {
@@ -2734,13 +2760,15 @@ void MerginApi::prepareDownloadConfig( const QString &projectFullName, bool down
     // if it would be possible to add mergin-config locally, it needs to be checked here
   }
 
-  startProjectPull( projectFullName );
+  startProjectPull( projectId );
 }
 
-void MerginApi::requestServerConfig( const QString &projectFullName )
+void MerginApi::requestServerConfig( const QString &projectId )
 {
-  Q_ASSERT( mTransactionalStatus.contains( projectFullName ) );
-  TransactionStatus &transaction = mTransactionalStatus[projectFullName];
+  Q_ASSERT( mTransactionalStatus.contains( projectId ) );
+  TransactionStatus &transaction = mTransactionalStatus[projectId];
+  const MerginProjectMetadata project = MerginProjectMetadata::fromJson( transaction.projectMetadata );
+  const QString projectFullName = CoreUtils::getFullProjectName( project.projectNamespace, project.name );
 
   QUrl url( mApiRoot + QStringLiteral( "/v1/project/raw/" ) + projectFullName );
   QUrlQuery query;
@@ -2751,7 +2779,7 @@ void MerginApi::requestServerConfig( const QString &projectFullName )
 
   QNetworkRequest request = getDefaultRequest();
   request.setUrl( url );
-  request.setAttribute( static_cast<QNetworkRequest::Attribute>( AttrProjectFullName ), projectFullName );
+  request.setAttribute( static_cast<QNetworkRequest::Attribute>( AttrProjectId ), projectId );
 
   Q_ASSERT( !transaction.replyPullServerConfig );
   transaction.replyPullServerConfig = mManager->get( request );
@@ -2760,13 +2788,13 @@ void MerginApi::requestServerConfig( const QString &projectFullName )
   CoreUtils::log( "pull " + projectFullName, QStringLiteral( "Requesting mergin config: " ) + url.toString() );
 }
 
-QList<DownloadQueueItem> MerginApi::itemsForFileChunks( const MerginFile &file, int version )
+QList<DownloadQueueItem> MerginApi::itemsForFileChunks( const MerginFile &file, const int version )
 {
   QList<DownloadQueueItem> lst;
   qint64 from = 0;
   while ( from < file.size )
   {
-    qint64 size = qMin( MerginApi::UPLOAD_CHUNK_SIZE, file.size - from );
+    const qint64 size = qMin( MerginApi::UPLOAD_CHUNK_SIZE, file.size - from );
     lst << DownloadQueueItem( file.path, size, version, from, from + size - 1 );
     from += size;
   }
@@ -2792,7 +2820,7 @@ static MerginFile findFile( const QString &filePath, const QList<MerginFile> &fi
     if ( merginFile.path == filePath )
       return merginFile;
   }
-  CoreUtils::log( QStringLiteral( "MerginFile" ), QStringLiteral( "requested findFile() for non-existant file: %1" ).arg( filePath ) );
+  CoreUtils::log( QStringLiteral( "MerginFile" ), QStringLiteral( "requested findFile() for non-existent file: %1" ).arg( filePath ) );
   return MerginFile();
 }
 
@@ -2803,9 +2831,10 @@ void MerginApi::pushInfoReplyFinished()
   Q_ASSERT( r );
 
   QString projectFullName = r->request().attribute( static_cast<QNetworkRequest::Attribute>( AttrProjectFullName ) ).toString();
+  QString projectId = r->request().attribute( static_cast<QNetworkRequest::Attribute>( AttrProjectId ) ).toString();
 
-  Q_ASSERT( mTransactionalStatus.contains( projectFullName ) );
-  TransactionStatus &transaction = mTransactionalStatus[projectFullName];
+  Q_ASSERT( mTransactionalStatus.contains( projectId ) );
+  TransactionStatus &transaction = mTransactionalStatus[projectId];
   Q_ASSERT( r == transaction.replyPushProjectInfo );
 
   if ( r->error() == QNetworkReply::NoError )
@@ -2817,7 +2846,7 @@ void MerginApi::pushInfoReplyFinished()
     transaction.replyPushProjectInfo->deleteLater();
     transaction.replyPushProjectInfo = nullptr;
 
-    LocalProject projectInfo = mLocalProjects.projectFromMerginName( projectFullName );
+    LocalProject projectInfo = mLocalProjects.projectFromProjectId( projectId );
     transaction.projectDir = projectInfo.projectDir;
     Q_ASSERT( !transaction.projectDir.isEmpty() );
 
@@ -2831,7 +2860,7 @@ void MerginApi::pushInfoReplyFinished()
       CoreUtils::log( "push " + projectFullName, QStringLiteral( "Need pull first: local version %1 | server version %2" )
                       .arg( projectInfo.localVersion ).arg( serverProject.version ) );
       transaction.pullBeforePush = true;
-      prepareProjectPull( projectFullName, data );
+      prepareProjectPull( projectId, data );
       return;
     }
 
@@ -2841,7 +2870,7 @@ void MerginApi::pushInfoReplyFinished()
     // Cache mergin-config, since we are on the most recent version, it is sufficient to just read the local version
     if ( transaction.configAllowed )
     {
-      transaction.config = MerginConfig::fromFile( transaction.projectDir + "/" + MerginApi::sMerginConfigFile );
+      transaction.config = MerginConfig::fromFile( transaction.projectDir + "/" + sMerginConfigFile );
     }
 
     transaction.diff = compareProjectFiles(
@@ -2872,7 +2901,7 @@ void MerginApi::pushInfoReplyFinished()
       MerginFile merginFile = findFile( filePath, localFiles );
       merginFile.chunks = generateChunkIdsForSize( merginFile.size );
 
-      if ( MerginApi::isFileDiffable( filePath ) )
+      if ( isFileDiffable( filePath ) )
       {
         // try to create a diff
         QString diffName;
@@ -2884,8 +2913,8 @@ void MerginApi::pushInfoReplyFinished()
         {
           QByteArray checksumDiff = CoreUtils::calculateChecksum( diffPath );
 
-          // TODO: this is ugly. our basefile may not need to have the same checksum as the server's
-          // basefile (because each of them have applied the diff independently) so we have to fake it
+          // TODO: this is ugly. our base file may not need to have the same checksum as the server's
+          // base file (because each of them have applied the diff independently) so we have to fake it
           QByteArray checksumBase = serverProject.fileInfo( filePath ).checksum.toLatin1();
 
           merginFile.diffName = diffName;
@@ -2920,7 +2949,7 @@ void MerginApi::pushInfoReplyFinished()
       transaction.projectMetadata = data;
       transaction.version = MerginProjectMetadata::fromJson( data ).version;
 
-      finishProjectSync( projectFullName, true );
+      finishProjectSync( projectFullName, projectId, true );
       return;
     }
 
@@ -2961,7 +2990,7 @@ void MerginApi::pushInfoReplyFinished()
     QJsonDocument jsonDoc;
     jsonDoc.setObject( json );
 
-    pushStart( projectFullName, jsonDoc.toJson( QJsonDocument::Compact ) );
+    pushStart( projectFullName, projectId, jsonDoc.toJson( QJsonDocument::Compact ) );
   }
   else
   {
@@ -2973,12 +3002,12 @@ void MerginApi::pushInfoReplyFinished()
     CoreUtils::log( "push " + projectFullName, QStringLiteral( "FAILED - %1" ).arg( message ) );
 
     int httpCode = r->attribute( QNetworkRequest::HttpStatusCodeAttribute ).toInt();
-    emit networkErrorOccurred( serverMsg, QStringLiteral( "Mergin API error: pushInfo" ), httpCode, projectFullName );
+    emit networkErrorOccurred( serverMsg, httpCode, projectId );
 
     transaction.replyPushProjectInfo->deleteLater();
     transaction.replyPushProjectInfo = nullptr;
 
-    finishProjectSync( projectFullName, false );
+    finishProjectSync( projectFullName, projectId, false );
   }
 }
 
@@ -2987,16 +3016,17 @@ void MerginApi::pushFinishReplyFinished()
   QNetworkReply *r = qobject_cast<QNetworkReply *>( sender() );
   Q_ASSERT( r );
 
-  QString projectFullName = r->request().attribute( static_cast<QNetworkRequest::Attribute>( AttrProjectFullName ) ).toString();
+  const QString projectFullName = r->request().attribute( static_cast<QNetworkRequest::Attribute>( AttrProjectFullName ) ).toString();
+  const QString projectId = r->request().attribute( static_cast<QNetworkRequest::Attribute>( AttrProjectId ) ).toString();
 
-  Q_ASSERT( mTransactionalStatus.contains( projectFullName ) );
-  TransactionStatus &transaction = mTransactionalStatus[projectFullName];
+  Q_ASSERT( mTransactionalStatus.contains( projectId ) );
+  TransactionStatus &transaction = mTransactionalStatus[projectId];
   Q_ASSERT( r == transaction.replyPushFinish );
 
   if ( r->error() == QNetworkReply::NoError )
   {
-    Q_ASSERT( mTransactionalStatus.contains( projectFullName ) );
-    QByteArray data = r->readAll();
+    Q_ASSERT( mTransactionalStatus.contains( projectId ) );
+    const QByteArray data = r->readAll();
     CoreUtils::log( "push " + projectFullName, QStringLiteral( "Transaction finish accepted" ) );
 
     transaction.replyPushFinish->deleteLater();
@@ -3005,18 +3035,18 @@ void MerginApi::pushFinishReplyFinished()
     transaction.projectMetadata = data;
     transaction.version = MerginProjectMetadata::fromJson( data ).version;
 
-    //  a new diffable files suppose to have their basefile copies in .mergin
+    //  a new diffable files suppose to have their base file copies in .mergin
     for ( QString filePath : transaction.diff.localAdded )
     {
-      if ( MerginApi::isFileDiffable( filePath ) )
+      if ( isFileDiffable( filePath ) )
       {
-        QString basefile = transaction.projectDir + "/.mergin/" + filePath;
-        createPathIfNotExists( basefile );
+        QString baseFile = transaction.projectDir + "/.mergin/" + filePath;
+        createPathIfNotExists( baseFile );
 
         QString sourcePath = transaction.projectDir + "/" + filePath;
-        if ( !QFile::copy( sourcePath, basefile ) )
+        if ( !QFile::copy( sourcePath, baseFile ) )
         {
-          CoreUtils::log( "push " + projectFullName, "failed to copy new basefile for: " + filePath );
+          CoreUtils::log( "push " + projectFullName, "failed to copy new base file for: " + filePath );
         }
       }
     }
@@ -3027,16 +3057,16 @@ void MerginApi::pushFinishReplyFinished()
     {
       QString diffPath = transaction.projectDir + "/.mergin/" + merginFile.diffName;
 
-      // update basefile (unmodified file that should be equivalent to the server)
+      // update base file (unmodified file that should be equivalent to the server)
       QString basePath = transaction.projectDir + "/.mergin/" + merginFile.path;
-      bool res = GeodiffUtils::applyChangeset( basePath, diffPath );
+      const bool res = GeodiffUtils::applyChangeset( basePath, diffPath );
       if ( res )
       {
         CoreUtils::log( "push " + projectFullName, QString( "Applied %1 to base file of %2" ).arg( merginFile.diffName, merginFile.path ) );
       }
       else
       {
-        CoreUtils::log( "push " + projectFullName, QString( "Failed to apply changeset %1 to basefile %2 - error %3" ).arg( diffPath ).arg( basePath ).arg( res ) );
+        CoreUtils::log( "push " + projectFullName, QString( "Failed to apply changeset %1 to base file %2 - error %3" ).arg( diffPath ).arg( basePath ).arg( res ) );
       }
 
       // remove temporary diff files
@@ -3044,7 +3074,7 @@ void MerginApi::pushFinishReplyFinished()
         CoreUtils::log( "push " + projectFullName, "Failed to remove diff: " + diffPath );
     }
 
-    finishProjectSync( projectFullName, true );
+    finishProjectSync( projectFullName, projectId, true );
   }
   else
   {
@@ -3052,11 +3082,11 @@ void MerginApi::pushFinishReplyFinished()
     if ( r->error() == QNetworkReply::OperationCanceledError )
       serverMsg = sSyncCanceledMessage;
 
-    QString message = QStringLiteral( "Network API error: %1(): %2. %3" ).arg( QStringLiteral( "pushFinish" ), r->errorString(), serverMsg );
+    const QString message = QStringLiteral( "Network API error: %1(): %2. %3" ).arg( QStringLiteral( "pushFinish" ), r->errorString(), serverMsg );
     CoreUtils::log( "push " + projectFullName, QStringLiteral( "FAILED - %1" ).arg( message ) );
 
-    int httpCode = r->attribute( QNetworkRequest::HttpStatusCodeAttribute ).toInt();
-    emit networkErrorOccurred( serverMsg, QStringLiteral( "Mergin API error: pushFinish" ), httpCode, projectFullName );
+    const int httpCode = r->attribute( QNetworkRequest::HttpStatusCodeAttribute ).toInt();
+    emit networkErrorOccurred( serverMsg, httpCode, projectId );
 
     // remove temporary diff files
     const auto diffFiles = transaction.pushDiffFiles;
@@ -3070,7 +3100,7 @@ void MerginApi::pushFinishReplyFinished()
     transaction.replyPushFinish->deleteLater();
     transaction.replyPushFinish = nullptr;
 
-    finishProjectSync( projectFullName, false );
+    finishProjectSync( projectFullName, projectId, false );
   }
 }
 
@@ -3079,7 +3109,8 @@ void MerginApi::pushCancelReplyFinished()
   QNetworkReply *r = qobject_cast<QNetworkReply *>( sender() );
   Q_ASSERT( r );
 
-  QString projectFullName = r->request().attribute( static_cast<QNetworkRequest::Attribute>( AttrProjectFullName ) ).toString();
+  const QString projectId = r->request().attribute( static_cast<QNetworkRequest::Attribute>( AttrProjectId ) ).toString();
+  const QString projectFullName = mLocalProjects.projectFromProjectId( projectId ).fullName();
 
   if ( r->error() == QNetworkReply::NoError )
   {
@@ -3088,11 +3119,11 @@ void MerginApi::pushCancelReplyFinished()
   else
   {
     QString serverMsg = extractServerErrorMsg( r->readAll() );
-    QString message = QStringLiteral( "Network API error: %1(): %2. %3" ).arg( QStringLiteral( "uploadCancel" ), r->errorString(), serverMsg );
+    const QString message = QStringLiteral( "Network API error: %1(): %2. %3" ).arg( QStringLiteral( "uploadCancel" ), r->errorString(), serverMsg );
     CoreUtils::log( "push " + projectFullName, QStringLiteral( "FAILED - %1" ).arg( message ) );
   }
 
-  emit pushCanceled( projectFullName, r->error() == QNetworkReply::NoError );
+  emit pushCanceled( projectId );
 
   r->deleteLater();
 }
@@ -3131,7 +3162,7 @@ void MerginApi::getUserInfoFinished()
   else
   {
     QString serverMsg = extractServerErrorMsg( r->readAll() );
-    QString message = QStringLiteral( "Network API error: %1(): %2. %3" ).arg( QStringLiteral( "getUserInfo" ), r->errorString(), serverMsg );
+    const QString message = QStringLiteral( "Network API error: %1(): %2. %3" ).arg( QStringLiteral( "getUserInfo" ), r->errorString(), serverMsg );
     CoreUtils::log( "user info", QStringLiteral( "FAILED - %1" ).arg( message ) );
 
     // This is an ugly fix for #3261: if the user was logged in, but the token was already expired
@@ -3149,7 +3180,7 @@ void MerginApi::getUserInfoFinished()
     }
     else
     {
-      emit networkErrorOccurred( serverMsg, QStringLiteral( "Mergin API error: getUserInfo" ) );
+      emit networkErrorOccurred( serverMsg );
     }
   }
 
@@ -3166,10 +3197,10 @@ void MerginApi::getWorkspaceInfoReplyFinished()
   if ( r->error() == QNetworkReply::NoError )
   {
     CoreUtils::log( "workspace info", QStringLiteral( "Success" ) );
-    QJsonDocument doc = QJsonDocument::fromJson( r->readAll() );
+    const QJsonDocument doc = QJsonDocument::fromJson( r->readAll() );
     if ( doc.isObject() )
     {
-      QJsonObject docObj = doc.object();
+      const QJsonObject docObj = doc.object();
       mWorkspaceInfo->setFromJson( docObj );
 
       emit getWorkspaceInfoFinished();
@@ -3178,10 +3209,10 @@ void MerginApi::getWorkspaceInfoReplyFinished()
   else
   {
     QString serverMsg = extractServerErrorMsg( r->readAll() );
-    QString message = QStringLiteral( "Network API error: %1(): %2. %3" ).arg( QStringLiteral( "getWorkspaceInfo" ), r->errorString(), serverMsg );
+    const QString message = QStringLiteral( "Network API error: %1(): %2. %3" ).arg( QStringLiteral( "getWorkspaceInfo" ), r->errorString(), serverMsg );
     CoreUtils::log( "workspace info", QStringLiteral( "FAILED - %1" ).arg( message ) );
     mWorkspaceInfo->clear();
-    emit networkErrorOccurred( serverMsg, QStringLiteral( "Mergin API error: getWorkspaceInfo" ) );
+    emit networkErrorOccurred( serverMsg );
   }
 
   r->deleteLater();
@@ -3191,7 +3222,7 @@ bool MerginApi::hasLocalChanges(
   const QList<MerginFile> &oldServerFiles,
   const QList<MerginFile> &localFiles,
   const QString &projectDir,
-  const MerginConfig config
+  const MerginConfig &config
 )
 {
   QList<MerginFile> resolvedOldServerFiles;
@@ -3224,7 +3255,7 @@ bool MerginApi::hasLocalChanges(
   for ( const MerginFile &localFile : localFiles )
   {
     QString filePath = localFile.path;
-    bool hasOldServer = oldServerFilesMap.contains( localFile.path );
+    const bool hasOldServer = oldServerFilesMap.contains( localFile.path );
 
     if ( !hasOldServer )
     {
@@ -3480,7 +3511,7 @@ MerginProject MerginApi::parseProjectMetadata( const QJsonObject &proj )
     project.serverVersion = versionStr.toInt();
   }
 
-  QDateTime updated = QDateTime::fromString( proj.value( QStringLiteral( "updated" ) ).toString(), Qt::ISODateWithMs ).toUTC();
+  const QDateTime updated = QDateTime::fromString( proj.value( QStringLiteral( "updated" ) ).toString(), Qt::ISODateWithMs ).toUTC();
   if ( !updated.isValid() )
   {
     project.serverUpdated = QDateTime::fromString( proj.value( QStringLiteral( "created" ) ).toString(), Qt::ISODateWithMs ).toUTC();
@@ -3503,14 +3534,14 @@ MerginProjectsList MerginApi::parseProjectsFromJson( const QJsonDocument &doc )
 
   if ( object.contains( "projects" ) && object.value( "projects" ).isArray() ) // listProjects API
   {
-    QJsonArray vArray = object.value( "projects" ).toArray();
+    const QJsonArray vArray = object.value( "projects" ).toArray();
 
     for ( auto it = vArray.constBegin(); it != vArray.constEnd(); ++it )
     {
       result << parseProjectMetadata( it->toObject() );
     }
   }
-  else if ( !object.isEmpty() ) // listProjectsbyName API returns projects as separate objects not in array
+  else if ( !object.isEmpty() ) // listProjectsByName API returns projects as separate objects not in array
   {
     for ( auto it = object.begin(); it != object.end(); ++it )
     {
@@ -3518,7 +3549,7 @@ MerginProjectsList MerginApi::parseProjectsFromJson( const QJsonDocument &doc )
       if ( !project.remoteError.isEmpty() )
       {
         // add project namespace/name from object name in case of error
-        MerginApi::extractProjectName( it.key(), project.projectNamespace, project.projectName );
+        CoreUtils::extractProjectName( it.key(), project.projectNamespace, project.projectName );
       }
       result << project;
     }
@@ -3550,9 +3581,9 @@ void MerginApi::refreshAuthToken()
   }
 }
 
-QStringList MerginApi::generateChunkIdsForSize( qint64 fileSize )
+QStringList MerginApi::generateChunkIdsForSize( const qint64 fileSize )
 {
-  qreal rawNoOfChunks = qreal( fileSize ) / UPLOAD_CHUNK_SIZE;
+  const qreal rawNoOfChunks = static_cast<qreal>( fileSize ) / UPLOAD_CHUNK_SIZE;
   int noOfChunks = qCeil( rawNoOfChunks );
 
   // edge case when file is empty, filesize equals zero
@@ -3608,20 +3639,20 @@ QJsonArray MerginApi::prepareUploadChangesJSON( const QList<MerginFile> &files )
   return jsonArray;
 }
 
-void MerginApi::finishProjectSync( const QString &projectFullName, bool syncSuccessful )
+void MerginApi::finishProjectSync( const QString &projectFullName, const QString &projectId, const bool syncSuccessful )
 {
-  Q_ASSERT( mTransactionalStatus.contains( projectFullName ) );
-  TransactionStatus &transaction = mTransactionalStatus[projectFullName];
+  Q_ASSERT( mTransactionalStatus.contains( projectId ) );
+  const TransactionStatus &transaction = mTransactionalStatus[projectId];
 
-  emit syncProjectStatusChanged( projectFullName, -1 );   // -1 means there's no sync going on
+  emit syncProjectStatusChanged( projectId, -1 );   // -1 means there's no sync going on
 
   if ( syncSuccessful )
   {
     // update the local metadata file
-    writeData( transaction.projectMetadata, transaction.projectDir + "/" + MerginApi::sMetadataFile );
+    writeData( transaction.projectMetadata, transaction.projectDir + "/" + sMetadataFile );
 
     // update info of local projects
-    mLocalProjects.updateLocalVersion( transaction.projectDir, transaction.version );
+    mLocalProjects.updateLocalVersion( projectId, transaction.version );
 
     CoreUtils::log( "sync " + projectFullName, QStringLiteral( "### Finished ###  New project version: %1\n" ).arg( transaction.version ) );
   }
@@ -3630,33 +3661,31 @@ void MerginApi::finishProjectSync( const QString &projectFullName, bool syncSucc
     CoreUtils::log( "sync " + projectFullName, QStringLiteral( "### FAILED ###\n" ) );
   }
 
-  bool pullBeforePush = transaction.pullBeforePush;
+  const bool pullBeforePush = transaction.pullBeforePush;
   QString projectDir = transaction.projectDir;  // keep it before the transaction gets removed
-  ProjectDiff diff = transaction.diff;
-  int newVersion = syncSuccessful ? transaction.version : -1;
+  const ProjectDiff diff = transaction.diff;
+  const int newVersion = syncSuccessful ? transaction.version : -1;
 
   if ( transaction.gpkgSchemaChanged || projectFileHasBeenUpdated( diff ) )
   {
-    emit projectReloadNeededAfterSync( projectFullName );
+    emit projectReloadNeededAfterSync( projectId );
   }
 
-  mTransactionalStatus.remove( projectFullName );
+  mTransactionalStatus.remove( projectId );
 
   if ( pullBeforePush )
   {
     CoreUtils::log( "sync " + projectFullName, QStringLiteral( "Continue with push after pull" ) );
     // we're done only with the download part before the actual upload - so let's continue with upload
-    QString projectNamespace, projectName;
-    extractProjectName( projectFullName, projectNamespace, projectName );
-    pushProject( projectNamespace, projectName );
+    pushProject( projectFullName, projectId );
   }
   else
   {
-    emit syncProjectFinished( projectFullName, syncSuccessful, newVersion );
+    emit syncProjectFinished( projectId, syncSuccessful, newVersion );
 
     if ( syncSuccessful )
     {
-      emit projectDataChanged( projectFullName );
+      emit projectDataChanged( projectFullName, projectId );
     }
   }
 }
@@ -3676,25 +3705,25 @@ bool MerginApi::writeData( const QByteArray &data, const QString &path )
   return true;
 }
 
-bool MerginApi::updateCachedProjectRole( const QString &projectFullName, const QString &newRole )
+bool MerginApi::updateCachedProjectRole( const QString &projectId, const QString &newRole ) const
 {
-  LocalProject project = mLocalProjects.projectFromMerginName( projectFullName );
+  const LocalProject project = mLocalProjects.projectFromProjectId( projectId );
   if ( !project.isValid() )
   {
     return false;
   }
 
-  QString metadataPath = project.projectDir + "/" + sMetadataFile;
+  const QString metadataPath = project.projectDir + "/" + sMetadataFile;
   return CoreUtils::replaceValueInJson( metadataPath, "role", newRole );
 }
 
 void MerginApi::createPathIfNotExists( const QString &filePath )
 {
-  QDir dir;
+  const QDir dir;
   if ( !dir.exists( mDataDir ) )
     dir.mkpath( mDataDir );
 
-  QFileInfo newFile( filePath );
+  const QFileInfo newFile( filePath );
   if ( !newFile.absoluteDir().exists() )
   {
     if ( !dir.mkpath( newFile.absolutePath() ) )
@@ -3713,9 +3742,9 @@ bool MerginApi::excludeFromSync( const QString &filePath, const MerginConfig &co
 {
   if ( config.isValid && config.selectiveSyncEnabled )
   {
-    QFileInfo info( filePath );
+    const QFileInfo info( filePath );
 
-    bool isExcludedFormat = sIgnoreImageExtensions.contains( info.suffix().toLower() );
+    const bool isExcludedFormat = sIgnoreImageExtensions.contains( info.suffix().toLower() );
 
     if ( !isExcludedFormat )
       return false;
@@ -3724,7 +3753,7 @@ bool MerginApi::excludeFromSync( const QString &filePath, const MerginConfig &co
     {
       return true; // we are ignoring photos in the entire project
     }
-    else if ( filePath.startsWith( config.selectiveSyncDir ) )
+    if ( filePath.startsWith( config.selectiveSyncDir ) )
     {
       return true; // we are ignoring photo in subfolder
     }
@@ -3732,16 +3761,16 @@ bool MerginApi::excludeFromSync( const QString &filePath, const MerginConfig &co
   return false;
 }
 
-QSet<QString> MerginApi::listFiles( const QString &path )
+QSet<QString> MerginApi::listFiles( const QString &projectPath )
 {
   QSet<QString> files;
-  QDirIterator it( path, QStringList() << QStringLiteral( "*" ), QDir::Files, QDirIterator::Subdirectories );
+  QDirIterator it( projectPath, QStringList() << QStringLiteral( "*" ), QDir::Files, QDirIterator::Subdirectories );
   while ( it.hasNext() )
   {
     it.next();
     if ( !isInIgnore( it.fileInfo() ) )
     {
-      files << it.filePath().replace( path, "" );
+      files << it.filePath().replace( projectPath, "" );
     }
   }
   return files;
@@ -3755,10 +3784,10 @@ void MerginApi::deleteAccount()
   }
 
   QNetworkRequest request = getDefaultRequest();
-  QUrl url( mApiRoot + QStringLiteral( "/v1/user" ) );
+  const QUrl url( mApiRoot + QStringLiteral( "/v1/user" ) );
   request.setUrl( url );
-  QNetworkReply *reply = mManager->deleteResource( request );
-  connect( reply, &QNetworkReply::finished, this, [this]() { this->deleteAccountFinished();} );
+  const QNetworkReply *reply = mManager->deleteResource( request );
+  connect( reply, &QNetworkReply::finished, this, [this] { this->deleteAccountFinished();} );
   CoreUtils::log( "delete account " + mUserInfo->username(), QStringLiteral( "Requesting account deletion: " ) + url.toString() );
 }
 
@@ -3772,11 +3801,7 @@ void MerginApi::deleteAccountFinished()
     CoreUtils::log( "delete account " + mUserInfo->username(), QStringLiteral( "Success" ) );
 
     // remove all local projects from the device
-    LocalProjectsList projects = mLocalProjects.projects();
-    for ( const LocalProject &info : projects )
-    {
-      mLocalProjects.removeLocalProject( info.id() );
-    }
+    mLocalProjects.projects().clear();
 
     clearAuth();
 
@@ -3784,8 +3809,8 @@ void MerginApi::deleteAccountFinished()
   }
   else
   {
-    int statusCode = r->attribute( QNetworkRequest::HttpStatusCodeAttribute ).toInt();
-    QString serverMsg = extractServerErrorMsg( r->readAll() );
+    const int statusCode = r->attribute( QNetworkRequest::HttpStatusCodeAttribute ).toInt();
+    const QString serverMsg = extractServerErrorMsg( r->readAll() );
     CoreUtils::log( "delete account " + mUserInfo->username(), QStringLiteral( "FAILED - %1 %2. %3" ).arg( statusCode ).arg( r->errorString() ).arg( serverMsg ) );
     if ( statusCode == 422 )
     {
@@ -3793,7 +3818,7 @@ void MerginApi::deleteAccountFinished()
     }
     else
     {
-      emit networkErrorOccurred( serverMsg, QStringLiteral( "Mergin API error: deleteAccount" ) );
+      emit networkErrorOccurred( serverMsg );
     }
 
     emit accountDeleted( false );
@@ -3805,11 +3830,11 @@ void MerginApi::deleteAccountFinished()
 void MerginApi::getServerConfig()
 {
   QNetworkRequest request = getDefaultRequest();
-  QString urlString = mApiRoot + QStringLiteral( "/config" );
-  QUrl url( urlString );
+  const QString urlString = mApiRoot + QStringLiteral( "/config" );
+  const QUrl url( urlString );
   request.setUrl( url );
 
-  QNetworkReply *reply = mManager->get( request );
+  const QNetworkReply *reply = mManager->get( request );
 
   connect( reply, &QNetworkReply::finished, this, &MerginApi::getServerConfigReplyFinished );
   CoreUtils::log( "Config", QStringLiteral( "Requesting server configuration: " ) + url.toString() );
@@ -3823,14 +3848,14 @@ void MerginApi::getServerConfigReplyFinished()
   if ( r->error() == QNetworkReply::NoError )
   {
     CoreUtils::log( "Config", QStringLiteral( "Success" ) );
-    QJsonDocument doc = QJsonDocument::fromJson( r->readAll() );
+    const QJsonDocument doc = QJsonDocument::fromJson( r->readAll() );
     if ( doc.isObject() )
     {
-      QString serverType = doc.object().value( QStringLiteral( "server_type" ) ).toString();
-      QString apiVersion = doc.object().value( QStringLiteral( "version" ) ).toString();
+      const QString serverType = doc.object().value( QStringLiteral( "server_type" ) ).toString();
+      const QString apiVersion = doc.object().value( QStringLiteral( "version" ) ).toString();
       int major = -1;
       int minor = -1;
-      bool validVersion = parseVersion( apiVersion, major, minor );
+      const bool validVersion = parseVersion( apiVersion, major, minor );
 
       if ( !validVersion )
       {
@@ -3874,7 +3899,7 @@ void MerginApi::getServerConfigReplyFinished()
   }
   else
   {
-    int statusCode = r->attribute( QNetworkRequest::HttpStatusCodeAttribute ).toInt();
+    const int statusCode = r->attribute( QNetworkRequest::HttpStatusCodeAttribute ).toInt();
     if ( statusCode == 404 ) // legacy (old) server
     {
       setServerType( MerginServerType::OLD );
@@ -3883,8 +3908,8 @@ void MerginApi::getServerConfigReplyFinished()
     else
     {
       QString serverMsg = extractServerErrorMsg( r->readAll() );
-      QString message = QStringLiteral( "Network API error: %1(): %2. %3" ).arg( QStringLiteral( "getServerType" ), r->errorString(), serverMsg );
-      emit networkErrorOccurred( serverMsg, QStringLiteral( "Mergin API error: getServerType" ) );
+      const QString message = QStringLiteral( "Network API error: %1(): %2. %3" ).arg( QStringLiteral( "getServerType" ), r->errorString(), serverMsg );
+      emit networkErrorOccurred( serverMsg );
       CoreUtils::log( "server type", QStringLiteral( "FAILED - %1" ).arg( message ) );
     }
   }
@@ -3924,11 +3949,11 @@ void MerginApi::listWorkspaces()
     return;
   }
 
-  QUrl url( mApiRoot + QStringLiteral( "/v1/workspaces" ) );
+  const QUrl url( mApiRoot + QStringLiteral( "/v1/workspaces" ) );
   QNetworkRequest request = getDefaultRequest( mUserAuth->hasAuthData() );
   request.setUrl( url );
 
-  QNetworkReply *reply = mManager->get( request );
+  const QNetworkReply *reply = mManager->get( request );
   CoreUtils::log( "list workspaces", QStringLiteral( "Requesting: " ) + url.toString() );
   connect( reply, &QNetworkReply::finished, this, &MerginApi::listWorkspacesReplyFinished );
 }
@@ -3941,11 +3966,11 @@ void MerginApi::listWorkspacesReplyFinished()
   if ( r->error() == QNetworkReply::NoError )
   {
     CoreUtils::log( "list workspaces", QStringLiteral( "Success" ) );
-    QJsonDocument doc = QJsonDocument::fromJson( r->readAll() );
+    const QJsonDocument doc = QJsonDocument::fromJson( r->readAll() );
     if ( doc.isArray() )
     {
       QMap<int, QString> workspaces;
-      QJsonArray array = doc.array();
+      const QJsonArray array = doc.array();
       for ( auto it = array.constBegin(); it != array.constEnd(); ++it )
       {
         QJsonObject ws = it->toObject();
@@ -3964,9 +3989,9 @@ void MerginApi::listWorkspacesReplyFinished()
   else
   {
     QString serverMsg = extractServerErrorMsg( r->readAll() );
-    QString message = QStringLiteral( "Network API error: %1(): %2. %3" ).arg( QStringLiteral( "listWorkspaces" ), r->errorString(), serverMsg );
+    const QString message = QStringLiteral( "Network API error: %1(): %2. %3" ).arg( QStringLiteral( "listWorkspaces" ), r->errorString(), serverMsg );
     CoreUtils::log( "list workspaces", QStringLiteral( "FAILED - %1" ).arg( message ) );
-    emit networkErrorOccurred( serverMsg, QStringLiteral( "Mergin API error: listWorkspaces" ) );
+    emit networkErrorOccurred( serverMsg );
     emit listWorkspacesFailed();
   }
 
@@ -3981,11 +4006,11 @@ void MerginApi::listInvitations()
     return;
   }
 
-  QUrl url( mApiRoot + QStringLiteral( "/v1/workspace/invitations" ) );
+  const QUrl url( mApiRoot + QStringLiteral( "/v1/workspace/invitations" ) );
   QNetworkRequest request = getDefaultRequest( mUserAuth->hasAuthData() );
   request.setUrl( url );
 
-  QNetworkReply *reply = mManager->get( request );
+  const QNetworkReply *reply = mManager->get( request );
   CoreUtils::log( "list invitations", QStringLiteral( "Requesting: " ) + url.toString() );
   connect( reply, &QNetworkReply::finished, this, &MerginApi::listInvitationsReplyFinished );
 }
@@ -3998,11 +4023,11 @@ void MerginApi::listInvitationsReplyFinished()
   if ( r->error() == QNetworkReply::NoError )
   {
     CoreUtils::log( "list invitations", QStringLiteral( "Success" ) );
-    QJsonDocument doc = QJsonDocument::fromJson( r->readAll() );
+    const QJsonDocument doc = QJsonDocument::fromJson( r->readAll() );
     if ( doc.isArray() )
     {
       QList<MerginInvitation> invitations;
-      QJsonArray array = doc.array();
+      const QJsonArray array = doc.array();
       for ( auto it = array.constBegin(); it != array.constEnd(); ++it )
       {
         MerginInvitation invite = MerginInvitation::fromJsonObject( it->toObject() );
@@ -4019,16 +4044,16 @@ void MerginApi::listInvitationsReplyFinished()
   else
   {
     QString serverMsg = extractServerErrorMsg( r->readAll() );
-    QString message = QStringLiteral( "Network API error: %1(): %2. %3" ).arg( QStringLiteral( "listInvitations" ), r->errorString(), serverMsg );
+    const QString message = QStringLiteral( "Network API error: %1(): %2. %3" ).arg( QStringLiteral( "listInvitations" ), r->errorString(), serverMsg );
     CoreUtils::log( "list invitations", QStringLiteral( "FAILED - %1" ).arg( message ) );
-    emit networkErrorOccurred( serverMsg, QStringLiteral( "Mergin API error: listInvitations" ) );
+    emit networkErrorOccurred( serverMsg );
     emit listInvitationsFailed();
   }
 
   r->deleteLater();
 }
 
-void MerginApi::processInvitation( const QString &uuid, bool accept )
+void MerginApi::processInvitation( const QString &uuid, const bool accept )
 {
   if ( !validateAuth() || mApiVersionStatus != MerginApiStatus::OK )
   {
@@ -4037,8 +4062,8 @@ void MerginApi::processInvitation( const QString &uuid, bool accept )
   }
 
   QNetworkRequest request = getDefaultRequest( true );
-  QString urlString = mApiRoot + QStringLiteral( "/v1/workspace/invitation/%1" ).arg( uuid );
-  QUrl url( urlString );
+  const QString urlString = mApiRoot + QStringLiteral( "/v1/workspace/invitation/%1" ).arg( uuid );
+  const QUrl url( urlString );
   request.setUrl( url );
   request.setRawHeader( "Content-Type", "application/json" );
   request.setAttribute( static_cast<QNetworkRequest::Attribute>( AttrAcceptFlag ), accept );
@@ -4047,8 +4072,8 @@ void MerginApi::processInvitation( const QString &uuid, bool accept )
   QJsonObject jsonObject;
   jsonObject.insert( QStringLiteral( "accept" ), accept );
   jsonDoc.setObject( jsonObject );
-  QByteArray json = jsonDoc.toJson( QJsonDocument::Compact );
-  QNetworkReply *reply = mManager->post( request, json );
+  const QByteArray json = jsonDoc.toJson( QJsonDocument::Compact );
+  const QNetworkReply *reply = mManager->post( request, json );
   CoreUtils::log( "process invitation", QStringLiteral( "Requesting: " ) + url.toString() );
   connect( reply, &QNetworkReply::finished, this, &MerginApi::processInvitationReplyFinished );
 }
@@ -4058,7 +4083,7 @@ void MerginApi::processInvitationReplyFinished()
   QNetworkReply *r = qobject_cast<QNetworkReply *>( sender() );
   Q_ASSERT( r );
 
-  bool accept = r->request().attribute( static_cast<QNetworkRequest::Attribute>( AttrAcceptFlag ) ).toBool();
+  const bool accept = r->request().attribute( static_cast<QNetworkRequest::Attribute>( AttrAcceptFlag ) ).toBool();
 
   if ( r->error() == QNetworkReply::NoError )
   {
@@ -4067,9 +4092,9 @@ void MerginApi::processInvitationReplyFinished()
   else
   {
     QString serverMsg = extractServerErrorMsg( r->readAll() );
-    QString message = QStringLiteral( "Network API error: %1(): %2. %3" ).arg( QStringLiteral( "processInvitation" ), r->errorString(), serverMsg );
+    const QString message = QStringLiteral( "Network API error: %1(): %2. %3" ).arg( QStringLiteral( "processInvitation" ), r->errorString(), serverMsg );
     CoreUtils::log( "process invitation", QStringLiteral( "FAILED - %1" ).arg( message ) );
-    emit networkErrorOccurred( serverMsg, QStringLiteral( "Mergin API error: processInvitation" ) );
+    emit networkErrorOccurred( serverMsg );
     emit processInvitationFailed();
   }
 
@@ -4082,6 +4107,7 @@ bool MerginApi::createWorkspace( const QString &workspaceName )
 {
   if ( !validateAuth() )
   {
+    // TODO: this error slot will never react as it expects projectId
     emit missingAuthorizationError( workspaceName );
     return false;
   }
@@ -4098,7 +4124,7 @@ bool MerginApi::createWorkspace( const QString &workspaceName )
   }
 
   QNetworkRequest request = getDefaultRequest();
-  QUrl url( mApiRoot + QString( "/v1/workspace" ) );
+  const QUrl url( mApiRoot + QString( "/v1/workspace" ) );
   request.setUrl( url );
   request.setRawHeader( "Content-Type", "application/json" );
   request.setRawHeader( "Accept", "application/json" );
@@ -4108,9 +4134,9 @@ bool MerginApi::createWorkspace( const QString &workspaceName )
   QJsonObject jsonObject;
   jsonObject.insert( QStringLiteral( "name" ), workspaceName );
   jsonDoc.setObject( jsonObject );
-  QByteArray json = jsonDoc.toJson( QJsonDocument::Compact );
+  const QByteArray json = jsonDoc.toJson( QJsonDocument::Compact );
 
-  QNetworkReply *reply = mManager->post( request, json );
+  const QNetworkReply *reply = mManager->post( request, json );
   connect( reply, &QNetworkReply::finished, this, &MerginApi::createWorkspaceReplyFinished );
   CoreUtils::log( "create " + workspaceName, QStringLiteral( "Requesting workspace creation: " ) + url.toString() );
 
@@ -4143,7 +4169,7 @@ void MerginApi::createWorkspaceReplyFinished()
   QNetworkReply *r = qobject_cast<QNetworkReply *>( sender() );
   Q_ASSERT( r );
 
-  QString workspaceName = r->request().attribute( static_cast<QNetworkRequest::Attribute>( AttrWorkspaceName ) ).toString();
+  const QString workspaceName = r->request().attribute( static_cast<QNetworkRequest::Attribute>( AttrWorkspaceName ) ).toString();
 
   if ( r->error() == QNetworkReply::NoError )
   {
@@ -4153,51 +4179,48 @@ void MerginApi::createWorkspaceReplyFinished()
   else
   {
     QString serverMsg = extractServerErrorMsg( r->readAll() );
-    QString message = QStringLiteral( "FAILED - %1: %2" ).arg( r->errorString(), serverMsg );
+    const QString message = QStringLiteral( "FAILED - %1: %2" ).arg( r->errorString(), serverMsg );
     CoreUtils::log( "create " + workspaceName, message );
 
-    int httpCode = r->attribute( QNetworkRequest::HttpStatusCodeAttribute ).toInt();
+    const int httpCode = r->attribute( QNetworkRequest::HttpStatusCodeAttribute ).toInt();
 
     if ( httpCode == 409 )
     {
-      emit networkErrorOccurred( tr( "Workspace %1 already exists" ).arg( workspaceName ), QStringLiteral( "Mergin API error: createWorkspace" ), httpCode, workspaceName );
+      emit networkErrorOccurred( tr( "Workspace %1 already exists" ).arg( workspaceName ), httpCode );
     }
     else
     {
-      emit networkErrorOccurred( serverMsg, QStringLiteral( "Mergin API error: createWorkspace" ), httpCode, workspaceName );
+      emit networkErrorOccurred( serverMsg, httpCode );
     }
   }
   r->deleteLater();
 }
 
-bool MerginApi::apiSupportsWorkspaces()
+bool MerginApi::apiSupportsWorkspaces() const
 {
   if ( mServerType == MerginServerType::SAAS || mServerType == MerginServerType::EE )
   {
     return true;
   }
-  else
-  {
-    return false;
-  }
+  return false;
 }
 
-DownloadQueueItem::DownloadQueueItem( const QString &fp, qint64 s, int v, qint64 rf, qint64 rt, bool diff )
+DownloadQueueItem::DownloadQueueItem( const QString &fp, const qint64 s, const int v, const qint64 rf, const qint64 rt, const bool diff )
   : filePath( fp ), size( s ), version( v ), rangeFrom( rf ), rangeTo( rt ), downloadDiff( diff )
 {
   tempFileName = CoreUtils::uuidWithoutBraces( QUuid::createUuid() );
 }
 
-void MerginApi::reloadProjectRole( const QString &projectFullName )
+void MerginApi::reloadProjectRole( const QString &projectId )
 {
-  if ( projectFullName.isEmpty() )
+  if ( projectId.isEmpty() )
     return;
 
-  QNetworkReply *reply = getProjectInfo( projectFullName, mUserAuth->hasAuthData() );
+  //withAuth depends on whether user is logged in or not
+  const QNetworkReply *reply = getProjectDetails( projectId, mUserAuth->hasAuthData() );
   if ( !reply )
     return;
 
-  reply->request().setAttribute( static_cast<QNetworkRequest::Attribute>( AttrProjectFullName ), projectFullName );
   connect( reply, &QNetworkReply::finished, this, &MerginApi::reloadProjectRoleReplyFinished );
 }
 
@@ -4206,38 +4229,38 @@ void MerginApi::reloadProjectRoleReplyFinished()
   QNetworkReply *r = qobject_cast<QNetworkReply *>( sender() );
   Q_ASSERT( r );
 
-  QString projectFullName = r->request().attribute( static_cast<QNetworkRequest::Attribute>( AttrProjectFullName ) ).toString();
-  QString cachedRole = MerginApi::getCachedProjectRole( projectFullName );
+  const QString projectId = r->request().attribute( static_cast<QNetworkRequest::Attribute>( AttrProjectId ) ).toString();
+  const QString cachedRole = getCachedProjectRole( projectId );
 
   if ( r->error() == QNetworkReply::NoError )
   {
-    QByteArray data = r->readAll();
-    MerginProjectMetadata serverProject = MerginProjectMetadata::fromJson( data );
-    QString role = serverProject.role;
+    const QByteArray data = r->readAll();
+    const MerginProjectMetadata serverProject = MerginProjectMetadata::fromJson( data );
+    const QString role = serverProject.role;
 
     if ( role != cachedRole )
     {
-      if ( updateCachedProjectRole( projectFullName, role ) )
-        emit projectRoleUpdated( projectFullName, role );
+      if ( updateCachedProjectRole( projectId, role ) )
+        emit projectRoleUpdated( projectId, role );
     }
   }
   else
   {
-    CoreUtils::log( "Metadata", QString( "Failed to update cached role for project %1 - likely due to missing auth or you are offline" ).arg( projectFullName ) );
+    CoreUtils::log( "Metadata", QString( "Failed to update cached role for project %1 - likely due to missing auth or you are offline" ).arg( projectId ) );
   }
 
   r->deleteLater();
 }
 
-QString MerginApi::getCachedProjectRole( const QString &projectFullName ) const
+QString MerginApi::getCachedProjectRole( const QString &projectId ) const
 {
-  if ( projectFullName.isEmpty() )
-    return QString();
+  if ( projectId.isEmpty() )
+    return {};
 
-  QString projectDir = mLocalProjects.projectFromMerginName( projectFullName ).projectDir;
+  const QString projectDir = mLocalProjects.projectFromProjectId( projectId ).projectDir;
 
   if ( projectDir.isEmpty() )
-    return QString();
+    return {};
 
   MerginProjectMetadata cachedProjectMetadata = MerginProjectMetadata::fromCachedJson( projectDir + "/" + sMetadataFile );
 
@@ -4323,21 +4346,21 @@ void MerginApi::abortSsoFlow()
     mOauth2ReplyHandler->close();
 }
 
-bool MerginApi::isRetryableNetworkError( QNetworkReply *reply )
+bool MerginApi::isRetryableNetworkError( const QNetworkReply *reply )
 {
   Q_ASSERT( reply );
 
-  QNetworkReply::NetworkError err = reply->error();
+  const QNetworkReply::NetworkError err = reply->error();
 
-  bool isRetryableError = ( err == QNetworkReply::TimeoutError ||
-                            err == QNetworkReply::TemporaryNetworkFailureError ||
-                            err == QNetworkReply::NetworkSessionFailedError ||
-                            err == QNetworkReply::UnknownNetworkError ||
-                            err == QNetworkReply::RemoteHostClosedError ||
-                            err == QNetworkReply::ProxyConnectionClosedError ||
-                            err == QNetworkReply::ProxyTimeoutError ||
-                            err == QNetworkReply::UnknownProxyError ||
-                            err == QNetworkReply::ServiceUnavailableError );
+  const bool isRetryableError = ( err == QNetworkReply::TimeoutError ||
+                                  err == QNetworkReply::TemporaryNetworkFailureError ||
+                                  err == QNetworkReply::NetworkSessionFailedError ||
+                                  err == QNetworkReply::UnknownNetworkError ||
+                                  err == QNetworkReply::RemoteHostClosedError ||
+                                  err == QNetworkReply::ProxyConnectionClosedError ||
+                                  err == QNetworkReply::ProxyTimeoutError ||
+                                  err == QNetworkReply::UnknownProxyError ||
+                                  err == QNetworkReply::ServiceUnavailableError );
 
   return isRetryableError;
 }

--- a/core/merginapi.cpp
+++ b/core/merginapi.cpp
@@ -1380,7 +1380,6 @@ void MerginApi::createProjectFinished()
     {
       emit notifyError( tr( "Couldn't create the project. Please try again later or contact support if the problem persists." ) );
       emit projectCreationFailed();
-      emit networkErrorOccurred( serverMsg, QStringLiteral( "Mergin API error: createProject" ), httpCode, projectId );
     }
   }
   r->deleteLater();

--- a/core/merginapi.h
+++ b/core/merginapi.h
@@ -12,22 +12,15 @@
 
 #include <memory>
 
-#include <QObject>
-#include <QNetworkAccessManager>
 #include <QNetworkReply>
 #include <QEventLoop>
-#include <QFile>
-#include <QFileInfo>
-#include <QUuid>
 #include <QPointer>
 #include <QSet>
 #include <QByteArray>
-#include <QDateTime>
 #include <QOAuth2AuthorizationCodeFlow>
 
 #include "merginapistatus.h"
 #include "merginservertype.h"
-#include "merginsubscriptionstatus.h"
 #include "merginerrortypes.h"
 #include "merginprojectmetadata.h"
 #include "localprojectsmanager.h"
@@ -175,7 +168,7 @@ struct TransactionStatus
 
   // retry handling
   int retryCount = 0;  //!< current number of retry attempts for failed network requests
-  static const int MAX_RETRY_COUNT = 5;  //!< maximum number of retry attempts for failed network requests
+  static constexpr int MAX_RETRY_COUNT = 5;  //!< maximum number of retry attempts for failed network requests
 
   QString projectDir;
   QByteArray projectMetadata;  //!< metadata of the new project (not parsed)
@@ -230,7 +223,7 @@ class MerginApi: public QObject
   public:
 
     explicit MerginApi( LocalProjectsManager &localProjects, QObject *parent = nullptr );
-    ~MerginApi() = default;
+    ~MerginApi() override = default;
 
     MerginUserAuth *userAuth() const;
     MerginUserInfo *userInfo() const;
@@ -239,7 +232,7 @@ class MerginApi: public QObject
 
     /**
      * Returns path of the local directory in which all projects are stored.
-     * Each project is one sub-directory.
+     * Each project is one subdirectory.
      * \note returns the directory without a trailing slash
      */
     QString projectsPath() const { return mDataDir; }
@@ -253,62 +246,62 @@ class MerginApi: public QObject
      * for "exploring" all public projects. However, it can be applied to fetch more results.
      * Eventually emits listProjectsFinished on which ProjectPanel (qml component) updates content.
      * \param searchExpression Search filter on projects name.
-     * \param flag If defined, it is used to filter out projects tagged as 'created' or 'shared' with a authorized user
+     * \param flag If defined, it is used to filter out projects tagged as 'created' or 'shared' with an authorized user
      * \param page Requested page of projects.
      * \returns unique id of a request
      */
-    Q_INVOKABLE QString listProjects( const QString &searchExpression = QStringLiteral(),
-                                      const QString &flag = QStringLiteral(),
-                                      const int page = 1 );
+    QString listProjects( const QString &searchExpression = QString(),
+                          const QString &flag = QString(),
+                          int page = 1 );
 
     /**
-     * Sends non-blocking GET request to the server to listProjectsByName API. Response is handled in listProjectsByNameFinished
-     * method. Projects are parsed from response JSON.
+     * Sends non-blocking GET request to the server to listProjectsByName API. Response is handled in
+     * listProjectsByNameFinished method. Projects are parsed from response JSON.
      *
      * \param projectNames QStringList of project full names (namespace/name)
-     * \returns unique id of a sent request
+     * \returns unique id of sent request
      */
-    Q_INVOKABLE QString listProjectsByName( const QStringList &projectNames = QStringList() );
+    QString listProjectsByName( const QStringList &projectNames = QStringList() );
 
     /**
-     * Sends non-blocking POST request to the server to pull (download) a project with a given name. On pullProjectReplyFinished,
-     * when a response is received, parses data-stream to files and rewrites local files with them. Extra files which don't match server
-     * files are removed. Emits syncProjectFinished at the end.
+     * Sends non-blocking POST request to the server to pull (download) a project with a given name.
+     * On pullProjectReplyFinished, when a response is received, parses data-stream to files and rewrites local files
+     * with them. Extra files which don't match server files are removed. Emits syncProjectFinished at the end.
      * If update has been successful, updates metadata file of the project.
-     * \param projectNamespace Project's namespace used in request.
-     * \param projectName  Project's name used in request.
+     * \param projectFullName Project's "namespace/name" full name used for requests
+     * \param projectId Project's ID used for internal processing
      * \param withAuth If True, request is constructed with current authorization
      * \return true when sync has started, false otherwise (e.g. due to a missing authorization or invalid server)
      */
-    Q_INVOKABLE bool pullProject( const QString &projectNamespace, const QString &projectName, bool withAuth = true );
+    bool pullProject( const QString &projectFullName, const QString &projectId, bool withAuth = true );
 
     /**
      * Sends non-blocking POST request to the server to push changes in a project with a given name.
-     * At the begining it checks if there are any changes on server and pulls them if so.
-     * If the pull was successful, it sends post request with list of local changes and modified/newly added files in JSON.
+     * At the beginning it checks if there are any changes on server and pulls them if so. If the pull was successful,
+     * it sends post request with list of local changes and modified/newly added files in JSON.
      * Emits syncProjectFinished at the end.
-     * \param projectNamespace Project's namespace used in request.
-     * \param projectName Project's name used in request.
+     * \param projectFullName Project's "namespace/name" full name used for requests
+     * \param projectId Project's ID used for internal processing
      * \param isInitialPush indicates if this is first push of the project (project creation)
      * \return true when sync has started, false otherwise (e.g. due to a missing authorization or invalid server)
      */
-    Q_INVOKABLE bool pushProject( const QString &projectNamespace, const QString &projectName, bool isInitialPush = false );
+    bool pushProject( const QString &projectFullName, const QString &projectId, bool isInitialPush = false );
 
     /**
      * Sends non-blocking POST request to the server to cancel a running push of a project with a given name.
-     * If push has not started yet and a client is waiting for transaction UUID, it cancels the procedure just on client side
-     * without sending cancel request to the server.
-     * \param projectFullName Project's full name to cancel its 4
+     * If push has not started yet and a client is waiting for transaction UUID, it cancels the procedure just
+     * on client side without sending cancel request to the server.
+     * \param projectId ID of project to cancel push for
      * \note pushCanceled() signal is emitted when the reply to the cancel request is received
      */
-    Q_INVOKABLE void cancelPush( const QString &projectFullName );
+    void cancelPush( const QString &projectId );
 
     /**
      * Cancels pull either (1) before project data download starts or
      * (2) when data transfer has begun - connections are aborted.
-     * \param projectFullName Project's full name to cancel
+     * \param projectId Project's ID to cancel
      */
-    Q_INVOKABLE void cancelPull( const QString &projectFullName );
+    void cancelPull( const QString &projectId );
 
     /**
     * Attempts to authorize user with the login and password
@@ -337,8 +330,8 @@ class MerginApi: public QObject
     Q_INVOKABLE void getUserInfo();
     Q_INVOKABLE void getWorkspaceInfo();
     Q_INVOKABLE void getServiceInfo();
-    Q_INVOKABLE void clearAuth();
-    Q_INVOKABLE QString resetPasswordUrl();
+    void clearAuth();
+    Q_INVOKABLE QString resetPasswordUrl() const;
 
     /**
     * Registers new user.
@@ -372,28 +365,21 @@ class MerginApi: public QObject
     Q_INVOKABLE void pingMergin();
 
     /**
-    * Uploads and registers a local project to Mergin.
-    * \param projectName Project name that will be migrated
-    * \param projectNamespace If empty, username of current user auth session is used.
-    */
-    Q_INVOKABLE void migrateProjectToMergin( const QString &projectName, const QString &projectNamespace = QString() );
-
-    /**
     * Makes a mergin project to be local by removing .mergin folder. Updates project's info and related models accordingly.
-    * \param projectNamespace Project namespace that will be detached from Mergin
-    * \param projectName Project name that will be detached from Mergin
+    * \param projectId Project id of project that will be detached from Mergin
+    * \param informUser Whether we notify user with notification about success
     */
-    Q_INVOKABLE void detachProjectFromMergin( const QString &projectNamespace, const QString &projectName, bool informUser = true );
+    void detachProjectFromMergin( const QString &projectId, bool informUser = true );
 
     /**
     * Deletes all local projects and then tries to remove user account.
     */
     Q_INVOKABLE void deleteAccount();
 
-    static const int MERGIN_API_VERSION_MAJOR = 2020;
-    static const int MERGIN_API_VERSION_MINOR = 4;
-    static const int MINIMUM_SERVER_VERSION_MAJOR = 2023;
-    static const int MINIMUM_SERVER_VERSION_MINOR = 2;
+    static constexpr int MERGIN_API_VERSION_MAJOR = 2020;
+    static constexpr int MERGIN_API_VERSION_MINOR = 4;
+    static constexpr int MINIMUM_SERVER_VERSION_MAJOR = 2023;
+    static constexpr int MINIMUM_SERVER_VERSION_MINOR = 2;
     static const QString sMetadataFile;
     static const QString sMetadataFolder;
     static const QString sMerginConfigFile;
@@ -403,9 +389,6 @@ class MerginApi: public QObject
     static QString defaultApiRoot() { return sDefaultApiRoot; }
 
     static bool isFileDiffable( const QString &fileName ) { return fileName.endsWith( ".gpkg" ); }
-
-    //! Get a list of all files that can be used with geodiff
-    QStringList projectDiffableFiles( const QString &projectFullName );
 
     static ProjectDiff localProjectChanges( const QString &projectDir );
     static bool hasLocalProjectChanges( const QString &projectDir, bool supportsSelectiveSync );
@@ -420,36 +403,20 @@ class MerginApi: public QObject
     static bool parseVersion( const QString &version, int &major, int &minor );
 
     /**
-    * Finds project in merginProjects list according its full name.
-    * \param projectPath Full path to project's folder
-    * \param metadataFile Relative path of metafile to project's folder
-    */
-    Q_INVOKABLE static QString getFullProjectName( QString projectNamespace, QString projectName );
-
-    /**
     * Creates an empty project on Mergin server. isPublic determines if the new project will be visible to all or private
-    * \param projectNamespace
-    * \param projectName
-    * \param isPublic
     * \return true when project creation has started, false otherwise (e.g. due to a missing authorization)
     */
-    bool createProject( const QString &projectNamespace, const QString &projectName, bool isPublic = false );
+    bool createProject( const QString &projectNamespace, const QString &projectName, const QString &projectId, bool isPublic = false );
 
     // Test functions
     /**
-    * Deletes the project of given namespace and name on Mergin server.
-    * Note that this deletion is not immediately done,
-    * but only scheduled to be deleted in few days.
-    *
-    * TODO - we should use DEL /v2/projects/ if possible, see
-    * TestMerginApi::deleteRemoteProjectNow()
-    *
-    * \param projectNamespace
-    * \param projectName
+    * Deletes the project of given projectId on Mergin server.
+    * \note This deletion is immediately done, if you want to schedule project for deletion use
+    * \code /v2/projects/{id}/scheduleDelete \endcode
     */
-    void deleteProject( const QString &projectNamespace, const QString &projectName, bool informUser = true );
+    void deleteProject( const QString &projectId, bool informUser = true );
 
-    LocalProject getLocalProject( const QString &projectFullName );
+    LocalProject getLocalProject( const QString &projectId ) const;
 
     // Production and Test functions (therefore not private)
 
@@ -494,7 +461,7 @@ class MerginApi: public QObject
       const QList<MerginFile> &oldServerFiles,
       const QList<MerginFile> &localFiles,
       const QString &projectDir,
-      const MerginConfig config
+      const MerginConfig &config
     );
 
     static QList<MerginFile> getLocalProjectFiles( const QString &projectPath );
@@ -513,9 +480,9 @@ class MerginApi: public QObject
 
     /**
      * Performs checks and returns if a given file is excluded from the sync.
-     * If selective-sync-enabled is true, it checks if a file extension is from exlcudeSync extension list.
-     * If selective-sync-dir is defined, additionally checks, if the file is located in selective-sync-dir or in its subdir,
-     * otherwise a project dir is considered as selective-sync-dir and therefore the path check is redundant
+     * If selective-sync-enabled is true, it checks if a file extension is from excludeSync extension list.
+     * If selective-sync-dir is defined, additionally checks, if the file is located in selective-sync-dir or in its
+     * subdir, otherwise a project dir is considered as selective-sync-dir and therefore the path check is redundant
      * (since given filePath is relative to the project dir.).
      * @param filePath Relative path of a file to project directory.
      * @param config MerginConfig parsed from JSON, selective-sync properties are read from it.
@@ -525,15 +492,6 @@ class MerginApi: public QObject
 
     bool apiSupportsSubscriptions() const;
     void setApiSupportsSubscriptions( bool apiSupportsSubscriptions );
-
-    /**
-    * Sets projectNamespace and projectName from sourceString - url or any string from which takes last (name)
-    * and the previous of last (namespace) substring after splitting sourceString with slash.
-    * \param sourceString QString either url or fullname of a project
-    * \param projectNamespace QString to be set as namespace, might not change original value
-    * \param projectName QString to be set to name of a project
-    */
-    static bool extractProjectName( const QString &sourceString, QString &projectNamespace, QString &projectName );
 
     bool supportsSelectiveSync() const;
     void setSupportsSelectiveSync( bool supportsSelectiveSync );
@@ -569,7 +527,7 @@ class MerginApi: public QObject
     void listInvitations();
 
     /**
-    * Accepts or discards an invitaion to join workspace.
+    * Accepts or discards an invitation to join workspace.
     * \param uuid Invitation UUID
     * \param accept Whether user accepted invitation
     */
@@ -594,7 +552,7 @@ class MerginApi: public QObject
     /**
      * Returns true if server supports workspaces
      */
-    bool apiSupportsWorkspaces();
+    bool apiSupportsWorkspaces() const;
 
     /**
      * Returns true if the configured server has SSO enabled
@@ -604,7 +562,7 @@ class MerginApi: public QObject
     /**
      * Reloads project metadata role by fetching latest information from server.
      */
-    Q_INVOKABLE void reloadProjectRole( const QString &projectFullName );
+    void reloadProjectRole( const QString &projectId );
 
     /**
      * Returns the network manager used for Mergin API requests
@@ -629,20 +587,19 @@ class MerginApi: public QObject
     void listProjectsFinished( const MerginProjectsList &merginProjects, int projectCount, int page, QString requestId );
     void listProjectsFailed();
     void listProjectsByNameFinished( const MerginProjectsList &merginProjects, QString requestId );
-    void syncProjectFinished( const QString &projectFullName, bool successfully, int version );
-    void projectReloadNeededAfterSync( const QString &projectFullName );
+    void syncProjectFinished( const QString &projectId, bool successfully, int version );
+    void projectReloadNeededAfterSync( const QString &projectId );
     /**
      * Emitted when sync starts/finishes or the progress changes - useful to give a clue in the GUI about the status.
      * Normally progress is in interval [0, 1] as data get pushed or pulled.
      * With no pending sync, progress is set to -1
      */
-    void syncProjectStatusChanged( const QString &projectFullName, qreal progress );
+    void syncProjectStatusChanged( const QString &projectId, qreal progress );
 
     void networkErrorOccurred(
       const QString &message,
-      const QString &topic,
       int httpCode = -1,
-      const QString &projectFullName = QLatin1String()
+      const QString &projectId = QString()
     );
 
     void storageLimitReached( qreal uploadSize );
@@ -662,8 +619,7 @@ class MerginApi: public QObject
     void postRegistrationFailed( const QString &msg );
     void apiRootChanged();
     void apiVersionStatusChanged();
-    void projectCreated( const QString &projectFullName, bool result );
-    void serverProjectDeleted( const QString &projecFullName, bool result );
+    void projectCreated( const QString &projectId, bool result );
     void userInfoChanged();
     void workspaceInfoChanged();
     void subscriptionInfoChanged();
@@ -672,13 +628,13 @@ class MerginApi: public QObject
     void pingMerginFinished( const QString &apiVersion, bool serverSupportsSubscriptions, const QString &msg );
     void pullFilesStarted();
     void pushFilesStarted();
-    void pushCanceled( const QString &projectFullName, bool result );
-    void projectDataChanged( const QString &projectFullName );
-    void projectDetached( const QString &projectFullName );
-    void projectAttachedToMergin( const QString &projectFullName, const QString &previousProjectName );
+    void pushCanceled( const QString &projectId );
+    void projectDataChanged( const QString &projectFullName, const QString &projectId );
+    void projectDetached( const QString &projectId );
+    void projectAttachedToMergin( const QString &projectId );
 
-    void projectAlreadyOnLatestVersion( const QString &projectFullName );
-    void missingAuthorizationError( const QString &projectFullName );
+    void projectAlreadyOnLatestVersion( const QString &projectId );
+    void missingAuthorizationError( const QString &projectId );
     void accountDeleted( bool result );
     void userIsAnOrgOwnerError();
 
@@ -702,11 +658,13 @@ class MerginApi: public QObject
 
     void serverWasUpgraded();
 
-    void projectRoleUpdated( const QString &projectFullName, const QString &role );
+    void projectRoleUpdated( const QString &projectId, const QString &role );
 
     void networkManagerChanged();
 
-    void downloadItemRetried( const QString &projectFullName, int retryCount );
+    void downloadItemRetried( const QString &projectId, int retryCount );
+
+    void projectIdChanged( const QString &projectFullName, QString projectId );
 
     void apiSupportsSsoChanged();
 
@@ -714,12 +672,12 @@ class MerginApi: public QObject
     void ssoConfigIsMultiTenant();
 
   private slots:
-    void listProjectsReplyFinished( QString requestId );
-    void listProjectsByNameReplyFinished( QString requestId );
+    void listProjectsReplyFinished( const QString &requestId );
+    void listProjectsByNameReplyFinished( const QString &requestId );
 
     // Pull slots
     void pullInfoReplyFinished();
-    void downloadItemReplyFinished( DownloadQueueItem item );
+    void downloadItemReplyFinished( const DownloadQueueItem &item );
     void cacheServerConfig();
 
     // Push slots
@@ -732,7 +690,7 @@ class MerginApi: public QObject
     void getUserInfoFinished();
     void getWorkspaceInfoReplyFinished();
     void getServiceInfoReplyFinished();
-    void saveAuthData();
+    void saveAuthData() const;
     void createProjectFinished();
     void deleteProjectFinished( bool informUser = true );
     void authorizeFinished();
@@ -762,32 +720,34 @@ class MerginApi: public QObject
     static QStringList generateChunkIdsForSize( qint64 fileSize );
     QJsonArray prepareUploadChangesJSON( const QList<MerginFile> &files );
     static QString getApiKey( const QString &serverName );
-    void abortPullItems( const QString &projectFullName );
+    void abortPullItems( const QString &projectId );
 
     /**
      * Sends non-blocking POST request to the server to upload a file (chunk).
      * \param projectFullName Namespace/name
+     * \param projectId ID of project
      * \param json project info containing metadata for upload
      */
-    void pushStart( const QString &projectFullName, const QByteArray &json );
+    void pushStart( const QString &projectFullName, const QString &projectId, const QByteArray &json );
 
     /**
      * Sends non-blocking POST request to the server to upload a file (chunk).
      * \param projectFullName Namespace/name
+     * \param projectId ID of project
      * \param transactionUUID Transaction ID which servers sends on uploadStart
      * \param file Mergin file to upload
      * \param chunkNo Chunk number of given file to be uploaded
      */
-    void pushFile( const QString &projectFullName, const QString &transactionUUID, MerginFile file, int chunkNo = 0 );
+    void pushFile( const QString &projectFullName, const QString &projectId, const QString &transactionUUID, const MerginFile &file, int chunkNo = 0 );
 
     /**
      * Closing request after successful push.
      * \param projectFullName Namespace/name
+     * \param projectId ID of project
      * \param transactionUUID transaction UUID to match upload process on the server
      */
-    void pushFinish( const QString &projectFullName, const QString &transactionUUID );
-
-    void sendPushCancelRequest( const QString &projectFullName, const QString &transactionUUID );
+    void pushFinish( const QString &projectFullName, const QString &projectId, const QString &transactionUUID );
+    void sendPushCancelRequest( const QString &projectFullName, const QString &projectId, const QString &transactionUUID );
 
     bool writeData( const QByteArray &data, const QString &path );
     void createPathIfNotExists( const QString &filePath );
@@ -795,21 +755,21 @@ class MerginApi: public QObject
     static QSet<QString> listFiles( const QString &projectPath );
 
     bool validateAuth();
-    void checkMerginVersion( QString apiVersion, bool serverSupportsSubscriptions, QString msg = QStringLiteral() );
+    void checkMerginVersion( const QString &apiVersion, bool serverSupportsSubscriptions, const QString &msg = QStringLiteral() );
 
     /**
-    * Extracts string code of an error json. If its not json or value cannot be parsed, QString() is return;
+    * Extracts string code of an error json. If it's not json or value cannot be parsed, QString() is return;
     * \param data Data received from mergin server on a request failed.
     */
     QString extractServerErrorCode( const QByteArray &data );
     /**
-    * Extracts value of an error json. If its not json or value cannot be parsed, QVariant() is return;
+    * Extracts value of an error json. If it's not json or value cannot be parsed, QVariant() is return;
     * \param data Data received from mergin server on a request failed.
     * \param key Where should be a value from data
     */
     QVariant extractServerErrorValue( const QByteArray &data, const QString &key );
     /**
-    * Extracts detail (message) of an error json. If its not json or detail cannot be parsed, the whole data are return;
+    * Extracts detail (message) of an error json. If it's not json or detail cannot be parsed, the whole data are return;
     * \param data Data received from mergin server on a request failed.
     */
     QString extractServerErrorMsg( const QByteArray &data );
@@ -817,34 +777,49 @@ class MerginApi: public QObject
     * Returns a temporary project path.
     * \param projectFullName
     */
-    QString getTempProjectDir( const QString &projectFullName );
+    QString getTempProjectDir( const QString &projectFullName ) const;
 
-    /** Creates a request to get project details (list of project files).
+    /**
+     * Creates a request to get project details with list of project files. The reason why we use both variants is
+     * the limitation of API, currently the endpoint which uses project ID doesn't return necessary versioning
+     * information for synchronization workflow. Thus, for synchronization use this method and for basic project details
+     * use \a getProjectDetails.
+     * \param projectFullName Project full name to use for request
+     * \param projectId project ID
+     * \param withAuth Specifies if the request will have authentication token
+     * \see getProjectDetails
      */
-    QNetworkReply *getProjectInfo( const QString &projectFullName, bool withAuth = true );
+    QNetworkReply *getProjectInfo( const QString &projectFullName, const QString &projectId, bool withAuth = true );
+
+    /**
+     * Creates a request to get project details. The reason why we use both variants is
+     * the limitation of API, currently the endpoint which uses project ID doesn't return necessary versioning
+     * information for synchronization workflow. Thus, for synchronization use \a getProjectInfo.
+     * \param projectId project ID to use for request
+     * \param withAuth Specifies if the request will have authentication token
+     * \see getProjectInfo
+     */
+    QNetworkReply *getProjectDetails( const QString &projectId, bool withAuth = true );
 
     //! Called when pull of project data has finished to finalize things and emit sync finished signal
-    void finalizeProjectPull( const QString &projectFullName );
-
+    void finalizeProjectPull( const QString &projectId );
     void finalizeProjectPullCopy( const QString &projectFullName, const QString &projectDir, const QString &tempDir, const QString &filePath, const QList<DownloadQueueItem> &items );
-    bool finalizeProjectPullApplyDiff( const QString &projectFullName, const QString &projectDir, const QString &tempDir, const QString &filePath, const QList<DownloadQueueItem> &items );
+    bool finalizeProjectPullApplyDiff( const QString &projectFullName, const QString &projectId, const QString &projectDir, const QString &tempDir, const QString &filePath, const QList<DownloadQueueItem> &items );
 
     //! Takes care of removal of the transaction, writing new metadata and emits syncProjectFinished()
-    void finishProjectSync( const QString &projectFullName, bool syncSuccessful );
-
-    void prepareProjectPull( const QString &projectFullName, const QByteArray &data );
-
-    void startProjectPull( const QString &projectFullName );
+    void finishProjectSync( const QString &projectFullName, const QString &projectId, bool syncSuccessful );
+    void prepareProjectPull( const QString &projectId, const QByteArray &data );
+    void startProjectPull( const QString &projectId );
 
     //! Takes care of finding the correct config file, appends it to current transaction and proceeds with project pull
-    void prepareDownloadConfig( const QString &projectFullName, bool downloaded = false );
-    void requestServerConfig( const QString &projectFullName );
+    void prepareDownloadConfig( const QString &projectId, bool downloaded = false );
+    void requestServerConfig( const QString &projectId );
 
     //! Starts download request of another item
-    void downloadNextItem( const QString &projectFullName );
+    void downloadNextItem( const QString &projectId );
 
     //! Removes temp folder for project
-    void removeProjectsTempFolder( const QString &projectNamespace, const QString &projectName );
+    void removeProjectsTempFolder( const QString &projectNamespace, const QString &projectName ) const;
 
     //! Refreshes auth token if it is expired. It does a blocking call to authorize.
     //! Works only when login, password and token is set in UserAuth. Does nothing if using SSO.
@@ -855,9 +830,9 @@ class MerginApi: public QObject
      * \param reply Network reply to check for retryable errors
      * \returns True if the error should trigger a retry, false otherwise
      */
-    bool isRetryableNetworkError( QNetworkReply *reply );
+    bool isRetryableNetworkError( const QNetworkReply *reply );
 
-    QNetworkRequest getDefaultRequest( bool withAuth = true );
+    QNetworkRequest getDefaultRequest( bool withAuth = true ) const;
 
     bool projectFileHasBeenUpdated( const ProjectDiff &diff );
 
@@ -866,10 +841,10 @@ class MerginApi: public QObject
     void reloadProjectRoleReplyFinished();
 
     //! Updates project role in metadata file
-    bool updateCachedProjectRole( const QString &projectFullName, const QString &newRole );
+    bool updateCachedProjectRole( const QString &projectId, const QString &newRole ) const;
 
     //! Retrieves cached role from metadata file
-    QString getCachedProjectRole( const QString &projectFullName ) const;
+    QString getCachedProjectRole( const QString &projectId ) const;
 
     void startSsoFlow( const QString &clientId );
 
@@ -889,10 +864,11 @@ class MerginApi: public QObject
       AttrProjectFullName = QNetworkRequest::User,
       AttrTempFileName    = QNetworkRequest::User + 1,
       AttrWorkspaceName   = QNetworkRequest::User + 2,
-      AttrAcceptFlag      = QNetworkRequest::User + 3
+      AttrAcceptFlag      = QNetworkRequest::User + 3,
+      AttrProjectId       = QNetworkRequest::User + 4
     };
 
-    Transactions mTransactionalStatus; //projectFullname -> transactionStatus
+    Transactions mTransactionalStatus; //projectId -> transactionStatus
     static const QSet<QString> sIgnoreExtensions;
     static const QSet<QString> sIgnoreImageExtensions;
     static const QSet<QString> sIgnoreFiles;

--- a/core/merginapi.h
+++ b/core/merginapi.h
@@ -17,6 +17,7 @@
 #include <QPointer>
 #include <QSet>
 #include <QByteArray>
+#include <utility>
 #include <QOAuth2AuthorizationCodeFlow>
 
 #include "merginapistatus.h"
@@ -100,7 +101,7 @@ struct ProjectDiff
  */
 struct DownloadQueueItem
 {
-  DownloadQueueItem( const QString &fp, qint64 s, int v, qint64 rf = -1, qint64 rt = -1, bool diff = false );
+  DownloadQueueItem( QString fp, qint64 s, int v, qint64 rf = -1, qint64 rt = -1, bool diff = false );
 
   QString filePath;          //!< path within the project
   qint64 size;               //!< size of the item in bytes
@@ -126,8 +127,8 @@ struct PullTask
     Delete,         //!< remove files that have been removed from the server
   };
 
-  PullTask( Method m, const QString &fp, const QList<DownloadQueueItem> &d )
-    : method( m ), filePath( fp ), data( d ) {}
+  PullTask( const Method m, QString fp, const QList<DownloadQueueItem> &d )
+    : method( m ), filePath( std::move( fp ) ), data( d ) {}
 
   Method method;                  //!< what to do with the file
   QString filePath;               //!< what is the file path within project
@@ -694,7 +695,7 @@ class MerginApi: public QObject
     void createProjectFinished();
     void deleteProjectFinished( bool informUser = true );
     void authorizeFinished();
-    void registrationFinished( const QString &login = QStringLiteral(), const QString &password = QStringLiteral() );
+    void registrationFinished( const QString &login = QString(), const QString &password = QString() );
     void postRegistrationFinished();
     void pingMerginReplyFinished();
     void deleteAccountFinished();

--- a/core/merginapi.h
+++ b/core/merginapi.h
@@ -675,6 +675,7 @@ class MerginApi: public QObject
   private slots:
     void listProjectsReplyFinished( const QString &requestId );
     void listProjectsByNameReplyFinished( const QString &requestId );
+    void getProjectsDetailsReplyFinished();
 
     // Pull slots
     void pullInfoReplyFinished();
@@ -788,7 +789,7 @@ class MerginApi: public QObject
      * \param projectFullName Project full name to use for request
      * \param projectId project ID
      * \param withAuth Specifies if the request will have authentication token
-     * \see getProjectDetails
+     * \see getProjectDetails, getProjectsDetails
      */
     QNetworkReply *getProjectInfo( const QString &projectFullName, const QString &projectId, bool withAuth = true );
 
@@ -798,9 +799,19 @@ class MerginApi: public QObject
      * information for synchronization workflow. Thus, for synchronization use \a getProjectInfo.
      * \param projectId project ID to use for request
      * \param withAuth Specifies if the request will have authentication token
-     * \see getProjectInfo
+     * \see getProjectInfo, getProjectsDetails
      */
     QNetworkReply *getProjectDetails( const QString &projectId, bool withAuth = true );
+
+    /**
+     * Similar to getProjectDetails, but it can fetch multiple projects in one call. Also, we use it as a fallback for
+     * getProjectInfo during syncing. The reason we use this instead of getProjectDetails is that this response is
+     * lighter and doesn't include file history.
+     * \param projectIds project IDs to use for request
+     * \param withAuth Specifies if the request will have authentication token
+     * \see getProjectInfo, getProjectDetails
+     */
+    QNetworkReply *getProjectsDetails( const QStringList &projectIds, bool withAuth = true );
 
     //! Called when pull of project data has finished to finalize things and emit sync finished signal
     void finalizeProjectPull( const QString &projectId );
@@ -866,7 +877,8 @@ class MerginApi: public QObject
       AttrTempFileName    = QNetworkRequest::User + 1,
       AttrWorkspaceName   = QNetworkRequest::User + 2,
       AttrAcceptFlag      = QNetworkRequest::User + 3,
-      AttrProjectId       = QNetworkRequest::User + 4
+      AttrProjectId       = QNetworkRequest::User + 4,
+      AttrAuthUsed        = QNetworkRequest::User + 5
     };
 
     Transactions mTransactionalStatus; //projectId -> transactionStatus

--- a/core/merginapi.h
+++ b/core/merginapi.h
@@ -265,6 +265,14 @@ class MerginApi: public QObject
     QString listProjectsByName( const QStringList &projectNames = QStringList() );
 
     /**
+     * Fallback method for listProjectsByName, which tries to request projects by IDs instead of names.
+     * Uses getProjectsDetails internally.
+     * \param projectIds QStringList of project IDs
+     * \see listProjectsByName
+     */
+    void refetchBrokenProjects( const QStringList &projectIds );
+
+    /**
      * Sends non-blocking POST request to the server to pull (download) a project with a given name.
      * On pullProjectReplyFinished, when a response is received, parses data-stream to files and rewrites local files
      * with them. Extra files which don't match server files are removed. Emits syncProjectFinished at the end.
@@ -633,6 +641,7 @@ class MerginApi: public QObject
     void projectDataChanged( const QString &projectFullName, const QString &projectId );
     void projectDetached( const QString &projectId );
     void projectAttachedToMergin( const QString &projectId );
+    void refetchBrokenProjectsFinished( const MerginProjectsList &projectList );
 
     void projectAlreadyOnLatestVersion( const QString &projectId );
     void missingAuthorizationError( const QString &projectId );
@@ -676,6 +685,7 @@ class MerginApi: public QObject
     void listProjectsReplyFinished( const QString &requestId );
     void listProjectsByNameReplyFinished( const QString &requestId );
     void getProjectsDetailsReplyFinished();
+    void refetchBrokenProjectsReplyFinished();
 
     // Pull slots
     void pullInfoReplyFinished();

--- a/core/merginprojectmetadata.h
+++ b/core/merginprojectmetadata.h
@@ -10,8 +10,6 @@
 #ifndef MERGINPROJECTMETADATA_H
 #define MERGINPROJECTMETADATA_H
 
-#include <QDateTime>
-#include <QList>
 #include <QJsonObject>
 
 struct MerginFile
@@ -36,7 +34,7 @@ struct MerginFile
   // (could be multiple diffs that need to be applied sequentially)
   //
 
-  bool pullCanUseDiff = false;  //!< whether or not we can update the local file by downloading and applying diffs
+  bool pullCanUseDiff = false;  //!< whether we can update the local file by downloading and applying diffs
   QList< QPair<int, qint64> > pullDiffFiles;   //!< list of diffs that will need to be fetched: the version and their sizes
 
   static MerginFile fromJsonObject( const QJsonObject &merginFileInfo );

--- a/core/merginprojectstatusmodel.cpp
+++ b/core/merginprojectstatusmodel.cpp
@@ -36,11 +36,11 @@ QHash<int, QByteArray> MerginProjectStatusModel::roleNames() const
   return roleNames;
 }
 
-QVariant MerginProjectStatusModel::data( const QModelIndex &index, int role ) const
+QVariant MerginProjectStatusModel::data( const QModelIndex &index, const int role ) const
 {
-  int row = index.row();
+  const int row = index.row();
   if ( row < 0 || row >= mItems.count() )
-    return QVariant();
+    return {};
 
   ProjectStatusItem item = mItems.at( row );
 
@@ -54,7 +54,7 @@ QVariant MerginProjectStatusModel::data( const QModelIndex &index, int role ) co
     case Updates: return item.updates;
     case Section: return item.section;
   }
-  return QVariant();
+  return {};
 
 }
 
@@ -123,14 +123,14 @@ void MerginProjectStatusModel::infoProjectUpdated( const ProjectDiff &projectDif
   endResetModel();
 }
 
-bool MerginProjectStatusModel::loadProjectInfo( const QString &projectFullName )
+bool MerginProjectStatusModel::loadProjectInfo( const QString &projectId )
 {
-  LocalProject projectInfo = mLocalProjects.projectFromMerginName( projectFullName );
+  const LocalProject projectInfo = mLocalProjects.projectFromProjectId( projectId );
   if ( !projectInfo.projectDir.isEmpty() )
   {
-    ProjectDiff diff = MerginApi::localProjectChanges( projectInfo.projectDir );
+    const ProjectDiff diff = MerginApi::localProjectChanges( projectInfo.projectDir );
 
-    bool hasLocalChanges = !diff.localAdded.isEmpty() || !diff.localUpdated.isEmpty() || !diff.localDeleted.isEmpty();
+    const bool hasLocalChanges = !diff.localAdded.isEmpty() || !diff.localUpdated.isEmpty() || !diff.localDeleted.isEmpty();
 
     if ( hasLocalChanges )
       infoProjectUpdated( diff, projectInfo.projectDir );

--- a/core/merginprojectstatusmodel.h
+++ b/core/merginprojectstatusmodel.h
@@ -10,7 +10,6 @@
 #ifndef MERGINPROJECTSTATUSMODEL_H
 #define MERGINPROJECTSTATUSMODEL_H
 
-#include <QObject>
 #include <QAbstractListModel>
 #include "merginapi.h"
 
@@ -59,7 +58,7 @@ class MerginProjectStatusModel : public QAbstractListModel
     QHash<int, QByteArray> roleNames() const override;
     Q_INVOKABLE QVariant data( const QModelIndex &index, int role ) const override;
 
-    Q_INVOKABLE bool loadProjectInfo( const QString &projectFullName );
+    Q_INVOKABLE bool loadProjectInfo( const QString &projectId );
 
   private:
     void insertIntoItems( const QSet<QString> &files, const ProjectChangelogStatus &status, const QString &projectDir );

--- a/core/project.cpp
+++ b/core/project.cpp
@@ -10,7 +10,6 @@
 #include "project.h"
 #include "merginapi.h"
 #include "coreutils.h"
-#include "../app/inpututils.h"
 
 QString LocalProject::id() const
 {

--- a/core/project.h
+++ b/core/project.h
@@ -96,39 +96,37 @@ struct LocalProject
  */
 struct MerginProject
 {
-    MerginProject() = default;
-    ~MerginProject() = default;
+  MerginProject() = default;
+  ~MerginProject() = default;
 
-    QString projectName;
-    QString projectNamespace;
+  QString projectName;
+  QString projectNamespace;
+  QString projectId;
 
-    /**
-     * Returns the project ID or empty string if no ID is known. Then it's necessary to fetch the ID from API.
-     */
-    QString id() const;
-    QString fullName() const;
+  /**
+   * Returns the project ID or empty string if no ID is known. Then it's necessary to fetch the ID from API.
+   */
+  QString id() const;
+  QString fullName() const;
 
-    QDateTime serverUpdated; // available latest version of project files on server
-    int serverVersion = -1;
+  QDateTime serverUpdated; // available latest version of project files on server
+  int serverVersion = -1;
 
-    ProjectStatus::Status status = ProjectStatus::NoVersion;
+  ProjectStatus::Status status = ProjectStatus::NoVersion;
 
-    QString remoteError; // Error leading to project not being able to sync (received error code from server)
+  QString remoteError; // Error leading to project not being able to sync (received error code from server)
 
-    bool isValid() const { return !projectName.isEmpty() && !projectNamespace.isEmpty(); }
+  bool isValid() const { return !projectName.isEmpty() && !projectNamespace.isEmpty(); }
 
-    bool operator ==( const MerginProject &other ) const
-    {
-      return ( this->id() == other.id() );
-    }
+  bool operator ==( const MerginProject &other ) const
+  {
+    return ( this->id() == other.id() );
+  }
 
-    bool operator !=( const MerginProject &other ) const
-    {
-      return !( *this == other );
-    }
-
-  private:
-    QString projectId;
+  bool operator !=( const MerginProject &other ) const
+  {
+    return !( *this == other );
+  }
 };
 
 /**

--- a/core/project.h
+++ b/core/project.h
@@ -10,8 +10,6 @@
 #ifndef PROJECT_H
 #define PROJECT_H
 
-#include <QObject>
-#include <QDateTime>
 #include <QDirIterator>
 #include <memory>
 
@@ -37,10 +35,8 @@ namespace ProjectStatus
 
 /**
  * \brief The LocalProject struct is used as a struct for projects that are available on the device.
- * The struct is used in the \see Projects struct and also for communication between LocalProjectsManager and ProjectsModel
- *
- * \note Struct contains member id() which in this time returns projects full name, however, once we
- * start using projects IDs, it can be replaced for that ID.
+ * The struct is used in the \see Projects struct and also for communication between LocalProjectsManager
+ * and ProjectsModel.
  */
 struct LocalProject
 {
@@ -48,15 +44,22 @@ struct LocalProject
 
   public:
 
+    // TODO: remove?
     Q_PROPERTY( QString qgisProjectFilePath MEMBER qgisProjectFilePath )
 
-    LocalProject() {};
-    ~LocalProject() {};
+    LocalProject() = default;
+    ~LocalProject() = default;
 
     QString projectName;
     QString projectNamespace;
+    QString projectId;
 
-    Q_INVOKABLE QString id() const; //! projectFullName for time being
+    //! Returns the UUID of project
+    Q_INVOKABLE QString id() const;
+
+    //! generates a new UUID
+    static QString generateProjectId();
+
     QString fullName() const;
 
     QString projectDir;
@@ -68,18 +71,20 @@ struct LocalProject
 
     bool isValid() const { return !projectDir.isEmpty(); }
 
-    //! Returns true if the local version instance has a mergin counterpart based on localVersion.
-    //! LocalVersion comes from metadata file stored in .mergin folder.
-    //! Note: this is just for scenarios where you only have LocalProject instance and not Project,
-    //!       Project->isMergin() is recommended to use over this one
+    /**
+     * Returns true if the local version instance has a mergin counterpart based on localVersion.
+     * LocalVersion comes from metadata file stored in .mergin folder.
+     * Note: this is just for scenarios where you only have LocalProject instance and not Project,
+     * \note Project->isMergin() is recommended to use over this one
+     */
     bool hasMerginMetadata() const { return localVersion > -1; }
 
-    bool operator ==( const LocalProject &other )
+    bool operator ==( const LocalProject &other ) const
     {
       return ( this->id() == other.id() );
     }
 
-    bool operator !=( const LocalProject &other )
+    bool operator !=( const LocalProject &other ) const
     {
       return !( *this == other );
     }
@@ -88,50 +93,54 @@ struct LocalProject
 /**
  * \brief The MerginProject struct is used for projects that comes from Mergin.
  * This struct is used in the \see Projects struct and also for communication between MerginAPI and ProjectsModel
- *
- * \note Struct contains member id() which in this time returns projects full name, however, once we
- * start using projects IDs, it can be replaced for that ID.
  */
 struct MerginProject
 {
-  MerginProject() {};
-  ~MerginProject() {};
+    MerginProject() = default;
+    ~MerginProject() = default;
 
-  QString projectName;
-  QString projectNamespace;
+    QString projectName;
+    QString projectNamespace;
 
-  QString id() const; //!< projectFullName for time being
+    /**
+     * Returns the project ID or empty string if no ID is known. Then it's necessary to fetch the ID from API.
+     */
+    QString id() const;
+    QString fullName() const;
 
-  QDateTime serverUpdated; // available latest version of project files on server
-  int serverVersion = -1;
+    QDateTime serverUpdated; // available latest version of project files on server
+    int serverVersion = -1;
 
-  ProjectStatus::Status status = ProjectStatus::NoVersion;
+    ProjectStatus::Status status = ProjectStatus::NoVersion;
 
-  QString remoteError; // Error leading to project not being able to sync (received error code from server)
+    QString remoteError; // Error leading to project not being able to sync (received error code from server)
 
-  bool isValid() const { return !projectName.isEmpty() && !projectNamespace.isEmpty(); }
+    bool isValid() const { return !projectName.isEmpty() && !projectNamespace.isEmpty(); }
 
-  bool operator ==( const MerginProject &other )
-  {
-    return ( this->id() == other.id() );
-  }
+    bool operator ==( const MerginProject &other ) const
+    {
+      return ( this->id() == other.id() );
+    }
 
-  bool operator !=( const MerginProject &other )
-  {
-    return !( *this == other );
-  }
+    bool operator !=( const MerginProject &other ) const
+    {
+      return !( *this == other );
+    }
+
+  private:
+    QString projectId;
 };
 
 /**
  * \brief The Project struct serves as a struct for any kind of project (local/mergin).
  * It consists of two main parts - mergin and local.
- * Both parts are pointers to their specific structs and based on the pointer value (nullptr or assigned) this structs
- * decides if the project is local, mergin or both.
+ * Both parts are pointers to their specific structs and based on the pointer value (nullptr or assigned) these structs
+ * decide if the project is local, mergin or both.
  */
 struct Project
 {
-  Project() {};
-  ~Project() {};
+  Project() = default;
+  ~Project() = default;
 
   MerginProject mergin;
   LocalProject local;
@@ -142,50 +151,52 @@ struct Project
   QString projectName() const
   {
     if ( isMergin() ) return mergin.projectName;
-    else if ( isLocal() ) return local.projectName;
-    return QString();
+    if ( isLocal() ) return local.projectName;
+    return {};
   }
 
   QString projectNamespace() const
   {
     if ( isMergin() ) return mergin.projectNamespace;
-    else if ( isLocal() ) return local.projectNamespace;
-    return QString();
+    if ( isLocal() ) return local.projectNamespace;
+    return {};
   }
 
   QString id() const
   {
     if ( isMergin() ) return mergin.id();
-    else if ( isLocal() ) return local.id();
-    return QString();
+    if ( isLocal() ) return local.id();
+    return {};
   }
 
   QString fullName() const
   {
-    return id();
+    if ( isMergin() ) return mergin.fullName();
+    if ( isLocal() ) return local.fullName();
+    return {};
   }
 
-  bool operator ==( const Project &other )
+  bool operator ==( const Project &other ) const
   {
     if ( this->isLocal() && other.isLocal() )
     {
-      return this->local.id() == other.local.id();
+      return this->local.id() == other.local.id() && this->local.fullName() == other.local.fullName();
     }
-    else if ( this->isMergin() && other.isMergin() )
+    if ( this->isMergin() && other.isMergin() )
     {
-      return this->mergin.id() == other.mergin.id();
+      return this->mergin.id() == other.mergin.id() && this->mergin.fullName() == other.mergin.fullName();
     }
     return false;
   }
 
-  bool operator !=( const Project &other )
+  bool operator !=( const Project &other ) const
   {
     return !( *this == other );
   }
 };
 
 typedef QList<MerginProject> MerginProjectsList;
-typedef QList<LocalProject> LocalProjectsList;
+typedef QHash<QString, LocalProject> LocalProjectsDict;
 Q_DECLARE_METATYPE( MerginProjectsList )
 
 #endif // PROJECT_H


### PR DESCRIPTION
Fixes #1969 

This PR adds foundational work for supporting project IDs in mobile app. Besides issue mentioned above this is preliminary work for #1008, #1102, #576, project renaming etc. 

Outline of the changes done:
- core
  - CoreUtils
    - refactor
    - `getFullProjectName()`, `extractProjectName()` has been moved from `MerginApi`
  - Project
    - `LocalProject` supports UUID type of IDs + new `generateProjectId()`
    - `MerginProject` supports UUID type of IDs + new `fullname()`
    - `LocalProjectsList` changed to HashMap `LocalProjectsDict` with ID as key
  - LocalProjectsManager
    - keeps projects in HashMap
    - delete `projectFromMerginName()`, it was used only by tests
    - new `updateProjectId()` necessary function for creating new projects on server ( server returns new ID for already existing projects, app needs to adapt to it)
    - general refactor and move from project fullnames to project IDs as parameters in functions
  - MerginApi
    - general refactor, a lot of the functions are never called from QML for example
    - `listProjectsByName()` stays until there is `v2` endpoint for IDs
    - delete `migrateProjectToMergin()` just a wrapper for `createProject()` ( i think it was used just by tests)
    - delete `projectDiffableFiles()` not used anywhere
    - move `getFullProjectName()` & `extractProjectName()` to utils
    - change `deleteProject()` to use immediate deletion instead of scheduled, we use it only internally for project management 
    - remove `topic` parameter  from `networkErrorOccured()` it was only used by tests (they use http error codes now)
    - new `projectIdChanged()` signal to trigger update of local project ID to server generated ID
    - new `getProjectDetails()` it's leaner version of `getProjectInfo()`, the response won't contain versioning history
    - `Transactions` now keep projectId as key
    - generally everything what could be, was moved to use project IDs, the synchronization workflow couldn't, so for communication with API we use project names but internally the project ID is propagated and used where possible
    - when a local project is "migrated" to mergin there is new request for new project ID generated on server that is further processed and local ID is changed to match server ID
- app
  - QML
    - just refactor to support project IDs
  - C++
    - ActiveProject
      - new `projectId()` to get project ID of active project
    - Main
      - rework to project IDs
    - ProjectsModel
      - replaced `listProjectsByName()`  by `fetchProjectsById()`
      - reworked slots to use project IDs
      - removed `porjectNames()`, it was used internally and is not necessary since we moved to IDs
    - ProjectWizard
      - refactor, most importantly moved from deprecated `QVariant::type` to `QMetaType`
    - SynchronizationManager
      - keeps synchronization processes by project ID
      - reworked to use project IDs instead of project names
  - Tests
    - mostly refactor & minor changes
    - replaced `findProjectByName()` with template function
    - moved descriptive inline test function comments to header file or written new ones
