### PR TITLE
Remove project loading flag few seconds after project load

### DIFF
--- a/app/activeproject.h
+++ b/app/activeproject.h
@@ -111,6 +111,7 @@ class ActiveProject: public QObject
 
     //! A File on this path represents that project is loading and exists only during the process.
     static const QString LOADING_FLAG_FILE_PATH;
+    static const int LOADING_FLAG_FILE_EXPIRATION_MS;
 
     const QString &mapTheme() const;
 

--- a/app/test/testactiveproject.cpp
+++ b/app/test/testactiveproject.cpp
@@ -166,3 +166,28 @@ void TestActiveProject::testRecordingAllowed()
   mApi->localProjectsManager().removeLocalProject( id );
 }
 
+void TestActiveProject::testLoadingFlagFileExpiration()
+{
+  AppSettings as;
+  ActiveLayer al;
+  ActiveProject activeProject( as, al, mApi->localProjectsManager() );
+
+  // project "planes" - tracking not enabled
+  QString projectDir = TestUtils::testDataDir() + "/planes/";
+  QString projectName = "quickapp_project.qgs";
+
+  mApi->localProjectsManager().addLocalProject( projectDir, projectName );
+
+  activeProject.load( projectDir + projectName );
+
+  QSignalSpy spyLoadingStarted( &activeProject, &ActiveProject::loadingStarted );
+
+  // check that loading flag file is created
+  QFile flagFile( ActiveProject::LOADING_FLAG_FILE_PATH );
+  QVERIFY( flagFile.exists() );
+
+  // wait for expiration + some margin
+  QTest::qWait( ActiveProject::LOADING_FLAG_FILE_EXPIRATION_MS + 1000 );
+
+  QVERIFY( !flagFile.exists() );
+}

--- a/app/test/testactiveproject.h
+++ b/app/test/testactiveproject.h
@@ -28,6 +28,7 @@ class TestActiveProject : public QObject
     void testProjectLoadFailure();
     void testPositionTrackingFlag();
     void testRecordingAllowed();
+    void testLoadingFlagFileExpiration();
 
   private:
     MerginApi *mApi;


### PR DESCRIPTION
So far we had a logic that prevented auto-opening of a project that failed to load on the last app run (crashed the app during project load). There was a case when the app crashed not during project load, but directly after that when trying to render first items.

The fix is to remove the loading flag only after a few seconds after the project is loaded. This helps with crashes like in #4069.

Fixes #4069 