### PR TITLE
Fix/diagnostic log copy able

### DIFF
--- a/app/qml/settings/MMLogPage.qml
+++ b/app/qml/settings/MMLogPage.qml
@@ -39,9 +39,9 @@ MMPage {
 
       TextEdit {
         id: txt
-        text: "Kaustuv <style>" + "a:link { color: " + __style.earthColor
+        text: "<style>" + "a:link { color: " + __style.earthColor
               + "; text-decoration: underline; }" + "p.odd { color: "
-              + __style.nightColor + "; }" + "</style>" + root.text + "KaustuvLAST"
+              + __style.nightColor + "; }" + "</style>" + root.text
         font: __style.t3
         color: __style.forestColor
         textFormat: Text.RichText


### PR DESCRIPTION
Changed **Text** element to **TextEdit**, as Text element doesn't have copyable property existing.
Add additional property to the component for making it readOnly and copyable from mouse or keyboard or with touch.
Changed the "selected text highlight with forestGreen" as the default one looked too off the branding. 

Could you please verify the color or if changed is required in the screenshots @tomasMizera 

<img width="491" height="731" alt="Screenshot 2025-09-29 at 3 23 43 PM" src="https://github.com/user-attachments/assets/63a28137-562c-4811-ac8f-aa3116ad67a1" />
<img width="490" height="756" alt="Screenshot 2025-09-29 at 3 35 21 PM" src="https://github.com/user-attachments/assets/063984c0-d453-44c2-a1ed-4914d6a7f8a5" />
