### PR TITLE
Fix: Unify measurement tools with Figma

### DIFF
--- a/app/qml/components/MMButton.qml
+++ b/app/qml/components/MMButton.qml
@@ -165,8 +165,19 @@ Button {
   implicitHeight: root.type === MMButton.Types.Tertiary ? buttonContent.height : buttonContent.height + topPadding + bottomPadding
   implicitWidth: row.paintedChildrenWidth + 2 * ( root.size === MMButton.Sizes.Small ? __style.margin16 : __style.margin20 )
 
-  topPadding: ( root.type === MMButton.Types.Tertiary ) ? 0 : 11 * __dp
-  bottomPadding: ( root.type === MMButton.Types.Tertiary ) ? 0 : 11 * __dp
+  topPadding: {
+    if ( root.type === MMButton.Types.Tertiary )
+      return 0
+    else
+      return ( root.size === MMButton.Sizes.Small ) ? 7 * __dp : 11 * __dp
+  }
+
+  bottomPadding: {
+    if ( root.type === MMButton.Types.Tertiary )
+      return 0
+    else
+      return ( root.size === MMButton.Sizes.Small ) ? 7 * __dp : 11 * __dp
+  }
   rightPadding: 0
   leftPadding: 0
 

--- a/app/qml/gps/MMMeasureDrawer.qml
+++ b/app/qml/gps/MMMeasureDrawer.qml
@@ -54,11 +54,16 @@ MMDrawer {
   drawerHeader.title: qsTr( "Measure" )
 
   drawerHeader.topLeftItemContent: MMButton {
-    type: MMButton.Types.Primary
     text: measurementFinalized ? qsTr( "Repeat" ) : qsTr( "Undo" )
     iconSourceLeft: measurementFinalized ? __style.syncIcon : __style.undoIcon
-    bgndColor: __style.lightGreenColor
+
+    type: MMButton.Types.Primary
     size: MMButton.Sizes.Small
+    bgndColor: __style.lightGreenColor
+    bgndColorDisabled: __style.polarColor
+    bgndColorHover: __style.mediumGreenColor
+    fontColorHover: __style.forestColor
+    iconColorHover: __style.forestColor
     enabled: measurementFinalized || canUndo
 
     anchors {

--- a/app/qml/gps/MMMeasureDrawer.qml
+++ b/app/qml/gps/MMMeasureDrawer.qml
@@ -54,6 +54,7 @@ MMDrawer {
   drawerHeader.title: qsTr( "Measure" )
 
   drawerHeader.topLeftItemContent: MMButton {
+    id: btnOne
     text: measurementFinalized ? qsTr( "Repeat" ) : qsTr( "Undo" )
     iconSourceLeft: measurementFinalized ? __style.syncIcon : __style.undoIcon
 
@@ -72,7 +73,11 @@ MMDrawer {
       verticalCenter: parent.verticalCenter
     }
 
-    onClicked: measurementFinalized ? root.mapTool.resetMeasurement() : root.mapTool.removePoint()
+    onClicked:
+    {
+      console.log("Height: " + btnOne.implicitHeight)
+      measurementFinalized ? root.mapTool.resetMeasurement() : root.mapTool.removePoint()
+    }
   }
 
   drawerContent: Column {


### PR DESCRIPTION
Fixed:
-Explicit value assigned for MMButton-"Undo btn" to match the requirement
- padding changed with conditionals to keep the old implementation of Tertiary type while, also enabling the height changed with size changed for MMButton to align with figma design.
