### PR TITLE
Fix temp sketch file not loading

### DIFF
--- a/app/photosketchingcontroller.cpp
+++ b/app/photosketchingcontroller.cpp
@@ -236,7 +236,7 @@ ColorPath PhotoSketchingController::getPath( const int row ) const
 QUrl PhotoSketchingController::getCurrentPhotoPath() const
 {
   const QString photoFileName = QUrl( mPhotoSource ).fileName();
-  const QString photoPath = QString( "%1/%2/%3" ).arg( QDir::temp().absolutePath(), mProjectName, photoFileName );
+  const QString photoPath = QString( "%1/%2/%3" ).arg( QDir::tempPath(), mProjectName, photoFileName );
   if ( QFile::exists( photoPath ) )
   {
     return { photoPath };
@@ -250,7 +250,7 @@ void PhotoSketchingController::prepareController()
   mProjectName = QUrl::fromLocalFile( mProjectName ).fileName();
   mOriginalPhotoSource = QUrl( mPhotoSource ).toLocalFile();
   const QString photoFileName = QUrl( mPhotoSource ).fileName();
-  const QString savePath = QString( "%1/%2/%3" ).arg( QDir::temp().absolutePath(), mProjectName, photoFileName );
+  const QString savePath = QString( "%1/%2/%3" ).arg( QDir::tempPath(), mProjectName, photoFileName );
   if ( !photoFileName.isEmpty() && QFile::exists( savePath ) )
   {
     mPhotoSource = QUrl::fromLocalFile( savePath ).toString();

--- a/app/test/testsketching.cpp
+++ b/app/test/testsketching.cpp
@@ -173,7 +173,7 @@ void TestSketching::testLoadBackupSketch()
   QCOMPARE( sketchingController.mOriginalPhotoSource, QUrl( path ).toLocalFile() );
   QCOMPARE( spy.count(), 1 );
   auto signalArgs = spy.takeLast();
-  QCOMPARE( signalArgs.first().toString(), "file://" + QDir::tempPath() + QStringLiteral( "/test_sketching" ) + QStringLiteral( "/MM_test_image.jpg" ) );
+  QCOMPARE( signalArgs.first().toString(), QDir::tempPath() + QStringLiteral( "/test_sketching" ) + QStringLiteral( "/MM_test_image.jpg" ) );
 
   // check for nonexisting backup
   PhotoSketchingController sketchingController2;


### PR DESCRIPTION
fixes some more bugs found during testing:

> Photos with photo sketches disappear when scrolling in the form on a mobile device. After saving the record, the images with sketches are visible again. You can use project tester-ws-1/test_photo-sketches

> Android only: the orientation of photo change after adding photo sketches. And if you save the record and reopen it in edit mode, the orientation change again after adding new sketches - the photo with sketches rotate 90degrees clockwise. You can use project tester-ws-1/test_photo-sketches

the android bug was a side effect probably