### PR TITLE
Sort layer order in the controller either by qgis order or by alphabetical order based on the setting

### DIFF
--- a/app/layer/layertreesortfiltermodel.cpp
+++ b/app/layer/layertreesortfiltermodel.cpp
@@ -95,10 +95,12 @@ QModelIndex LayerTreeSortFilterModel::node2index( QgsLayerTreeNode *node ) const
 void LayerTreeSortFilterModel::onSourceModelInitialized()
 {
   bool sortMethod = mLayerTreeModel->qgsProject()->readNumEntry( QStringLiteral( "Mergin" ), QStringLiteral( "SortLayersMethod/Method" ), 1 );
-  if ( sortMethod == SortMethodEnum::Alphabetical ) {
+  if ( sortMethod == SortMethodEnum::Alphabetical )
+  {
     sort( 0 );
   }
-  else{
+  else
+  {
     // pass
   }
 

--- a/app/layer/layertreesortfiltermodel.cpp
+++ b/app/layer/layertreesortfiltermodel.cpp
@@ -94,5 +94,8 @@ QModelIndex LayerTreeSortFilterModel::node2index( QgsLayerTreeNode *node ) const
 
 void LayerTreeSortFilterModel::onSourceModelInitialized()
 {
-  sort( 0 );
+  bool sortAlphabetical = mLayerTreeModel->qgsProject()->readBoolEntry( QStringLiteral( "Mergin" ), QStringLiteral( "SortLayersAlphabetical/Enabled" ), true );
+
+  if ( sortAlphabetical )
+    sort( 0 );
 }

--- a/app/layer/layertreesortfiltermodel.cpp
+++ b/app/layer/layertreesortfiltermodel.cpp
@@ -94,8 +94,12 @@ QModelIndex LayerTreeSortFilterModel::node2index( QgsLayerTreeNode *node ) const
 
 void LayerTreeSortFilterModel::onSourceModelInitialized()
 {
-  bool sortAlphabetical = mLayerTreeModel->qgsProject()->readBoolEntry( QStringLiteral( "Mergin" ), QStringLiteral( "SortLayersAlphabetical/Enabled" ), true );
-
-  if ( sortAlphabetical )
+  bool sortMethod = mLayerTreeModel->qgsProject()->readNumEntry( QStringLiteral( "Mergin" ), QStringLiteral( "SortLayersMethod/Method" ), 1 );
+  if ( sortMethod == SortMethodEnum::Alphabetical ) {
     sort( 0 );
+  }
+  else{
+    // pass
+  }
+
 }

--- a/app/layer/layertreesortfiltermodel.h
+++ b/app/layer/layertreesortfiltermodel.h
@@ -26,6 +26,13 @@ class LayerTreeSortFilterModel : public QSortFilterProxyModel
 
   public:
 
+    enum SortMethodEnum
+    {
+      PreserveQgisOrder = 0,
+      Alphabetical,
+    };
+    Q_ENUM( SortMethodEnum );
+
     explicit LayerTreeSortFilterModel( QObject *parent = nullptr );
     virtual ~LayerTreeSortFilterModel();
 

--- a/app/test/testlayertree.cpp
+++ b/app/test/testlayertree.cpp
@@ -116,7 +116,7 @@ void TestLayerTree::testLayerTreeModel()
 
   QVariant firstNode = sortModel->data( sortModel->index( 0, 0 ), Qt::DisplayRole );
   QCOMPARE( firstNode.toString(), QStringLiteral( "FlySector" ) );
-  
+
   // the signal here (in order to sort) manually as we assign the source model later
   project->writeEntry( QStringLiteral( "Mergin" ), QStringLiteral( "SortLayersAlphabetical/Enabled" ), true );
   emit model->modelInitialized();

--- a/app/test/testlayertree.cpp
+++ b/app/test/testlayertree.cpp
@@ -111,9 +111,17 @@ void TestLayerTree::testLayerTreeModel()
 
   // in QML sourceModel is set immediately, so we need to emit
   // the signal here (in order to sort) manually as we assign the source model later
+  project->writeEntry( QStringLiteral( "Mergin" ), QStringLiteral( "SortLayersAlphabetical/Enabled" ), false );
   emit model->modelInitialized();
 
   QVariant firstNode = sortModel->data( sortModel->index( 0, 0 ), Qt::DisplayRole );
+  QCOMPARE( firstNode.toString(), QStringLiteral( "FlySector" ) );
+  
+  // the signal here (in order to sort) manually as we assign the source model later
+  project->writeEntry( QStringLiteral( "Mergin" ), QStringLiteral( "SortLayersAlphabetical/Enabled" ), true );
+  emit model->modelInitialized();
+
+  firstNode = sortModel->data( sortModel->index( 0, 0 ), Qt::DisplayRole );
   QCOMPARE( firstNode.toString(), QStringLiteral( "airport-towers" ) );
 
   delete sortModel;

--- a/app/test/testlayertree.cpp
+++ b/app/test/testlayertree.cpp
@@ -111,14 +111,14 @@ void TestLayerTree::testLayerTreeModel()
 
   // in QML sourceModel is set immediately, so we need to emit
   // the signal here (in order to sort) manually as we assign the source model later
-  project->writeEntry( QStringLiteral( "Mergin" ), QStringLiteral( "SortLayersAlphabetical/Enabled" ), false );
+  project->writeEntry( QStringLiteral( "Mergin" ), QStringLiteral( "SortLayersMethod/Method" ), LayerTreeSortFilterModel::SortMethodEnum::PreserveQgisOrder );
   emit model->modelInitialized();
 
   QVariant firstNode = sortModel->data( sortModel->index( 0, 0 ), Qt::DisplayRole );
   QCOMPARE( firstNode.toString(), QStringLiteral( "FlySector" ) );
 
   // the signal here (in order to sort) manually as we assign the source model later
-  project->writeEntry( QStringLiteral( "Mergin" ), QStringLiteral( "SortLayersAlphabetical/Enabled" ), true );
+  project->writeEntry( QStringLiteral( "Mergin" ), QStringLiteral( "SortLayersMethod/Method" ), LayerTreeSortFilterModel::SortMethodEnum::Alphabetical );
   emit model->modelInitialized();
 
   firstNode = sortModel->data( sortModel->index( 0, 0 ), Qt::DisplayRole );


### PR DESCRIPTION
Respect qgis layer panel order unless specified otherwise in the mergin configuration

See also https://github.com/MerginMaps/qgis-plugin/pull/756 