### PR TITLE
cancel running background feature requests on model destruction

### DIFF
--- a/app/layerfeaturesmodel.cpp
+++ b/app/layerfeaturesmodel.cpp
@@ -114,6 +114,8 @@ QgsFeatureList LayerFeaturesModel::fetchFeatures( QgsVectorLayerFeatureSource *s
     fl.append( f );
   }
 
+  canceled = canceled || ( req.feedback() && req.feedback()->isCanceled() );
+
   qDebug() << QString( "Search (%1) %2 after %3ms, results: %4" ).arg( searchId ).arg( canceled ? "was canceled" : "completed" ).arg( t.elapsed() ).arg( fl.count() );
   return fl;
 }

--- a/app/layerfeaturesmodel.h
+++ b/app/layerfeaturesmodel.h
@@ -117,6 +117,8 @@ class LayerFeaturesModel : public FeaturesModel
     bool mFetchingResults = false;
     bool mUseAttributeTableSortOrder = false;
 
+    std::unique_ptr<QgsFeedback> mFeedback;
+
     friend class TestModels;
 };
 


### PR DESCRIPTION
Very long running feature requests would keep running in background thread even if the caller model was destroyed.

We could also increment `mNextSearchId` upon destruction to cancel pending request, but passing a `QgsFeedback` pointer is clearer.