### PR TITLE
WIP: ThemeDrawer maxHeight changed; testing left for theme lists

### DIFF
--- a/app/qml/main.qml
+++ b/app/qml/main.qml
@@ -516,7 +516,7 @@ ApplicationWindow {
   MMMapThemeDrawer {
     id: mapThemesPanel
 
-    maxHeight: ( window.height / 2 )
+    maxHeight: window.height
     width: window.width
     edge: Qt.BottomEdge
 


### PR DESCRIPTION
Only changed the `maxHeight: window.height ` of existing MMMapThemeDrawer, and now it fills the window at max with all the themes, and after filling entirely, we can scroll for the rest of the themes.

Tested as in attached video:

https://github.com/user-attachments/assets/b803d8da-9283-40df-a8b7-6f23dd2f4505

