### PR TITLE
Fix replacing photos with renaming expression set

### DIFF
--- a/app/qml/form/editors/MMFormPhotoEditor.qml
+++ b/app/qml/form/editors/MMFormPhotoEditor.qml
@@ -127,7 +127,9 @@ MMFormPhotoViewer {
 
     onDeleteImage: {
       // schedule the image for deletion
-      internal.imageSourceToDelete = imageDeleteDialog.imagePath
+      const deletedPath = imageDeleteDialog.imagePath + ".deleted"
+      __inputUtils.renameFile( imageDeleteDialog.imagePath, deletedPath )
+      internal.imageSourceToDelete = deletedPath
       resetValueAndClose()
     }
 
@@ -203,6 +205,11 @@ MMFormPhotoViewer {
   }
 
   function callbackOnFormCanceled() {
+    // we remove the ".deleted" suffix
+    if ( internal.imageSourceToDelete ) {
+      const originalPath = internal.imageSourceToDelete.slice( 0, internal.imageSourceToDelete.length - 8 )
+      __inputUtils.renameFile( internal.imageSourceToDelete, originalPath )
+    }
     internal.imageSourceToDelete = ""
   }
 


### PR DESCRIPTION
fixes #3600

When user is editing feature and tries to replace photo which has expression set to rename the file name to the same as previous photo this action fails. We fix this with adding `.deleted` suffix to marked photo. This suffix gets removed on cancel.