### PR TITLE
Fix haptic vibration

### DIFF
--- a/app/android/src/uk/co/lutraconsulting/InputActivity.java
+++ b/app/android/src/uk/co/lutraconsulting/InputActivity.java
@@ -50,6 +50,8 @@ import android.provider.OpenableColumns;
 import androidx.core.view.WindowCompat;
 import androidx.core.splashscreen.SplashScreen;
 
+import java.util.Arrays;
+
 public class InputActivity extends QtActivity
 {
   private static final String TAG = "Mergin Maps Input Activity";
@@ -290,19 +292,23 @@ public class InputActivity extends QtActivity
       vib = vibManager.getDefaultVibrator();
     }
 
+    // The reason why we use duplicate calls to vibrate is because some manufacturers (samsung) don't support
+    // the usage of predefined VibrationEffect and vice versa. In the end only one vibration gets executed.
     if (Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU)
     {
       if (Build.VERSION.SDK_INT < Build.VERSION_CODES.Q)
       {
-        vib.vibrate(VibrationEffect.createOneShot(10, VibrationEffect.DEFAULT_AMPLITUDE));
+        vib.vibrate(VibrationEffect.createOneShot(100, VibrationEffect.DEFAULT_AMPLITUDE));
       } else
       {
         vib.vibrate(VibrationEffect.createPredefined(VibrationEffect.EFFECT_CLICK));
+        vib.vibrate(VibrationEffect.createOneShot(100, VibrationEffect.DEFAULT_AMPLITUDE));
       }
     } else
     {
       vib.vibrate(VibrationEffect.createPredefined(VibrationEffect.EFFECT_CLICK),
         VibrationAttributes.createForUsage(VibrationAttributes.USAGE_CLASS_FEEDBACK));
+      vib.vibrate(VibrationEffect.createOneShot(100, VibrationEffect.DEFAULT_AMPLITUDE));
     }
   }
 

--- a/app/android/src/uk/co/lutraconsulting/InputActivity.java
+++ b/app/android/src/uk/co/lutraconsulting/InputActivity.java
@@ -50,8 +50,6 @@ import android.provider.OpenableColumns;
 import androidx.core.view.WindowCompat;
 import androidx.core.splashscreen.SplashScreen;
 
-import java.util.Arrays;
-
 public class InputActivity extends QtActivity
 {
   private static final String TAG = "Mergin Maps Input Activity";


### PR DESCRIPTION
fixes #4047 

On some manufacturer devices (Samsung) the native method `vibrate(VibrationEffect vibe, VibrationAttributes attributes)` is not supported even though the android version should support it. However some other devices don't support `vibrate(VibrationEffect vibe)` while supporting the previous overload. Thus we use both variants and one execution should trigger the actual vibration.

Android Vibrator API has `areEffectsSupported(int... effectIds)` method, however on tested devices it returned the same value even though the behavior was different. And even this value is not final as the vibrator should have a fallback vibration even if it returns `unsupported`.

I was not able to reproduce the sound issue, but @IvaKuklica was. I'll have to investigate further with her.