### PR TITLE
Fix empty name enables account closing

### DIFF
--- a/app/qml/project/MMProjectController.qml
+++ b/app/qml/project/MMProjectController.qml
@@ -549,7 +549,7 @@ Item {
 
   MMCloseAccountDialog {
     id: closeAccountDialog
-    username: __merginApi.userAuth.username
+    username: __merginApi.userInfo.username
 
     onCloseAccountClicked: {
       __merginApi.deleteAccount()


### PR DESCRIPTION
fixes #3951 

When logged in via SSO the button to close your account in Close account dialog is automatically enabled. We don't want this as it doesn't mirror the behaviour when logged in via email/password.