### PR TITLE
Fix panning in image preview

### DIFF
--- a/app/qml/form/components/photo/MMPhotoPreview.qml
+++ b/app/qml/form/components/photo/MMPhotoPreview.qml
@@ -110,25 +110,30 @@ Popup {
         PinchArea {
           id: pincher
           anchors.fill: parent
+          pinch.target: imagePreview
+          pinch.minimumRotation: -180
+          pinch.maximumRotation: 180
+          pinch.minimumScale: 0.5
+          pinch.maximumScale: 10
           property real _startScale: 1
 
           onPinchStarted: function(pinch) {
             pinch.accepted = true
             _startScale = photoFrame.scale
           }
-          onPinchUpdated: function(pinch) {
-            var newScale = Math.max(photoFrame.minScale, Math.min(photoFrame.maxScale, _startScale * pinch.scale))
-            var p = pincher.mapToItem(flick.contentItem, pinch.center.x, pinch.center.y)
+          // onPinchUpdated: function(pinch) {
+          //   var newScale = Math.max(photoFrame.minScale, Math.min(photoFrame.maxScale, _startScale * pinch.scale))
+          //   var p = pincher.mapToItem(flick.contentItem, pinch.center.x, pinch.center.y)
 
-            var prevScale = photoFrame.scale
-            photoFrame.scale = newScale
+          //   var prevScale = photoFrame.scale
+          //   photoFrame.scale = newScale
 
-            var ratio = newScale / prevScale
-            flick.contentX = (flick.contentX + p.x) * ratio - p.x
-            flick.contentY = (flick.contentY + p.y) * ratio - p.y
+          //   var ratio = newScale / prevScale
+          //   flick.contentX = (flick.contentX + p.x) * ratio - p.x
+          //   flick.contentY = (flick.contentY + p.y) * ratio - p.y
 
-            flick._clamp()
-          }
+          //   flick._clamp()
+          // }
 
           onPinchFinished: function(pinch) {
             flick._clamp()

--- a/app/qml/form/components/photo/MMPhotoPreview.qml
+++ b/app/qml/form/components/photo/MMPhotoPreview.qml
@@ -61,15 +61,16 @@ Popup {
         boundsBehavior: Flickable.StopAtBounds
         maximumFlickVelocity: 4000
 
-
-        contentWidth:  Math.max(width,  imagePreview.width  * photoFrame.scale)
-        contentHeight: Math.max(height, imagePreview.height * photoFrame.scale)
+        contentWidth:  Math.max(width,  imagePreview.width  * imagePreview.scale)
+        contentHeight: Math.max(height, imagePreview.height * imagePreview.scale)
 
         Image {
           id: imagePreview
           source: root.photoUrl
           anchors.centerIn: parent
-          height: root.height * 0.75
+          sourceSize.width: root.width * 0.85
+          sourceSize.height: root.height * 0.85
+
           smooth: true
           clip: true
           focus: true
@@ -77,6 +78,17 @@ Popup {
           autoTransform: true
           fillMode: Image.PreserveAspectFit
           scale: photoFrame.scale
+          Component.onCompleted:
+          {
+            if(root.width > root.height)
+            {
+              this.height = root.height * 0.85
+            }
+            else
+            {
+              this.width = root.width * 0.85
+            }
+          }
         }
 
         // Keep content in bounds; recenters when content smaller or bigger than viewport

--- a/app/qml/form/components/photo/MMPhotoPreview.qml
+++ b/app/qml/form/components/photo/MMPhotoPreview.qml
@@ -15,7 +15,7 @@ import "../../../components" as MMComponents
 Popup {
   id: root
 
-  property alias photoUrl: imagePreview.source
+  property url photoUrl //passed url externally
 
   parent: Overlay.overlay
   visible: true
@@ -79,7 +79,7 @@ Popup {
 
             Image {
               id: imagePreview
-
+              source: root.photoUrl
               height: root.height / 2
 
               clip: true
@@ -98,6 +98,7 @@ Popup {
             }
           }
         }
+
         // Keep content in bounds; recenters when content smaller than viewport
         function _clamp() {
           const maxX = Math.max(0, contentWidth  - width)

--- a/app/qml/form/components/photo/MMPhotoPreview.qml
+++ b/app/qml/form/components/photo/MMPhotoPreview.qml
@@ -68,9 +68,8 @@ Popup {
           id: imagePreview
           source: root.photoUrl
           anchors.centerIn: parent
-          sourceSize.width: root.width * 0.85
-          sourceSize.height: root.height * 0.85
-
+          width:  (implicitWidth  >= implicitHeight) ? root.width  * 0.85 : undefined
+          height: (implicitHeight >  implicitWidth)  ? root.height * 0.85 : undefined
           smooth: true
           clip: true
           focus: true
@@ -78,17 +77,6 @@ Popup {
           autoTransform: true
           fillMode: Image.PreserveAspectFit
           scale: photoFrame.scale
-          Component.onCompleted:
-          {
-            if(root.width > root.height)
-            {
-              this.height = root.height * 0.85
-            }
-            else
-            {
-              this.width = root.width * 0.85
-            }
-          }
         }
 
         // Keep content in bounds; recenters when content smaller or bigger than viewport

--- a/app/qml/form/components/photo/MMPhotoPreview.qml
+++ b/app/qml/form/components/photo/MMPhotoPreview.qml
@@ -45,32 +45,60 @@ Popup {
 
     Item {
       id: photoFrame
+      anchors.fill: parent
+      clip: true
 
-      width: Math.min(imagePreview.width, parent.width)
-      height: Math.min(imagePreview.height, parent.height)
+      //Zoom limits
+      property real minScale: 0.5
+      property real maxScale: 10.0
+      property real scale: 1.0
+      // width: Math.min(imagePreview.width, parent.width)
+      // height: Math.min(imagePreview.height, parent.height)
 
-      y: parent.height / 2 - height / 2
-      x: parent.width / 2 - width / 2
-
-      Image {
-        id: imagePreview
-
-        height: root.height / 2
-
+      Flickable {
+        id: flick
+        anchors.fill: parent
         clip: true
+        interactive: true
+        boundsBehavior: Flickable.StopAtBounds
+        maximumFlickVelocity: 4000
 
-        focus: true
-        asynchronous: true
-        autoTransform: true
-        fillMode: Image.PreserveAspectFit
+        contentWidth:  Math.max(width,  imagePreview.paintedWidth  * photoFrame.scale)
+        contentHeight: Math.max(height, imagePreview.paintedHeight * photoFrame.scale)
 
-        PinchArea {
-          anchors.fill: parent
-          pinch.target: imagePreview
-          pinch.minimumRotation: -180
-          pinch.maximumRotation: 180
-          pinch.minimumScale: 0.5
-          pinch.maximumScale: 10
+        Item {
+          id: canvas
+          width: flick.contentWidth
+          height: flick.contentHeight
+
+          Item {
+            id: imageHolder
+            width: imagePreview.width
+            height: imagePreview.height
+            anchors.centerIn: parent
+
+            Image {
+              id: imagePreview
+
+              height: root.height / 2
+
+              clip: true
+
+              focus: true
+              asynchronous: true
+              autoTransform: true
+              fillMode: Image.PreserveAspectFit
+
+              PinchArea {
+                anchors.fill: parent
+                pinch.target: imagePreview
+                pinch.minimumRotation: -180
+                pinch.maximumRotation: 180
+                pinch.minimumScale: 0.5
+                pinch.maximumScale: 10
+              }
+            }
+          }
         }
       }
     }

--- a/app/qml/form/components/photo/MMPhotoPreview.qml
+++ b/app/qml/form/components/photo/MMPhotoPreview.qml
@@ -48,9 +48,11 @@ Popup {
       anchors.fill: parent
       clip: true
 
-      //Zoom limits
+      // //Zoom limits
       property real minScale: 0.5
       property real maxScale: 10.0
+      property real maxRotation: 180
+      property real minRotation: -180
       property real scale: 1.0
       // width: Math.min(imagePreview.width, parent.width)
       // height: Math.min(imagePreview.height, parent.height)
@@ -63,7 +65,7 @@ Popup {
         boundsBehavior: Flickable.StopAtBounds
         maximumFlickVelocity: 4000
 
-        contentWidth:  Math.max(width,  imagePreview.paintedWidth  * photoFrame.scale)
+        contentWidth:  Math.max(width,  imagePreview.paintedWidth * photoFrame.scale)
         contentHeight: Math.max(height, imagePreview.paintedHeight * photoFrame.scale)
 
         Item {
@@ -80,7 +82,8 @@ Popup {
             Image {
               id: imagePreview
               source: root.photoUrl
-              height: root.height / 2
+              height: root.height
+              width: root.width
 
               clip: true
 
@@ -111,29 +114,33 @@ Popup {
           id: pincher
           anchors.fill: parent
           pinch.target: imagePreview
-          pinch.minimumRotation: -180
-          pinch.maximumRotation: 180
-          pinch.minimumScale: 0.5
-          pinch.maximumScale: 10
+          pinch.minimumRotation: photoFrame.minRotation
+          pinch.maximumRotation: photoFrame.maxRotation
+          pinch.minimumScale: photoFrame.minScale
+          pinch.maximumScale: photoFrame.maxScale
           property real _startScale: 1
 
           onPinchStarted: function(pinch) {
             pinch.accepted = true
             _startScale = photoFrame.scale
+            console.log("_startScale:"+ _startScale)
           }
-          // onPinchUpdated: function(pinch) {
-          //   var newScale = Math.max(photoFrame.minScale, Math.min(photoFrame.maxScale, _startScale * pinch.scale))
-          //   var p = pincher.mapToItem(flick.contentItem, pinch.center.x, pinch.center.y)
+          onPinchUpdated: function(pinch) {
+            var newScale = Math.min(photoFrame.scale, _startScale * pinch.scale)
+            var p = pincher.mapToItem(flick.contentItem, pinch.center.x, pinch.center.y)
+            console.log("newScale and p: "+ newScale + "...." + p)
 
-          //   var prevScale = photoFrame.scale
-          //   photoFrame.scale = newScale
+            var prevScale = photoFrame.scale
+            photoFrame.scale = newScale
 
-          //   var ratio = newScale / prevScale
-          //   flick.contentX = (flick.contentX + p.x) * ratio - p.x
-          //   flick.contentY = (flick.contentY + p.y) * ratio - p.y
+            var ratio = newScale / prevScale
+            console.log("ratio"+ ratio)
+            flick.contentX = (flick.contentX + p.x) * ratio
+            flick.contentY = (flick.contentY + p.y) * ratio
+            console.log("flick.contentX and flick.contentY"+ flick.contentX + "....." + flick.contentY)
 
-          //   flick._clamp()
-          // }
+            flick._clamp()
+          }
 
           onPinchFinished: function(pinch) {
             flick._clamp()

--- a/app/qml/form/components/photo/MMPhotoPreview.qml
+++ b/app/qml/form/components/photo/MMPhotoPreview.qml
@@ -80,7 +80,7 @@ Popup {
         }
 
         // Keep content in bounds; recenters when content smaller or bigger than viewport
-        function _clamp() {
+        function clamp {
           const maxX = Math.max(0, contentWidth  - width)
           const maxY = Math.max(0, contentHeight - height)
           contentX = Math.max(0, Math.min(maxX, contentX))
@@ -119,10 +119,10 @@ Popup {
               flick.contentY += (after.y - before.y)
             }
 
-            flick._clamp()
+            flick.clamp
           }
 
-          onPinchFinished: function() { flick._clamp() }
+          onPinchFinished: function() { flick.clamp }
         }
       }
     }

--- a/app/qml/form/components/photo/MMPhotoPreview.qml
+++ b/app/qml/form/components/photo/MMPhotoPreview.qml
@@ -48,7 +48,7 @@ Popup {
       anchors.fill: parent
       clip: true
 
-      // //Zoom limits
+      // Zoom limits
       property real minScale: 0.5
       property real maxScale: 10.0
       property real scale: 1.0

--- a/app/qml/form/components/photo/MMPhotoPreview.qml
+++ b/app/qml/form/components/photo/MMPhotoPreview.qml
@@ -127,7 +127,7 @@ Popup {
             imagePreview.smooth = true
             flick.interactive = true
             flick.clamp()
-            flick.returnToBounds()
+            flick.returnToBounds() //builin func- helps rebound to original location after zoom in/out without disorienting picture.
           }
         }
       }

--- a/app/qml/form/components/photo/MMPhotoPreview.qml
+++ b/app/qml/form/components/photo/MMPhotoPreview.qml
@@ -15,7 +15,7 @@ import "../../../components" as MMComponents
 Popup {
   id: root
 
-  property url photoUrl //passed url externally
+  property url photoUrl
 
   parent: Overlay.overlay
   visible: true

--- a/app/qml/form/components/photo/MMPhotoPreview.qml
+++ b/app/qml/form/components/photo/MMPhotoPreview.qml
@@ -67,8 +67,8 @@ Popup {
         Image {
           id: imagePreview
           source: root.photoUrl
-          height: root.height
           width: root.width
+          anchors.centerIn: parent
 
           clip: true
 
@@ -77,7 +77,6 @@ Popup {
           autoTransform: true
           fillMode: Image.PreserveAspectFit
           scale: photoFrame.scale
-          transformOrigin: Item.TopLeft
         }
 
         // Keep content in bounds; recenters when content smaller or bigger than viewport

--- a/app/qml/form/components/photo/MMPhotoPreview.qml
+++ b/app/qml/form/components/photo/MMPhotoPreview.qml
@@ -104,15 +104,15 @@ Popup {
 
           onPinchUpdated: function(pinch) {
             //to keep the new scaled value after the user zooms in, calculating
-            var newScale = Math.max(photoFrame.minScale, Math.min(photoFrame.maxScale, startScale * pinch.scale))
-            var local = pincher.mapToItem(imagePreview, pinch.center.x, pinch.center.y)
-            var before = imagePreview.mapToItem(flick.contentItem, local.x, local.y)
-            var old = photoFrame.scale
+            const newScale = Math.max(photoFrame.minScale, Math.min(photoFrame.maxScale, startScale * pinch.scale))
+            const local = pincher.mapToItem(imagePreview, pinch.center.x, pinch.center.y)
+            const before = imagePreview.mapToItem(flick.contentItem, local.x, local.y)
+            const old = photoFrame.scale
             if (newScale !== old) {
               photoFrame.scale = newScale
 
               // same local point sits in content -after- scaling
-              var after = imagePreview.mapToItem(flick.contentItem, local.x, local.y)
+              const after = imagePreview.mapToItem(flick.contentItem, local.x, local.y)
 
               //shift scroll so the point stays under the fingers
               flick.contentX += (after.x - before.x)

--- a/app/qml/form/components/photo/MMPhotoPreview.qml
+++ b/app/qml/form/components/photo/MMPhotoPreview.qml
@@ -61,17 +61,17 @@ Popup {
         boundsBehavior: Flickable.StopAtBounds
         maximumFlickVelocity: 4000
 
+
         contentWidth:  Math.max(width,  imagePreview.width  * photoFrame.scale)
         contentHeight: Math.max(height, imagePreview.height * photoFrame.scale)
 
         Image {
           id: imagePreview
           source: root.photoUrl
-          width: root.width
           anchors.centerIn: parent
-
+          height: root.height * 0.75
+          smooth: true
           clip: true
-
           focus: true
           asynchronous: true
           autoTransform: true


### PR DESCRIPTION
- Replaced pinch.target scaling with Flickable and PinchArea.
- On pinch, map center -> adjust contentX and Y so zoom focuses under fingers.
- Added _clamp() to keep content within bounds
- Changed photoUrl from alias -> plain url (avoid circular binding).

fixes #3563 

https://github.com/user-attachments/assets/b0183ddb-f873-454e-b09d-58c839564a9d

