### PR TITLE
Fix missing photosketches after editing geometry

### DIFF
--- a/app/qml/form/editors/MMFormPhotoEditor.qml
+++ b/app/qml/form/editors/MMFormPhotoEditor.qml
@@ -93,7 +93,12 @@ MMFormPhotoViewer {
   photoUrl: internal.tempSketchedImageSource ? internal.tempSketchedImageSource : internal.resolvedImageSource
   hasCameraCapability: __androidUtils.isAndroid || __iosUtils.isIos
 
-  on_FieldValueChanged: internal.setImageSource()
+  on_FieldValueChanged: function (){
+    internal.setImageSource()
+    // after editing geometry this needs to be triggered to populate internal.tempSketchedImageSource for components,
+    // which were not in view
+    sketchingController?.prepareController()
+  }
   on_FieldValueIsNullChanged: internal.setImageSource()
 
   onCapturePhotoClicked: internal.capturePhoto()


### PR DESCRIPTION
This fixes a  bug where photo sketches were missing after users finished editing geometry. This bug only occurred on photo form components out of view when starting editing geometry.