### PR TITLE
Switch workspace on invitation accepted

### DIFF
--- a/app/invitationsmodel.cpp
+++ b/app/invitationsmodel.cpp
@@ -56,6 +56,7 @@ void InvitationsModel::onListInvitationsFinished( const QList<MerginInvitation> 
     item->setData( invite.role, Qt::ToolTipRole );
     item->setData( invite.uuid, Qt::WhatsThisRole );
     item->setData( invite.expiration, Qt::StatusTipRole );
+    item->setData( invite.workspaceId, Qt::BackgroundRole );
     appendRow( item );
   }
 

--- a/app/notificationmodel.cpp
+++ b/app/notificationmodel.cpp
@@ -109,7 +109,7 @@ void NotificationModel::addError( const QString &message, const NotificationType
 
 void NotificationModel::addInfo( const QString &message, const NotificationType::ActionType action, const uint interval )
 {
-  add( message, interval, NotificationType::Information, NotificationType::WaitingIcon, action );
+  add( message, interval, NotificationType::Information, NotificationType::InfoIcon, action );
 }
 
 void NotificationModel::addWarning( const QString &message, const NotificationType::ActionType action, const uint interval )

--- a/app/notificationmodel.h
+++ b/app/notificationmodel.h
@@ -32,6 +32,7 @@ class NotificationType
     {
       NoneIcon,
       WaitingIcon,
+      InfoIcon,
       CheckIcon,
       ExclamationIcon
     };

--- a/app/qml/account/MMAccountController.qml
+++ b/app/qml/account/MMAccountController.qml
@@ -20,6 +20,8 @@ Item {
   property bool inProgress: false
   property MM.MerginInvitation invitation
 
+  signal projectsListRequested()
+
   QtObject {
     //! Data to send to postRegister endpoint
     id: postRegisterData
@@ -303,8 +305,7 @@ Item {
 
         function onProcessInvitationFinished( accepted ) {
           controller.end()
-          stackView.currentItem.state = "workspace"
-          __notificationModel.addInfo( qsTr( "Download a project and start collecting." ), MM.NotificationType.NoAction, 10 )
+          controller.projectsListRequested()
         }
       }
     }

--- a/app/qml/account/MMAccountController.qml
+++ b/app/qml/account/MMAccountController.qml
@@ -303,6 +303,8 @@ Item {
 
         function onProcessInvitationFinished( accepted ) {
           controller.end()
+          stackView.currentItem.state = "workspace"
+          __notificationModel.addInfo( qsTr( "Download a project and start collecting." ), MM.NotificationType.NoAction, 10 )
         }
       }
     }

--- a/app/qml/components/MMNotification.qml
+++ b/app/qml/components/MMNotification.qml
@@ -48,6 +48,7 @@ Rectangle {
       switch( model.icon ) {
       case MM.NotificationType.NoneIcon: return ""
       case MM.NotificationType.WaitingIcon: return __style.waitingIcon
+      case MM.NotificationType.InfoIcon: return __style.infoIcon
       case MM.NotificationType.ExclamationIcon: return __style.errorCircleIcon
       case MM.NotificationType.CheckIcon: return __style.doneCircleIcon
       default: return ""

--- a/app/qml/project/MMProjectController.qml
+++ b/app/qml/project/MMProjectController.qml
@@ -462,6 +462,11 @@ Item {
     id: accountController
     enabled: root.visible
     stackView: stackView
+
+    onProjectsListRequested: function() {
+      stackView.currentItem.state = "workspace"
+      __notificationModel.addInfo( qsTr( "Download a project and start collecting." ), MM.NotificationType.NoAction, 10 )
+    }
   }
 
   MMCreateWorkspaceController {

--- a/app/qml/project/MMProjectController.qml
+++ b/app/qml/project/MMProjectController.qml
@@ -81,13 +81,6 @@ Item {
     stackView.push( workspaceListComponent )
   }
 
-  function showProjectsPage() {
-    if ( stackView.depth > 1 )
-      stackView.pop( null ) // gets back to workspaceProjectsPanelComp (initialItem)
-
-    stackView.currentItem.state = "workspace"
-  }
-
   visible: false
   focus: true
 
@@ -676,11 +669,6 @@ Item {
       if ( __merginApi.userAuth.hasValidToken() ) {
         root.refreshProjects()
       }
-    }
-
-    function onProcessInvitationSuccess() {
-      root.showProjectsPage()
-      __notificationModel.addInfo( qsTr( "Download a project and start collecting." ), MM.NotificationType.NoAction, 10 ) // 10 seconds
     }
   }
 }

--- a/app/qml/project/MMProjectController.qml
+++ b/app/qml/project/MMProjectController.qml
@@ -670,5 +670,9 @@ Item {
         root.refreshProjects()
       }
     }
+
+    function onProcessInvitationSuccess() {
+      stackView.popOnePageOrClose()
+    }
   }
 }

--- a/app/qml/project/MMProjectController.qml
+++ b/app/qml/project/MMProjectController.qml
@@ -680,6 +680,7 @@ Item {
 
     function onProcessInvitationSuccess() {
       root.showProjectsPage()
+      __notificationModel.addInfo( qsTr( "Download a project and start collecting." ) )
     }
   }
 }

--- a/app/qml/project/MMProjectController.qml
+++ b/app/qml/project/MMProjectController.qml
@@ -680,7 +680,7 @@ Item {
 
     function onProcessInvitationSuccess() {
       root.showProjectsPage()
-      __notificationModel.addInfo( qsTr( "Download a project and start collecting." ) )
+      __notificationModel.addInfo( qsTr( "Download a project and start collecting." ), MM.NotificationType.NoAction, 10 ) // 10 seconds
     }
   }
 }

--- a/app/qml/project/MMProjectController.qml
+++ b/app/qml/project/MMProjectController.qml
@@ -81,6 +81,13 @@ Item {
     stackView.push( workspaceListComponent )
   }
 
+  function showProjectsPage() {
+    if ( stackView.depth > 1 )
+      stackView.pop( null ) // gets back to workspaceProjectsPanelComp (initialItem)
+
+    stackView.currentItem.state = "workspace"
+  }
+
   visible: false
   focus: true
 
@@ -672,7 +679,7 @@ Item {
     }
 
     function onProcessInvitationSuccess() {
-      stackView.popOnePageOrClose()
+      root.showProjectsPage()
     }
   }
 }

--- a/app/test/testmerginapi.cpp
+++ b/app/test/testmerginapi.cpp
@@ -3353,3 +3353,40 @@ void TestMerginApi::testApiRoot()
 
   mApi->setApiRoot( originalRoot );
 }
+
+void TestMerginApi::testServerVersionIsAtLeast()
+{
+  mApi->setApiVersion( "2024.4.3" );
+
+  // required version is lower than server version
+  QVERIFY( mApi->serverVersionIsAtLeast( 2023, 4, 3 ) );  // lower major
+  QVERIFY( mApi->serverVersionIsAtLeast( 2024, 3, 3 ) );  // same major, lower minor
+  QVERIFY( mApi->serverVersionIsAtLeast( 2024, 4, 2 ) );  // same major and minor, lower patch
+
+  // required version equals server version
+  QVERIFY( mApi->serverVersionIsAtLeast( 2024, 4, 3 ) );  // exact match
+
+  // required version is higher than server version
+  QVERIFY( !mApi->serverVersionIsAtLeast( 2025, 4, 3 ) );  // higher major
+  QVERIFY( !mApi->serverVersionIsAtLeast( 2024, 5, 3 ) );  // same major, higher minor
+  QVERIFY( !mApi->serverVersionIsAtLeast( 2024, 4, 4 ) );  // same major and minor, higher patch
+
+  // invalid API versions
+  mApi->setApiVersion( "invalid.version" );
+  QVERIFY( !mApi->serverVersionIsAtLeast( 2023, 4, 3 ) );  // non-parseable version
+  mApi->setApiVersion( "" );
+  QVERIFY( !mApi->serverVersionIsAtLeast( 2023, 4, 3 ) );  // empty version string
+
+  // missing patch version
+  mApi->setApiVersion( "2024.4" );
+  QVERIFY( !mApi->serverVersionIsAtLeast( 2023, 4, 3 ) );
+
+  // non-numeric patch version
+  mApi->setApiVersion( "2024.4.a" );
+  QVERIFY( !mApi->serverVersionIsAtLeast( 2023, 4, 3 ) );
+
+  // very large version numbers
+  mApi->setApiVersion( "9999.9999.9999" );
+  QVERIFY( mApi->serverVersionIsAtLeast( 9999, 9999, 9999 ) );  // equal
+  QVERIFY( !mApi->serverVersionIsAtLeast( 10000, 0, 0 ) ); // higher major
+}

--- a/app/test/testmerginapi.h
+++ b/app/test/testmerginapi.h
@@ -162,8 +162,8 @@ class TestMerginApi: public QObject
     void testRegistration();
     void testParseVersion();
     void testApiRoot();
-
     void testServerDiagnosticLogsUrl();
+    void testServerVersionIsAtLeast();
 
   private:
     MerginApi *mApi = nullptr;

--- a/core/merginapi.cpp
+++ b/core/merginapi.cpp
@@ -3837,7 +3837,8 @@ void MerginApi::getServerConfigReplyFinished()
       if ( !validVersion )
       {
         CoreUtils::log( QStringLiteral( "Server version" ), QStringLiteral( "Cannot parse server version" ) );
-      } else
+      }
+      else
       {
         setApiVersion( apiVersion );
       }
@@ -4091,7 +4092,7 @@ void MerginApi::processInvitationReplyFinished()
   {
     CoreUtils::log( "process invitation", QStringLiteral( "Success" ) );
 
-    // if server version is at least 2025.4.1, let‘s get workspaceId from response and switch to it
+    // if server version is at least 2025.4.1, let's get workspaceId from response and switch to it
     // emit processInvitationSuccess to navigate to project's page in qml
     if ( serverVersionIsAtLeast( 2025, 4, 1 ) && accept )
     {
@@ -4101,19 +4102,19 @@ void MerginApi::processInvitationReplyFinished()
       if ( doc.isObject() )
       {
         const QJsonObject responseObj = doc.object();
-        if ( responseObj.contains( "workspace_id" ) )
-        {
-          const int workspaceId = responseObj.value( "workspace_id" ).toInt();
-          mUserInfo->setActiveWorkspace( workspaceId );
-          emit processInvitationSuccess();
-        }
+        const MerginInvitation invitation = MerginInvitation::fromJsonObject( responseObj );
+        QMap<int, QString> workspaces = mUserInfo->workspaces();
+        workspaces.insert( invitation.workspaceId, invitation.workspace );
+        mUserInfo->updateWorkspacesList( workspaces );
+        mUserInfo->setActiveWorkspace( invitation.workspaceId );
+        emit processInvitationSuccess();
       }
     }
   }
   else
   {
-    QString serverMsg = extractServerErrorMsg( r->readAll() );
-    QString message = QStringLiteral( "Network API error: %1(): %2. %3" ).arg( QStringLiteral( "processInvitation" ), r->errorString(), serverMsg );
+    const QString serverMsg = extractServerErrorMsg( r->readAll() );
+    const QString message = QStringLiteral( "Network API error: %1(): %2. %3" ).arg( QStringLiteral( "processInvitation" ), r->errorString(), serverMsg );
     CoreUtils::log( "process invitation", QStringLiteral( "FAILED - %1" ).arg( message ) );
     emit networkErrorOccurred( serverMsg, QStringLiteral( "Mergin API error: processInvitation" ) );
     emit processInvitationFailed();
@@ -4450,7 +4451,7 @@ void MerginApi::setApiVersion( const QString &apiVersion )
   }
 }
 
-bool MerginApi::serverVersionIsAtLeast(const int requiredMajor, const int requiredMinor, const int requiredPatch ) const
+bool MerginApi::serverVersionIsAtLeast( const int requiredMajor, const int requiredMinor, const int requiredPatch ) const
 {
   int serverMajor = -1;
   int serverMinor = -1;

--- a/core/merginapi.cpp
+++ b/core/merginapi.cpp
@@ -4099,7 +4099,6 @@ void MerginApi::processInvitationReplyFinished()
       if ( doc.isObject() )
       {
         QJsonObject responseObj = doc.object();
-
         if ( responseObj.contains( "workspace_id" ) )
         {
           int workspaceId = responseObj.value( "workspace_id" ).toInt();

--- a/core/merginapi.cpp
+++ b/core/merginapi.cpp
@@ -4091,7 +4091,7 @@ void MerginApi::processInvitationReplyFinished()
 
     // if server version is at least 2025.4.1, let‘s get workspaceId from response and switch to it
     // emit processInvitationSuccess to navigate to project's page in qml
-    if ( serverVersionIsAtLeast( 2025, 4, 1 ) )
+    if ( serverVersionIsAtLeast( 2025, 4, 1 ) && accept )
     {
       QByteArray data = r->readAll();
       QJsonDocument doc = QJsonDocument::fromJson( data );
@@ -4103,11 +4103,8 @@ void MerginApi::processInvitationReplyFinished()
         if ( responseObj.contains( "workspace_id" ) )
         {
           int workspaceId = responseObj.value( "workspace_id" ).toInt();
-          if ( accept )
-          {
-            mUserInfo->setActiveWorkspace( workspaceId );
-            emit processInvitationSuccess();
-          }
+          mUserInfo->setActiveWorkspace( workspaceId );
+          emit processInvitationSuccess();
         }
       }
     }

--- a/core/merginapi.cpp
+++ b/core/merginapi.cpp
@@ -3829,15 +3829,17 @@ void MerginApi::getServerConfigReplyFinished()
       QString serverType = doc.object().value( QStringLiteral( "server_type" ) ).toString();
       QString apiVersion = doc.object().value( QStringLiteral( "version" ) ).toString();
       QString diagnosticUrl = doc.object().value( QStringLiteral( "diagnostic_logs_url" ) ).toString();
-      setApiVersion( apiVersion );
-
       int major = -1;
       int minor = -1;
-      bool validVersion = parseVersion( apiVersion, major, minor );
+
+      const bool validVersion = parseVersion( apiVersion, major, minor );
 
       if ( !validVersion )
       {
         CoreUtils::log( QStringLiteral( "Server version" ), QStringLiteral( "Cannot parse server version" ) );
+      } else
+      {
+        setApiVersion( apiVersion );
       }
 
       if ( serverType == QStringLiteral( "ee" ) )
@@ -4083,7 +4085,7 @@ void MerginApi::processInvitationReplyFinished()
   QNetworkReply *r = qobject_cast<QNetworkReply *>( sender() );
   Q_ASSERT( r );
 
-  bool accept = r->request().attribute( static_cast<QNetworkRequest::Attribute>( AttrAcceptFlag ) ).toBool();
+  const bool accept = r->request().attribute( static_cast<QNetworkRequest::Attribute>( AttrAcceptFlag ) ).toBool();
 
   if ( r->error() == QNetworkReply::NoError )
   {
@@ -4093,15 +4095,15 @@ void MerginApi::processInvitationReplyFinished()
     // emit processInvitationSuccess to navigate to project's page in qml
     if ( serverVersionIsAtLeast( 2025, 4, 1 ) && accept )
     {
-      QByteArray data = r->readAll();
-      QJsonDocument doc = QJsonDocument::fromJson( data );
+      const QByteArray data = r->readAll();
+      const QJsonDocument doc = QJsonDocument::fromJson( data );
 
       if ( doc.isObject() )
       {
-        QJsonObject responseObj = doc.object();
+        const QJsonObject responseObj = doc.object();
         if ( responseObj.contains( "workspace_id" ) )
         {
-          int workspaceId = responseObj.value( "workspace_id" ).toInt();
+          const int workspaceId = responseObj.value( "workspace_id" ).toInt();
           mUserInfo->setActiveWorkspace( workspaceId );
           emit processInvitationSuccess();
         }
@@ -4448,11 +4450,11 @@ void MerginApi::setApiVersion( const QString &apiVersion )
   }
 }
 
-bool MerginApi::serverVersionIsAtLeast( int requiredMajor, int requiredMinor, int requiredPatch ) const
+bool MerginApi::serverVersionIsAtLeast(const int requiredMajor, const int requiredMinor, const int requiredPatch ) const
 {
   int serverMajor = -1;
   int serverMinor = -1;
-  bool validVersion = parseVersion( mApiVersion, serverMajor, serverMinor );
+  const bool validVersion = parseVersion( mApiVersion, serverMajor, serverMinor );
 
   if ( !validVersion )
     return false;

--- a/core/merginapi.h
+++ b/core/merginapi.h
@@ -422,6 +422,16 @@ class MerginApi: public QObject
     static bool parseVersion( const QString &version, int &major, int &minor );
 
     /**
+    * Parse major, minor and patch version number from version string.
+    * \param version full server version string
+    * \param major parsed major number
+    * \param minor parsed minor number
+    * \param patch parsed patch number
+    * @return true when parsing was successful
+    */
+    static bool parseVersion( const QString &version, int &major, int &minor, int &patch );
+
+    /**
     * Finds project in merginProjects list according its full name.
     * \param projectPath Full path to project's folder
     * \param metadataFile Relative path of metafile to project's folder
@@ -742,8 +752,6 @@ class MerginApi: public QObject
     void ssoConfigIsMultiTenant();
 
     void userSelfRegistrationEnabledChanged();
-
-    void apiVersionChanged( const QString &apiVersion );
 
   private slots:
     void listProjectsReplyFinished( QString requestId );

--- a/core/merginapi.h
+++ b/core/merginapi.h
@@ -638,6 +638,17 @@ class MerginApi: public QObject
 
     QNetworkRequest getDefaultRequest( bool withAuth = true ) const;
 
+    /**
+     * Returns server API version string (e.g. "2023.4.0")
+     */
+    QString apiVersion() const;
+    void setApiVersion( const QString &apiVersion );
+
+    /**
+     * Checks if server version meets or exceeds a required minimum version
+     */
+    bool serverVersionIsAtLeast( int requiredMajor, int requiredMinor, int requiredPatch ) const;
+
   signals:
     void apiSupportsSubscriptionsChanged();
     void supportsSelectiveSyncChanged();
@@ -707,6 +718,7 @@ class MerginApi: public QObject
     void listInvitationsFinished( const QList<MerginInvitation> &invitations );
 
     void processInvitationFailed();
+    void processInvitationSuccess();
     void processInvitationFinished( bool accepted );
 
     void workspaceCreated( const QString &workspaceName );
@@ -730,6 +742,8 @@ class MerginApi: public QObject
     void ssoConfigIsMultiTenant();
 
     void userSelfRegistrationEnabledChanged();
+
+    void apiVersionChanged( const QString &apiVersion );
 
   private slots:
     void listProjectsReplyFinished( QString requestId );
@@ -918,6 +932,7 @@ class MerginApi: public QObject
     bool mSupportsSelectiveSync = true;
     bool mApiSupportsSso = false;
     bool mUserSelfRegistrationEnabled = false;
+    QString mApiVersion;
 
     static const int UPLOAD_CHUNK_SIZE;
     const int PROJECT_PER_PAGE = 50;

--- a/core/merginuserinfo.cpp
+++ b/core/merginuserinfo.cpp
@@ -18,7 +18,7 @@ MerginInvitation MerginInvitation::fromJsonObject( const QJsonObject &invitation
   MerginInvitation merginInvitation;
   merginInvitation.uuid = invitationInfo.value( QStringLiteral( "uuid" ) ).toString();
   merginInvitation.workspace = invitationInfo.value( QStringLiteral( "workspace" ) ).toString();
-  merginInvitation.workspaceId = invitationInfo.value( QStringLiteral( "workspace_id" ) ).toString();
+  merginInvitation.workspaceId = invitationInfo.value( QStringLiteral( "workspace_id" ) ).toInt();
   merginInvitation.role = invitationInfo.value( QStringLiteral( "role" ) ).toString();
   merginInvitation.expiration = invitationInfo.value( QStringLiteral( "expire" ) ).toVariant().toDateTime();
 

--- a/core/merginuserinfo.cpp
+++ b/core/merginuserinfo.cpp
@@ -18,6 +18,7 @@ MerginInvitation MerginInvitation::fromJsonObject( const QJsonObject &invitation
   MerginInvitation merginInvitation;
   merginInvitation.uuid = invitationInfo.value( QStringLiteral( "uuid" ) ).toString();
   merginInvitation.workspace = invitationInfo.value( QStringLiteral( "workspace" ) ).toString();
+  merginInvitation.workspaceId = invitationInfo.value( QStringLiteral( "workspace_id" ) ).toString();
   merginInvitation.role = invitationInfo.value( QStringLiteral( "role" ) ).toString();
   merginInvitation.expiration = invitationInfo.value( QStringLiteral( "expire" ) ).toVariant().toDateTime();
 

--- a/core/merginuserinfo.h
+++ b/core/merginuserinfo.h
@@ -21,12 +21,14 @@ struct MerginInvitation
 
   public:
     Q_PROPERTY( QString workspace MEMBER workspace )
+    Q_PROPERTY( QString workspaceId MEMBER workspaceId )
     Q_PROPERTY( QString uuid MEMBER uuid )
     Q_PROPERTY( QString role MEMBER role )
     Q_PROPERTY( QDateTime expiration MEMBER expiration )
 
     QString uuid;
     QString workspace;
+    QString workspaceId;
     QString role;
     QDateTime expiration;
 

--- a/core/merginuserinfo.h
+++ b/core/merginuserinfo.h
@@ -21,14 +21,14 @@ struct MerginInvitation
 
   public:
     Q_PROPERTY( QString workspace MEMBER workspace )
-    Q_PROPERTY( QString workspaceId MEMBER workspaceId )
+    Q_PROPERTY( int workspaceId MEMBER workspaceId )
     Q_PROPERTY( QString uuid MEMBER uuid )
     Q_PROPERTY( QString role MEMBER role )
     Q_PROPERTY( QDateTime expiration MEMBER expiration )
 
     QString uuid;
     QString workspace;
-    QString workspaceId;
+    int workspaceId;
     QString role;
     QDateTime expiration;
 


### PR DESCRIPTION
- Added `workspaceId` to `InvitationsModel` after `/v1/workspace/invitations` endpoint began including this field with each invitation. After accepting a workspace invitation, app now switches to accepted workspace and navigates to its project list if server version is bigger than `2025.4.1` ( see https://github.com/MerginMaps/server-private/issues/2936 ). 
- Added a new method `serverVersionIsAtLeast` to check whether server version meets or exceeds a required minimum version.
- Changed icon of `addIcon` method in `NotificationModel` from `WaitingIcon` to `InfoIcon`.

Resolves #3847