### PR TITLE
Fix testHasLocalProjectChanges 

### DIFF
--- a/app/test/testmerginapi.cpp
+++ b/app/test/testmerginapi.cpp
@@ -3286,9 +3286,9 @@ void TestMerginApi::testHasLocalProjectChanges()
   QVERIFY( !mApi->hasLocalProjectChanges( projectDir, mApi->supportsSelectiveSync() ) );
 
   // 4: fourth scenario => local files differs from metadata, selective sync supported
-  writeFileContent( projectDir + "/test.txt", QByteArray( "modified content" ) );
+  writeFileContent( projectDir + "/new_file.txt", QByteArray( "new content" ) );
 
-  QTest::qSleep( TestUtils::SHORT_REPLY );
+  QTest::qSleep( 1000 );
 
   // expected results: has changes
   QVERIFY( mApi->hasLocalProjectChanges( projectDir, mApi->supportsSelectiveSync() ) );

--- a/app/test/testmerginapi.cpp
+++ b/app/test/testmerginapi.cpp
@@ -2744,6 +2744,7 @@ void TestMerginApi::writeFileContent( const QString &filename, const QByteArray 
   bool ok = f.open( QIODeviceBase::WriteOnly );
   Q_ASSERT( ok );
   f.write( data );
+  f.flush();
   f.close();
 }
 
@@ -3287,7 +3288,7 @@ void TestMerginApi::testHasLocalProjectChanges()
   // 4: fourth scenario => local files differs from metadata, selective sync supported
   writeFileContent( projectDir + "/test.txt", QByteArray( "modified content" ) );
 
-  QTest::qSleep( 1000 );
+  QTest::qSleep( TestUtils::SHORT_REPLY );
 
   // expected results: has changes
   QVERIFY( mApi->hasLocalProjectChanges( projectDir, mApi->supportsSelectiveSync() ) );


### PR DESCRIPTION
In fourth scenario, add a new file instead of modifying existing one.