### PR TITLE
Prevent excessive zoom by growing default map extent

### DIFF
--- a/app/map/inputmapsettings.cpp
+++ b/app/map/inputmapsettings.cpp
@@ -258,7 +258,6 @@ void InputMapSettings::onReadProject( const QDomDocument &doc )
 
     QgsRectangle defaultExtent = mProject->viewSettings()->fullExtent();
     defaultExtent.grow( mProject->crs().isGeographic() ? 0.01 : 100.0 );
-    defaultExtent.scale( 1.05 );
     mMapSettings.setExtent( defaultExtent );
   }
 

--- a/app/map/inputmapsettings.cpp
+++ b/app/map/inputmapsettings.cpp
@@ -255,10 +255,11 @@ void InputMapSettings::onReadProject( const QDomDocument &doc )
   if ( !foundTheMapCanvas )
   {
     mMapSettings.setDestinationCrs( mProject->crs() );
-    QgsRectangle defaultExtent = mProject->viewSettings()->fullExtent();
-    mMapSettings.setExtent( defaultExtent );
 
     const double MIN_SCALE_DENOMINATOR = 100;
+    QgsRectangle defaultExtent = mProject->viewSettings()->fullExtent();
+
+    mMapSettings.setExtent( defaultExtent );
     if ( mMapSettings.computeScaleForExtent( defaultExtent ) < MIN_SCALE_DENOMINATOR )
     {
       mMapSettings.setExtent( mMapSettings.computeExtentForScale( center(), MIN_SCALE_DENOMINATOR ) );

--- a/app/map/inputmapsettings.cpp
+++ b/app/map/inputmapsettings.cpp
@@ -255,10 +255,14 @@ void InputMapSettings::onReadProject( const QDomDocument &doc )
   if ( !foundTheMapCanvas )
   {
     mMapSettings.setDestinationCrs( mProject->crs() );
-
     QgsRectangle defaultExtent = mProject->viewSettings()->fullExtent();
-    defaultExtent.grow( mProject->crs().isGeographic() ? 0.01 : 100.0 );
     mMapSettings.setExtent( defaultExtent );
+
+    const double MIN_SCALE_DENOMINATOR = 100;
+    if ( mMapSettings.computeScaleForExtent( defaultExtent ) < MIN_SCALE_DENOMINATOR )
+    {
+      mMapSettings.setExtent( mMapSettings.computeExtentForScale( center(), MIN_SCALE_DENOMINATOR ) );
+    }
   }
 
   mMapSettings.setRotation( 0 );

--- a/app/map/inputmapsettings.cpp
+++ b/app/map/inputmapsettings.cpp
@@ -19,6 +19,8 @@
 #include "qgsmessagelog.h"
 #include "qgsprojectviewsettings.h"
 
+constexpr double MIN_SCALE_DENOMINATOR = 100;
+
 InputMapSettings::InputMapSettings( QObject *parent )
   : QObject( parent )
 {
@@ -256,8 +258,7 @@ void InputMapSettings::onReadProject( const QDomDocument &doc )
   {
     mMapSettings.setDestinationCrs( mProject->crs() );
 
-    const double MIN_SCALE_DENOMINATOR = 100;
-    QgsRectangle defaultExtent = mProject->viewSettings()->fullExtent();
+    const QgsReferencedRectangle defaultExtent = mProject->viewSettings()->fullExtent();
 
     mMapSettings.setExtent( defaultExtent );
     if ( mMapSettings.computeScaleForExtent( defaultExtent ) < MIN_SCALE_DENOMINATOR )

--- a/app/map/inputmapsettings.cpp
+++ b/app/map/inputmapsettings.cpp
@@ -255,7 +255,11 @@ void InputMapSettings::onReadProject( const QDomDocument &doc )
   if ( !foundTheMapCanvas )
   {
     mMapSettings.setDestinationCrs( mProject->crs() );
-    mMapSettings.setExtent( mProject->viewSettings()->fullExtent() );
+
+    QgsRectangle defaultExtent = mProject->viewSettings()->fullExtent();
+    defaultExtent.grow( mProject->crs().isGeographic() ? 0.01 : 100.0 );
+    defaultExtent.scale( 1.05 );
+    mMapSettings.setExtent( defaultExtent );
   }
 
   mMapSettings.setRotation( 0 );


### PR DESCRIPTION
To prevent excessively zoomed-in initial views, especially when opening local projects with sparse data (such as a single point), the map now automatically zooms out in these scenarios.

Relates to #2445
