### PR TITLE
Fix error dump on quit from QML components

### DIFF
--- a/app/main.cpp
+++ b/app/main.cpp
@@ -573,6 +573,9 @@ int main( int argc, char *argv[] )
     CoreUtils::log( QStringLiteral( "AppState" ), QStringLiteral( "Application has quit" ) );
   } );
 
+  // this fixes the error dump from C++ defined QML components, when quiting application
+  QObject::connect( &app, &QCoreApplication::aboutToQuit, &engine, &QQmlEngine::deleteLater );
+
   QObject::connect( &help, &InputHelp::submitReportSuccessful, &lambdaContext, [&notificationModel]()
   {
     notificationModel.addSuccess( QObject::tr( "Report submitted. Please contact the support" ) );


### PR DESCRIPTION
fixes #4019 

When the application is quit there are lines of errors logged. This started with C++ defined QML components using the `QML_ELEMENT` signature. The issue was in the chain of deleting objects on quit.