### PR TITLE
Drop project owner variable

### DIFF
--- a/app/variablesmanager.cpp
+++ b/app/variablesmanager.cpp
@@ -33,11 +33,9 @@ void VariablesManager::removeMerginProjectVariables( QgsProject *project )
   QgsExpressionContextUtils::removeProjectVariable( project, QStringLiteral( "mergin_project_name" ) );
   QgsExpressionContextUtils::removeProjectVariable( project, QStringLiteral( "mergin_project_full_name" ) );
   QgsExpressionContextUtils::removeProjectVariable( project, QStringLiteral( "mergin_project_version" ) );
-  QgsExpressionContextUtils::removeProjectVariable( project, QStringLiteral( "mergin_project_owner" ) );
   QgsExpressionContextUtils::removeProjectVariable( project, QStringLiteral( "mm_project_name" ) );
   QgsExpressionContextUtils::removeProjectVariable( project, QStringLiteral( "mm_project_full_name" ) );
   QgsExpressionContextUtils::removeProjectVariable( project, QStringLiteral( "mm_project_version" ) );
-  QgsExpressionContextUtils::removeProjectVariable( project, QStringLiteral( "mm_project_owner" ) );
 }
 
 void VariablesManager::registerInputExpressionFunctions()
@@ -198,11 +196,9 @@ void VariablesManager::setProjectVariables()
     QgsExpressionContextUtils::setProjectVariable( mCurrentProject, QStringLiteral( "mergin_project_version" ), metadata.version );
     QgsExpressionContextUtils::setProjectVariable( mCurrentProject, QStringLiteral( "mergin_project_name" ),  metadata.name );
     QgsExpressionContextUtils::setProjectVariable( mCurrentProject, QStringLiteral( "mergin_project_full_name" ),  mMerginApi->getFullProjectName( metadata.projectNamespace,  metadata.name ) );
-    QgsExpressionContextUtils::setProjectVariable( mCurrentProject, QStringLiteral( "mergin_project_owner" ),   metadata.projectNamespace );
     QgsExpressionContextUtils::setProjectVariable( mCurrentProject, QStringLiteral( "mm_project_version" ), metadata.version );
     QgsExpressionContextUtils::setProjectVariable( mCurrentProject, QStringLiteral( "mm_project_name" ),  metadata.name );
     QgsExpressionContextUtils::setProjectVariable( mCurrentProject, QStringLiteral( "mm_project_full_name" ),  mMerginApi->getFullProjectName( metadata.projectNamespace,  metadata.name ) );
-    QgsExpressionContextUtils::setProjectVariable( mCurrentProject, QStringLiteral( "mm_project_owner" ),   metadata.projectNamespace );
   }
   else
   {


### PR DESCRIPTION
This is a follow-up after changes in the plugin https://github.com/MerginMaps/qgis-plugin/pull/696. `mergin_project_owner` and `mm_project_owner` did not bear any value with the current DB structure. 