### PR TITLE
Add empty state for value map/relation

### DIFF
--- a/app/qml/components/MMListMultiselectDrawer.qml
+++ b/app/qml/components/MMListMultiselectDrawer.qml
@@ -66,7 +66,6 @@ MMDrawer {
       MMListSpacer { id: searchBarSpacer; height: __style.spacing20; visible: root.withSearch }
 
       Item {
-        id: featureList
         width: parent.width
         height: listViewComponent.count === 0 ? emptyStateDelegateLoader.height : listViewComponent.height
 

--- a/app/qml/form/editors/MMFormValueMapEditor.qml
+++ b/app/qml/form/editors/MMFormValueMapEditor.qml
@@ -87,14 +87,12 @@ MMFormComboboxBaseEditor {
 
       emptyStateDelegate: Item {
         width: parent.width
-        height: noItemsText.implicitHeight
-        anchors.centerIn: parent
-
+        height: noItemsText.implicitHeight + __style.margin40
+      
         MMComponents.MMText {
           id: noItemsText
           text: qsTr( "No items" )
           anchors.centerIn: parent
-          topPadding: __style.margin20
         }
       }
 

--- a/app/qml/form/editors/MMFormValueRelationEditor.qml
+++ b/app/qml/form/editors/MMFormValueRelationEditor.qml
@@ -73,14 +73,12 @@ MMFormComboboxBaseEditor {
 
       emptyStateDelegate: Item {
         width: parent.width
-        height: noItemsText.implicitHeight
-        anchors.centerIn: parent
-
+        height: noItemsText.implicitHeight + __style.margin40
+      
         MMComponents.MMText {
           id: noItemsText
           text: qsTr( "No items" )
           anchors.centerIn: parent
-          topPadding: __style.margin20
         }
       }
 


### PR DESCRIPTION
Fixed:
Component was missing emptyDelegate condition, which not fixed with "no items" text as a emptyDelegateState when no features are present on the list.
Added padding to match figma design
Added drawer bottom margin

<img width="413" height="713" alt="Screenshot 2025-10-07 at 11 59 31 PM" src="https://github.com/user-attachments/assets/dea768d0-5073-4ab9-a9ac-d0e382d0cbbe" />
