### PR TITLE
Add build number to CI summary

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -242,6 +242,9 @@ jobs:
             echo "INPUT_VERSION_CODE=${BUILD_NUM}" >> $GITHUB_ENV
 
             echo "Version code: ${BUILD_NUM}"
+
+            # add build number to summary
+            echo ":rocket: Build number: ${BUILD_NUM}" >> $GITHUB_STEP_SUMMARY
                                     
       - name: Configure Input
         env:

--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -180,6 +180,9 @@ jobs:
             echo "INPUT_VERSION_CODE=${CF_BUNDLE_VERSION}" >> $GITHUB_ENV
             echo "Build number: ${CF_BUNDLE_VERSION}"
 
+            # add build number to summary
+            echo ":rocket: Build number: ${CF_BUNDLE_VERSION}" >> $GITHUB_STEP_SUMMARY
+
       - name: Create build system with cmake
         run: |
           mkdir -p install-Input


### PR DESCRIPTION
Adds build number to CI summary so we won't need to dig it in logs. Implemented for Android and iOS builds.

<img width="300" alt="image" src="https://github.com/user-attachments/assets/3cf416b2-88b3-41b0-9d20-236f954c6b48" />
