### PR TITLE
Android CI runner did not have enough storage to finish

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -294,6 +294,7 @@ jobs:
           name: Mergin Maps ${{ env.INPUT_VERSION_CODE }} APK [v7 + v8a]
 
       - name: Build AAB
+        if: ${{ github.ref_name == 'master' || github.ref_type == 'tag' }}
         env:
           ANDROID_NDK_ROOT: ${{ steps.setup-ndk.outputs.ndk-path }}
           ANDROID_NDK_HOST: darwin-x86_64
@@ -307,12 +308,14 @@ jobs:
             find . | grep .aab
 
       - name: Rename AAB artefacts
+        if: ${{ github.ref_name == 'master' || github.ref_type == 'tag' }}
         run: |
           mv \
             ${{ github.workspace }}/build-Input/app/android-build/build/outputs/bundle/release/android-build-release.aab \
             ${{ github.workspace }}/merginmaps-${{ env.INPUT_VERSION_CODE }}.aab
 
       - name: Upload AAB to Artifacts
+        if: ${{ github.ref_name == 'master' || github.ref_type == 'tag' }}
         uses: actions/upload-artifact@v4
         with:
           path: ${{ github.workspace }}/merginmaps-${{ env.INPUT_VERSION_CODE }}.aab


### PR DESCRIPTION
The step to clear out some space by removing simulators on `macos-15` somehow stopped working, see https://github.com/actions/runner-images/issues/10511#issuecomment-2960303939 and https://github.com/MerginMaps/mobile/commit/87ed328e676c1859598902d24c4a893d35e4f2d2. We now remove unused XCode versions instead to give us some space.