### PR TITLE
Throw exception on transform error

### DIFF
--- a/app/inpututils.cpp
+++ b/app/inpututils.cpp
@@ -937,7 +937,8 @@ double InputUtils::screenUnitsToMeters( InputMapSettings *mapSettings, int baseL
   }
   catch ( QgsCsException &e )
   {
-    Q_UNUSED( e )
+    Q_UNUSED( e );
+    CoreUtils::log( "screenUnitsToMeters", QString( "Coordinate transformation failed: %1" ).arg( e.what() ) );
   }
 
   return 0.0;

--- a/app/inpututils.cpp
+++ b/app/inpututils.cpp
@@ -930,7 +930,17 @@ double InputUtils::screenUnitsToMeters( InputMapSettings *mapSettings, int baseL
   QPoint pointCenter( s.width() / 2, s.height() / 2 );
   QgsPointXY p1 = mapSettings->screenToCoordinate( pointCenter );
   QgsPointXY p2 = mapSettings->screenToCoordinate( pointCenter + QPoint( baseLengthPixels, 0 ) );
-  return mDistanceArea.measureLine( p1, p2 );
+
+  try
+  {
+    return mDistanceArea.measureLine( p1, p2 );
+  }
+  catch ( QgsCsException &e )
+  {
+    Q_UNUSED( e )
+  }
+
+  return 0.0;
 }
 
 QgsPoint InputUtils::mapPointToGps( QPointF mapPosition, InputMapSettings *mapSettings )

--- a/app/scalebarkit.cpp
+++ b/app/scalebarkit.cpp
@@ -82,7 +82,7 @@ void ScaleBarKit::updateScaleBar()
     return;
 
   double distInMeters = InputUtils().screenUnitsToMeters( mMapSettings, mPreferredWidth ); // meters
-  if ( std::isnan( distInMeters ) )
+  if ( std::isnan( distInMeters ) || distInMeters <= 0.0 )
     return;
 
   double dist;


### PR DESCRIPTION
This PR adds an exception when `screenUnitsToMeters` method fails in order to prevent app crashes.