### PR TITLE
Make detail dialog only visible if errorMessage exists

### DIFF
--- a/app/qml/dialogs/MMSyncFailedDialog.qml
+++ b/app/qml/dialogs/MMSyncFailedDialog.qml
@@ -38,10 +38,6 @@ MMComponents.MMDrawerDialog {
       width: parent.width
       text: qsTr("Details") + ": " + root.detailedText
     }
-    Component.onCompleted:
-    {
-      console.log(detailedText);
-    }
   }
 
   onPrimaryButtonClicked: {

--- a/app/qml/dialogs/MMSyncFailedDialog.qml
+++ b/app/qml/dialogs/MMSyncFailedDialog.qml
@@ -23,10 +23,7 @@ MMComponents.MMDrawerDialog {
   id: root
 
   property string detailedText
-  property bool hasDetails: {
-    const t = (root.detailedText ?? "").trim()
-    return t.length > 0
-  }
+  property bool hasDetails: root.detailedText?.trim() ?? false
 
   title: qsTr( "Failed to synchronise your changes" )
   imageSource: __style.syncFailedImage

--- a/app/qml/dialogs/MMSyncFailedDialog.qml
+++ b/app/qml/dialogs/MMSyncFailedDialog.qml
@@ -23,6 +23,10 @@ MMComponents.MMDrawerDialog {
   id: root
 
   property string detailedText
+  property bool hasDetails: {
+    const t = (root.detailedText ?? "").trim()
+    return t.length > 0
+  }
 
   title: qsTr( "Failed to synchronise your changes" )
   imageSource: __style.syncFailedImage
@@ -30,9 +34,17 @@ MMComponents.MMDrawerDialog {
   description: qsTr( "Your changes could not be sent to the server, make sure you have a data connection and have permission to edit this project." )
   primaryButton.text: qsTr( "Ok, I understand" )
 
-  additionalContent: MMDialogComponents.MMDialogAdditionalText {
+  additionalContent: Loader {
     width: parent.width
-    text: root.detailedText
+    active: root.hasDetails //status we receive if there is no data connection, either True or False
+    sourceComponent: MMDialogComponents.MMDialogAdditionalText {
+      width: parent.width
+      text: qsTr("Details") + ": " + root.detailedText
+    }
+    Component.onCompleted:
+    {
+      console.log(detailedText);
+    }
   }
 
   onPrimaryButtonClicked: {

--- a/app/qml/main.qml
+++ b/app/qml/main.qml
@@ -959,7 +959,7 @@ ApplicationWindow {
         }
         else
         {
-          syncFailedDialog.detailedText = qsTr( "Details" ) + ": " + errorMessage
+          syncFailedDialog.detailedText = errorMessage
           if ( willRetry )
           {
             __notificationModel.addError( qsTr( "There was an issue during synchronisation, we will try again. Click to learn more" ),


### PR DESCRIPTION
Added the hasDetails flag to show or hide details component.
Set detailedText only if error message exists
Loader is used so details block is created only when needed