### PR TITLE
scrollbar for desktop builds in feature lists

### DIFF
--- a/app/inpututils.h
+++ b/app/inpututils.h
@@ -222,7 +222,7 @@ class InputUtils: public QObject
 
     /** InputApp platform */
     static QString appPlatform();
-    static bool isMobilePlatform();
+    Q_INVOKABLE static bool isMobilePlatform();
 
     static QString appDataDir();
 

--- a/app/qml/components/MMListDelegate.qml
+++ b/app/qml/components/MMListDelegate.qml
@@ -24,6 +24,7 @@ Item {
   property string text
   property string secondaryText
 
+  readonly property int scrollSpace: (ListView.view && ListView.view.scrollSpace) ? ListView.view.scrollSpace : 0
   property alias leftContent: leftContentGroup.children
   property alias rightContent: rightContentGroup.children
 
@@ -40,9 +41,10 @@ Item {
 
   property real verticalSpacing: root.secondaryText ? __style.margin8 : __style.margin20
 
-  implicitWidth: ListView?.view?.width ?? 0 // in case ListView is injected as attached property (usually it is)
+  implicitWidth: ListView?.view?.width ?? 0  // in case ListView is injected as attached property (usually it is)
   implicitHeight: contentLayout.implicitHeight
   height: visible ? implicitHeight : 0.1 // hide invisible items, for some reason setting 0 does not work ¯\_(ツ)_/¯
+  width: implicitWidth - root.scrollSpace
 
   MouseArea {
     anchors.fill: contentLayout

--- a/app/qml/components/MMListDelegate.qml
+++ b/app/qml/components/MMListDelegate.qml
@@ -24,7 +24,6 @@ Item {
   property string text
   property string secondaryText
 
-  readonly property int scrollSpace: (ListView.view && ListView.view.scrollSpace) ? ListView.view.scrollSpace : 0
   property alias leftContent: leftContentGroup.children
   property alias rightContent: rightContentGroup.children
 
@@ -44,7 +43,7 @@ Item {
   implicitWidth: ListView?.view?.width ?? 0  // in case ListView is injected as attached property (usually it is)
   implicitHeight: contentLayout.implicitHeight
   height: visible ? implicitHeight : 0.1 // hide invisible items, for some reason setting 0 does not work ¯\_(ツ)_/¯
-  width: implicitWidth - ListView.view.scrollSpace
+  width: implicitWidth - ( ListView?.view?.scrollSpace ?? 0 )
 
   MouseArea {
     anchors.fill: contentLayout

--- a/app/qml/components/MMListDelegate.qml
+++ b/app/qml/components/MMListDelegate.qml
@@ -40,10 +40,9 @@ Item {
 
   property real verticalSpacing: root.secondaryText ? __style.margin8 : __style.margin20
 
-  implicitWidth: ListView?.view?.width ?? 0  // in case ListView is injected as attached property (usually it is)
+  implicitWidth: ListView?.view?.width - ListView?.view?.scrollBarWidth ?? 0  // in case ListView is injected as attached property (usually it is)
   implicitHeight: contentLayout.implicitHeight
   height: visible ? implicitHeight : 0.1 // hide invisible items, for some reason setting 0 does not work ¯\_(ツ)_/¯
-  width: implicitWidth - ( ListView?.view?.scrollSpace ?? 0 )
 
   MouseArea {
     anchors.fill: contentLayout

--- a/app/qml/components/MMListDelegate.qml
+++ b/app/qml/components/MMListDelegate.qml
@@ -44,7 +44,7 @@ Item {
   implicitWidth: ListView?.view?.width ?? 0  // in case ListView is injected as attached property (usually it is)
   implicitHeight: contentLayout.implicitHeight
   height: visible ? implicitHeight : 0.1 // hide invisible items, for some reason setting 0 does not work ¯\_(ツ)_/¯
-  width: implicitWidth - root.scrollSpace
+  width: implicitWidth - ListView.view.scrollSpace
 
   MouseArea {
     anchors.fill: contentLayout

--- a/app/qml/components/MMListView.qml
+++ b/app/qml/components/MMListView.qml
@@ -28,6 +28,7 @@ ListView {
     id: verticalScrollBar
 
     policy: isMobile ? ScrollBar.AlwaysOff : ScrollBar.AlwaysOn
-    opacity: active ? 0.7 : 0.2
+    visible: contentHeight > availableHeight ? true  : false
+    opacity: active ? 0.7 : 0.4
   }
 }

--- a/app/qml/components/MMListView.qml
+++ b/app/qml/components/MMListView.qml
@@ -21,14 +21,14 @@ ListView {
 
   cacheBuffer: 0
   readonly property bool isMobile: (Qt.platform.os === "android" || Qt.platform.os === "ios")
-  property int scrollSpace: !isMobile ? 10 : 0
-  property bool showScrollBar: true
+  readonly property int scrollBarWidth: !isMobile ? __style.margin10 : 0
+  property alias showScrollBar: verticalScrollBar.policy
 
-  ScrollBar.vertical: ScrollBar {
+  ScrollBar.vertical: ScrollBar{
     id: verticalScrollBar
 
     policy: isMobile ? ScrollBar.AlwaysOff : ScrollBar.AlwaysOn
-    visible: showScrollBar
+    //visible: !isMobile && (root.contentHeight > root.height)
     opacity: active ? 0.7 : 0.4
 
     contentItem: Rectangle {

--- a/app/qml/components/MMListView.qml
+++ b/app/qml/components/MMListView.qml
@@ -22,13 +22,14 @@ ListView {
   cacheBuffer: 0
   readonly property bool isMobile: (Qt.platform.os === "android" || Qt.platform.os === "ios")
   property int scrollSpace: !isMobile ? 10 : 0
+  property bool showScrollBar: true
 
   ScrollBar.vertical: ScrollBar {
     id: verticalScrollBar
 
-    policy: ScrollBar.AlwaysOn
-    visible: !isMobile && (root.contentHeight > root.height)
-    opacity: (pressed || root.moving) ? 0.7 : 0.4
+    policy: isMobile ? ScrollBar.AlwaysOff : ScrollBar.AlwaysOn
+    visible: showScrollBar
+    opacity: active ? 0.7 : 0.4
 
     contentItem: Rectangle {
       implicitWidth: 5

--- a/app/qml/components/MMListView.qml
+++ b/app/qml/components/MMListView.qml
@@ -20,7 +20,7 @@ ListView {
   id: root
 
   cacheBuffer: 0
-  readonly property int scrollBarWidth: __inputUtils.isMobilePlatform ?  0 : __style.margin10
+  readonly property int scrollBarWidth: __inputUtils.isMobilePlatform() ?  0 : __style.margin10
   property alias scrollBarPolicy: verticalScrollBar.policy
 
   ScrollBar.vertical: ScrollBar{
@@ -30,7 +30,7 @@ ListView {
     // - both 'policy' and 'visible' properties need to be set, with 'policy' set to AlwaysOn.
     // - the use the 'AsNeeded' policy will make the scroll bar hide when not focused or in use,
     // and only appear after the user starts scrolling.
-    policy: __inputUtils.isMobilePlatform ? ScrollBar.AlwaysOff : ScrollBar.AlwaysOn
+    policy: __inputUtils.isMobilePlatform() ? ScrollBar.AlwaysOff : ScrollBar.AlwaysOn
     visible: contentHeight > availableHeight ? true  : false
     opacity: active ? 0.7 : 0.4
     width: scrollBarWidth

--- a/app/qml/components/MMListView.qml
+++ b/app/qml/components/MMListView.qml
@@ -20,15 +20,19 @@ ListView {
   id: root
 
   cacheBuffer: 0
-  readonly property bool isMobile: (Qt.platform.os === "android" || Qt.platform.os === "ios")
-  readonly property int scrollBarWidth: !isMobile ? __style.margin10 : 0
-  property alias showScrollBar: verticalScrollBar.policy
+  readonly property int scrollBarWidth: __inputUtils.isMobilePlatform ?  0 : __style.margin10
+  property alias scrollBarPolicy: verticalScrollBar.policy
 
   ScrollBar.vertical: ScrollBar{
     id: verticalScrollBar
 
-    policy: isMobile ? ScrollBar.AlwaysOff : ScrollBar.AlwaysOn
+    // To make sure the scroll bar stays visible on desktop, even when not focused:
+    // - both 'policy' and 'visible' properties need to be set, with 'policy' set to AlwaysOn.
+    // - the use the 'AsNeeded' policy will make the scroll bar hide when not focused or in use,
+    // and only appear after the user starts scrolling.
+    policy: __inputUtils.isMobilePlatform ? ScrollBar.AlwaysOff : ScrollBar.AlwaysOn
     visible: contentHeight > availableHeight ? true  : false
     opacity: active ? 0.7 : 0.4
+    width: scrollBarWidth
   }
 }

--- a/app/qml/components/MMListView.qml
+++ b/app/qml/components/MMListView.qml
@@ -8,6 +8,7 @@
  ***************************************************************************/
 
 import QtQuick
+import QtQuick.Controls
 
 //
 // Hot-fix for hotfix https://github.com/MerginMaps/mobile/issues/3417
@@ -15,6 +16,27 @@ import QtQuick
 //
 
 ListView {
+  id: root
 
   cacheBuffer: 0
+  readonly property bool isMobile: (Qt.platform.os === "android" || Qt.platform.os === "ios")
+  property int scrollSpace: !isMobile ? 10 : 0
+
+  ScrollBar.vertical: ScrollBar {
+    id: verticalScrollBar
+
+    policy: ScrollBar.AlwaysOn
+    visible: !isMobile && (root.contentHeight > root.height)
+    opacity: (pressed || root.moving) ? 0.7 : 0.4
+
+    anchors.right: root.right
+
+    implicitHeight: root.height
+
+    contentItem: Rectangle {
+      implicitWidth: 5
+      radius: width / 2
+      color: __style.darkGreenColor
+    }
+  }
 }

--- a/app/qml/components/MMListView.qml
+++ b/app/qml/components/MMListView.qml
@@ -9,6 +9,7 @@
 
 import QtQuick
 import QtQuick.Controls
+import QtQml
 
 //
 // Hot-fix for hotfix https://github.com/MerginMaps/mobile/issues/3417
@@ -28,10 +29,6 @@ ListView {
     policy: ScrollBar.AlwaysOn
     visible: !isMobile && (root.contentHeight > root.height)
     opacity: (pressed || root.moving) ? 0.7 : 0.4
-
-    anchors.right: root.right
-
-    implicitHeight: root.height
 
     contentItem: Rectangle {
       implicitWidth: 5

--- a/app/qml/components/MMListView.qml
+++ b/app/qml/components/MMListView.qml
@@ -28,13 +28,6 @@ ListView {
     id: verticalScrollBar
 
     policy: isMobile ? ScrollBar.AlwaysOff : ScrollBar.AlwaysOn
-    //visible: !isMobile && (root.contentHeight > root.height)
-    opacity: active ? 0.7 : 0.4
-
-    contentItem: Rectangle {
-      implicitWidth: 5
-      radius: width / 2
-      color: __style.darkGreenColor
-    }
+    opacity: active ? 0.7 : 0.2
   }
 }

--- a/app/qml/components/MMScrollView.qml
+++ b/app/qml/components/MMScrollView.qml
@@ -1,3 +1,5 @@
+
+
 /***************************************************************************
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
@@ -6,37 +8,22 @@
  *   (at your option) any later version.                                   *
  *                                                                         *
  ***************************************************************************/
-
 import QtQuick
 import QtQuick.Controls
 import QtQml
 
-// Convenient class to use as a pageContent or drawerContent
-// base element to make the content scroll
-
 ScrollView {
-  id: root
+    id: root
 
-  readonly property bool isMobile: (Qt.platform.os === "android" || Qt.platform.os === "ios")
-  readonly property int scrollBarWidth: !isMobile ? 10 : 0
-  property alias showScrollBar:  verticalScrollBar.policy
+    readonly property bool isMobile: (Qt.platform.os === "android"
+                                      || Qt.platform.os === "ios")
+    readonly property int scrollBarWidth: !isMobile ? 10 : 0
+    property bool showScrollBar:  root.ScrollBar.vertical.policy
 
-  contentWidth: availableWidth - scrollBarWidth
 
-  ScrollBar.horizontal.policy: ScrollBar.AlwaysOff
+    contentWidth: availableWidth - scrollBarWidth
 
-  ScrollBar.vertical : ScrollBar {
-    id: verticalScrollBar
-
-    policy: isMobile ? ScrollBar.AlwaysOff : ScrollBar.AlwaysOn
-    //visible: showScrollBar
-    opacity: active ? 0.7 : 0.4
-
-    contentItem: Rectangle {
-      implicitWidth: 5
-      radius: width / 2
-      color: __style.darkGreenColor
-    }
-  }
+    ScrollBar.horizontal.policy: ScrollBar.AlwaysOff
+    ScrollBar.vertical.policy: isMobile ? ScrollBar.AlwaysOff : ScrollBar.AlwaysOn
+    ScrollBar.vertical.opacity: active ? 0.7 : 0.2
 }
-

--- a/app/qml/components/MMScrollView.qml
+++ b/app/qml/components/MMScrollView.qml
@@ -20,4 +20,5 @@ ScrollView {
 
   ScrollBar.vertical.policy: ScrollBar.AlwaysOff
   ScrollBar.horizontal.policy: ScrollBar.AlwaysOff
+
 }

--- a/app/qml/components/MMScrollView.qml
+++ b/app/qml/components/MMScrollView.qml
@@ -13,8 +13,8 @@ import QtQml
 ScrollView {
     id: root
 
-    readonly property int scrollBarWidth: __inputUtils.isMobilePlatform ? 0 : __style.margin10 
-    property bool scrollBarPolicy:  root.ScrollBar.vertical.policy
+    readonly property int scrollBarWidth: __inputUtils.isMobilePlatform() ? 0 : __style.margin10 
+    property bool scrollBarPolicy:  verticalScrollBar.policy
 
 
     contentWidth: availableWidth - scrollBarWidth
@@ -25,8 +25,11 @@ ScrollView {
     // - both 'policy' and 'visible' properties need to be set, with 'policy' set to AlwaysOn.
     // - the use the 'AsNeeded' policy will make the scroll bar hide when not focused or in use,
     // and only appear after the user starts scrolling.
-    ScrollBar.vertical.policy: __inputUtils.isMobilePlatform ? ScrollBar.AlwaysOff : ScrollBar.AlwaysOn
-    ScrollBar.vertical.visible: contentHeight > availableHeight ? true  : false
-    ScrollBar.vertical.opacity: active ? 0.7 : 0.4
-    ScrollBar.vertical.width: scrollBarWidth
+     ScrollBar.vertical {
+      id : verticalScrollBar
+      policy: __inputUtils.isMobilePlatform() ? ScrollBar.AlwaysOff : ScrollBar.AlwaysOn
+      visible: contentHeight > availableHeight ? true  : false
+      opacity: active ? 0.7 : 0.4
+      width: scrollBarWidth
+    }
 }

--- a/app/qml/components/MMScrollView.qml
+++ b/app/qml/components/MMScrollView.qml
@@ -19,6 +19,7 @@ ScrollView {
 
   readonly property bool isMobile: (Qt.platform.os === "android" || Qt.platform.os === "ios")
   property int scrollSpace: !isMobile ? 10 : 0
+  property bool showScrollBar: true
 
   contentWidth: availableWidth - scrollSpace
 
@@ -26,9 +27,9 @@ ScrollView {
   ScrollBar.vertical: ScrollBar {
     id: verticalScrollBar
 
-    policy: ScrollBar.AlwaysOn
-    visible: !isMobile && (root.contentHeight > root.height)
-    opacity: (pressed || root.moving) ? 0.7 : 0.4
+    policy: isMobile ? ScrollBar.AlwaysOff : ScrollBar.AlwaysOn
+    visible: showScrollBar
+    opacity: active ? 0.7 : 0.4
     implicitHeight: root.height
     anchors.right: parent.right
 

--- a/app/qml/components/MMScrollView.qml
+++ b/app/qml/components/MMScrollView.qml
@@ -13,18 +13,20 @@ import QtQml
 ScrollView {
     id: root
 
-    readonly property bool isMobile: (Qt.platform.os === "android"
-                                      || Qt.platform.os === "ios")
-    readonly property int scrollBarWidth: !isMobile ? __style.margin10 : 0
-    property bool showScrollBar:  root.ScrollBar.vertical.policy
+    readonly property int scrollBarWidth: __inputUtils.isMobilePlatform ? 0 : __style.margin10 
+    property bool scrollBarPolicy:  root.ScrollBar.vertical.policy
 
 
     contentWidth: availableWidth - scrollBarWidth
 
     ScrollBar.horizontal.policy: ScrollBar.AlwaysOff
 
-    // vertical scroll bar should appear only when needed
-    ScrollBar.vertical.policy: isMobile ? ScrollBar.AlwaysOff : ScrollBar.AlwaysOn
+    // To make sure the scroll bar stays visible on desktop, even when not focused:
+    // - both 'policy' and 'visible' properties need to be set, with 'policy' set to AlwaysOn.
+    // - the use the 'AsNeeded' policy will make the scroll bar hide when not focused or in use,
+    // and only appear after the user starts scrolling.
+    ScrollBar.vertical.policy: __inputUtils.isMobilePlatform ? ScrollBar.AlwaysOff : ScrollBar.AlwaysOn
     ScrollBar.vertical.visible: contentHeight > availableHeight ? true  : false
     ScrollBar.vertical.opacity: active ? 0.7 : 0.4
+    ScrollBar.vertical.width: scrollBarWidth
 }

--- a/app/qml/components/MMScrollView.qml
+++ b/app/qml/components/MMScrollView.qml
@@ -16,9 +16,29 @@ import QtQuick.Controls
 ScrollView {
   id: root
 
-  contentWidth: availableWidth // to only scroll vertically
+  readonly property bool isMobile: (Qt.platform.os === "android" || Qt.platform.os === "ios")
+  property int scrollSpace: !isMobile ? 10 : 0
 
-  ScrollBar.vertical.policy: ScrollBar.AlwaysOff
-  ScrollBar.horizontal.policy: ScrollBar.AlwaysOff
+  contentWidth: availableWidth - scrollSpace // to only scroll vertically
+
+  ScrollBar.horizontal: null
+
+  ScrollBar.vertical: ScrollBar {
+    id: verticalScrollBar
+
+    policy: ScrollBar.AsNeeded
+    visible: !isMobile && (root.contentHeight > root.height)
+    opacity: (pressed || root.moving) ? 0.7 : 0.4
+
+    anchors.right: root.right
+
+    implicitHeight: root.height
+
+    contentItem: Rectangle {
+      implicitWidth: 5
+      radius: width / 2
+      color: __style.darkGreenColor
+    }
+  }
 
 }

--- a/app/qml/components/MMScrollView.qml
+++ b/app/qml/components/MMScrollView.qml
@@ -1,5 +1,3 @@
-
-
 /***************************************************************************
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
@@ -24,6 +22,9 @@ ScrollView {
     contentWidth: availableWidth - scrollBarWidth
 
     ScrollBar.horizontal.policy: ScrollBar.AlwaysOff
+
+    // vertical scroll bar should appear only when needed
     ScrollBar.vertical.policy: isMobile ? ScrollBar.AlwaysOff : ScrollBar.AlwaysOn
-    ScrollBar.vertical.opacity: active ? 0.7 : 0.2
+    ScrollBar.vertical.visible: contentHeight > availableHeight ? true  : false
+    ScrollBar.vertical.opacity: active ? 0.7 : 0.4
 }

--- a/app/qml/components/MMScrollView.qml
+++ b/app/qml/components/MMScrollView.qml
@@ -15,7 +15,7 @@ ScrollView {
 
     readonly property bool isMobile: (Qt.platform.os === "android"
                                       || Qt.platform.os === "ios")
-    readonly property int scrollBarWidth: !isMobile ? 10 : 0
+    readonly property int scrollBarWidth: !isMobile ? __style.margin10 : 0
     property bool showScrollBar:  root.ScrollBar.vertical.policy
 
 

--- a/app/qml/components/MMScrollView.qml
+++ b/app/qml/components/MMScrollView.qml
@@ -9,6 +9,7 @@
 
 import QtQuick
 import QtQuick.Controls
+import QtQml
 
 // Convenient class to use as a pageContent or drawerContent
 // base element to make the content scroll
@@ -19,20 +20,17 @@ ScrollView {
   readonly property bool isMobile: (Qt.platform.os === "android" || Qt.platform.os === "ios")
   property int scrollSpace: !isMobile ? 10 : 0
 
-  contentWidth: availableWidth - scrollSpace // to only scroll vertically
+  contentWidth: availableWidth - scrollSpace
 
-  ScrollBar.horizontal: null
-
+  ScrollBar.horizontal.policy: ScrollBar.AlwaysOff
   ScrollBar.vertical: ScrollBar {
     id: verticalScrollBar
 
-    policy: ScrollBar.AsNeeded
+    policy: ScrollBar.AlwaysOn
     visible: !isMobile && (root.contentHeight > root.height)
     opacity: (pressed || root.moving) ? 0.7 : 0.4
-
-    anchors.right: root.right
-
     implicitHeight: root.height
+    anchors.right: parent.right
 
     contentItem: Rectangle {
       implicitWidth: 5
@@ -40,5 +38,4 @@ ScrollView {
       color: __style.darkGreenColor
     }
   }
-
 }

--- a/app/qml/components/MMScrollView.qml
+++ b/app/qml/components/MMScrollView.qml
@@ -18,20 +18,19 @@ ScrollView {
   id: root
 
   readonly property bool isMobile: (Qt.platform.os === "android" || Qt.platform.os === "ios")
-  property int scrollSpace: !isMobile ? 10 : 0
-  property bool showScrollBar: true
+  readonly property int scrollBarWidth: !isMobile ? 10 : 0
+  property alias showScrollBar:  verticalScrollBar.policy
 
-  contentWidth: availableWidth - scrollSpace
+  contentWidth: availableWidth - scrollBarWidth
 
   ScrollBar.horizontal.policy: ScrollBar.AlwaysOff
-  ScrollBar.vertical: ScrollBar {
+
+  ScrollBar.vertical : ScrollBar {
     id: verticalScrollBar
 
     policy: isMobile ? ScrollBar.AlwaysOff : ScrollBar.AlwaysOn
-    visible: showScrollBar
+    //visible: showScrollBar
     opacity: active ? 0.7 : 0.4
-    implicitHeight: root.height
-    anchors.right: parent.right
 
     contentItem: Rectangle {
       implicitWidth: 5
@@ -40,3 +39,4 @@ ScrollView {
     }
   }
 }
+

--- a/app/qml/components/MMToolbar.qml
+++ b/app/qml/components/MMToolbar.qml
@@ -8,6 +8,7 @@
  ***************************************************************************/
 
 import QtQuick
+import QtQuick.Controls
 
 import "./private"
 
@@ -43,7 +44,7 @@ Rectangle {
 
     MMListView {
       id: toolbar
-      showScrollBar : false
+      showScrollBar : ScrollBar.AlwaysOff
 
       onWidthChanged: root.recalculate()
       model: toolbarModel

--- a/app/qml/components/MMToolbar.qml
+++ b/app/qml/components/MMToolbar.qml
@@ -44,7 +44,7 @@ Rectangle {
 
     MMListView {
       id: toolbar
-      showScrollBar : ScrollBar.AlwaysOff
+      scrollBarPolicy : ScrollBar.AlwaysOff
 
       onWidthChanged: root.recalculate()
       model: toolbarModel

--- a/app/qml/components/MMToolbar.qml
+++ b/app/qml/components/MMToolbar.qml
@@ -43,6 +43,7 @@ Rectangle {
 
     MMListView {
       id: toolbar
+      showScrollBar : false
 
       onWidthChanged: root.recalculate()
       model: toolbarModel

--- a/app/qml/form/MMFormPage.qml
+++ b/app/qml/form/MMFormPage.qml
@@ -276,7 +276,7 @@ Page {
 
     Item {
 
-      width: ListView.view.width - ListView.view.scrollSpace
+      width: ListView.view.width - ListView.view.scrollBarWidth
       implicitHeight: childrenRect.height
 
       // In future, better to filter such fields in the field proxy model instead

--- a/app/qml/form/MMFormPage.qml
+++ b/app/qml/form/MMFormPage.qml
@@ -276,7 +276,7 @@ Page {
 
     Item {
 
-      width: ListView.view.width
+      width: ListView.view.width - ListView.view.scrollSpace
       implicitHeight: childrenRect.height
 
       // In future, better to filter such fields in the field proxy model instead

--- a/app/qml/form/MMPreviewDrawer.qml
+++ b/app/qml/form/MMPreviewDrawer.qml
@@ -198,7 +198,7 @@ Item {
           model: root.controller.fieldModel
 
           delegate: Item {
-            width: ListView.view.width - ListView.view.width
+            width: ListView.view.width - ListView.view.scrollSpace
             height: childrenRect.height
 
             Column {

--- a/app/qml/form/MMPreviewDrawer.qml
+++ b/app/qml/form/MMPreviewDrawer.qml
@@ -193,7 +193,7 @@ Item {
           height: contentHeight
 
           spacing: __style.margin8
-          showScrollBar: ScrollBar.AsNeeded
+          scrollBarPolicy: ScrollBar.AsNeeded
 
           model: root.controller.fieldModel
 

--- a/app/qml/form/MMPreviewDrawer.qml
+++ b/app/qml/form/MMPreviewDrawer.qml
@@ -198,7 +198,7 @@ Item {
           model: root.controller.fieldModel
 
           delegate: Item {
-            width: ListView.view.width - ListView.view.scrollSpace
+            width: ListView.view.width - ListView.view.scrollBarWidth
             height: childrenRect.height
 
             Column {

--- a/app/qml/form/MMPreviewDrawer.qml
+++ b/app/qml/form/MMPreviewDrawer.qml
@@ -193,12 +193,12 @@ Item {
           height: contentHeight
 
           spacing: __style.margin8
-          interactive: false
+          showScrollBar: ScrollBar.AsNeeded
 
           model: root.controller.fieldModel
 
           delegate: Item {
-            width: ListView.view.width - ListView.view.scrollBarWidth
+            width: ListView.view.width
             height: childrenRect.height
 
             Column {

--- a/app/qml/form/MMPreviewDrawer.qml
+++ b/app/qml/form/MMPreviewDrawer.qml
@@ -198,7 +198,7 @@ Item {
           model: root.controller.fieldModel
 
           delegate: Item {
-            width: ListView.view.width
+            width: ListView.view.width - ListView.view.width
             height: childrenRect.height
 
             Column {

--- a/app/qml/layers/MMFeaturesListPage.qml
+++ b/app/qml/layers/MMFeaturesListPage.qml
@@ -80,10 +80,16 @@ MMComponents.MMPage {
         visible: !isMobile
         interactive: !isMobile
         anchors.right: listView.right
-        thickness: 8
         implicitHeight: listView.height
         opacity: active ? 1.0 : 0.0
-        Behavior on opacity { NumberAnimation { duration: 120 } }
+        Behavior on opacity { NumberAnimation { duration: 150 } }
+
+        contentItem: Rectangle {
+          implicitWidth: 5
+          radius: width / 2
+          color: __style.darkGreenColor
+          opacity: verticalScrollBar.pressed ? 0.5 : 0.3
+        }
       }
 
       footer: MMComponents.MMListSpacer {

--- a/app/qml/layers/MMFeaturesListPage.qml
+++ b/app/qml/layers/MMFeaturesListPage.qml
@@ -73,23 +73,6 @@ MMComponents.MMPage {
         onClicked: root.featureClicked( model.FeaturePair )
       }
 
-      ScrollBar.vertical: ScrollBar {
-        id: verticalScrollBar
-
-        readonly property bool isMobile: (Qt.platform.os === "android" || Qt.platform.os === "ios")
-        policy: ScrollBar.AlwaysOn
-        visible: !isMobile
-        opacity: (pressed || listView.moving) ? 0.7 : 0.4
-
-        implicitHeight: listView.height
-
-        contentItem: Rectangle {
-          implicitWidth: 5
-          radius: width / 2
-          color: __style.darkGreenColor
-        }
-      }
-
       footer: MMComponents.MMListSpacer {
         height: __style.margin20 + ( root.hasToolbar ? 0 : __style.safeAreaBottom ) + ( addButton.visible ? addButton.height : 0 )
       }

--- a/app/qml/layers/MMFeaturesListPage.qml
+++ b/app/qml/layers/MMFeaturesListPage.qml
@@ -79,7 +79,6 @@ MMComponents.MMPage {
         readonly property bool isMobile: (Qt.platform.os === "android" || Qt.platform.os === "ios")
         policy: ScrollBar.AlwaysOn
         visible: !isMobile
-        interactive: !isMobile
         opacity: (pressed || listView.moving) ? 0.7 : 0.4
 
         implicitHeight: listView.height

--- a/app/qml/layers/MMFeaturesListPage.qml
+++ b/app/qml/layers/MMFeaturesListPage.qml
@@ -10,7 +10,6 @@
 import QtQuick
 import QtQuick.Controls
 import QtQuick.Layouts
-import QtQml
 
 import mm 1.0 as MM
 

--- a/app/qml/layers/MMFeaturesListPage.qml
+++ b/app/qml/layers/MMFeaturesListPage.qml
@@ -23,7 +23,6 @@ MMComponents.MMPage {
   property var selectedLayer: null
   property bool hasToolbar: false
   property bool layerIsReadOnly: selectedLayer?.readOnly ?? false
-  readonly property bool isMobile: (Qt.platform.os === "android" || Qt.platform.os === "ios")
 
   signal featureClicked( var featurePair )
   signal addFeatureClicked( var toLayer )
@@ -76,9 +75,12 @@ MMComponents.MMPage {
 
       ScrollBar.vertical: ScrollBar {
         id: verticalScrollBar
+
+        readonly property bool isMobile: (Qt.platform.os === "android" || Qt.platform.os === "ios")
         policy: isMobile ? ScrollBar.AlwaysOff : ScrollBar.AsNeeded
         visible: !isMobile
         interactive: !isMobile
+
         anchors.right: listView.right
         implicitHeight: listView.height
         opacity: active ? 1.0 : 0.0

--- a/app/qml/layers/MMFeaturesListPage.qml
+++ b/app/qml/layers/MMFeaturesListPage.qml
@@ -77,20 +77,17 @@ MMComponents.MMPage {
         id: verticalScrollBar
 
         readonly property bool isMobile: (Qt.platform.os === "android" || Qt.platform.os === "ios")
-        policy: isMobile ? ScrollBar.AlwaysOff : ScrollBar.AsNeeded
+        policy: ScrollBar.AlwaysOn
         visible: !isMobile
         interactive: !isMobile
+        opacity: (pressed || listView.moving) ? 0.7 : 0.4
 
-        anchors.right: listView.right
         implicitHeight: listView.height
-        opacity: active ? 1.0 : 0.0
-        Behavior on opacity { NumberAnimation { duration: 150 } }
 
         contentItem: Rectangle {
           implicitWidth: 5
           radius: width / 2
           color: __style.darkGreenColor
-          opacity: verticalScrollBar.pressed ? 0.5 : 0.3
         }
       }
 

--- a/app/qml/layers/MMFeaturesListPage.qml
+++ b/app/qml/layers/MMFeaturesListPage.qml
@@ -10,6 +10,7 @@
 import QtQuick
 import QtQuick.Controls
 import QtQuick.Layouts
+import QtQml
 
 import mm 1.0 as MM
 
@@ -22,6 +23,7 @@ MMComponents.MMPage {
   property var selectedLayer: null
   property bool hasToolbar: false
   property bool layerIsReadOnly: selectedLayer?.readOnly ?? false
+  readonly property bool isMobile: (Qt.platform.os === "android" || Qt.platform.os === "ios")
 
   signal featureClicked( var featurePair )
   signal addFeatureClicked( var toLayer )
@@ -70,6 +72,18 @@ MMComponents.MMPage {
         secondaryText: model.Description + ( model.SearchResult ? ", " + model.SearchResult.replace(/\n/g, ' ') : "" )
 
         onClicked: root.featureClicked( model.FeaturePair )
+      }
+
+      ScrollBar.vertical: ScrollBar {
+        id: verticalScrollBar
+        policy: isMobile ? ScrollBar.AlwaysOff : ScrollBar.AsNeeded
+        visible: !isMobile
+        interactive: !isMobile
+        anchors.right: listView.right
+        thickness: 8
+        implicitHeight: listView.height
+        opacity: active ? 1.0 : 0.0
+        Behavior on opacity { NumberAnimation { duration: 120 } }
       }
 
       footer: MMComponents.MMListSpacer {

--- a/app/qml/layers/MMLayerDetailPage.qml
+++ b/app/qml/layers/MMLayerDetailPage.qml
@@ -193,8 +193,6 @@ Page {
                     wrapMode: Text.WordWrap
                     text: __inputUtils.layerAttribution(layerDetailData.mapLayer)
                   }
-
-                  ScrollBar.vertical: ScrollBar {}
                 }
               }
             }

--- a/app/qml/project/MMProjectList.qml
+++ b/app/qml/project/MMProjectList.qml
@@ -94,7 +94,7 @@ Item {
     delegate: MMProjectComponents.MMProjectDelegate {
       id: projectDelegate
 
-      width: ListView.view.width - ListView.view.scrollSpace
+      width: ListView.view.width - ListView.view.scrollBarWidth
       height: visible ? implicitHeight : 0
 
       projectDisplayName: root.projectModelType === MM.ProjectsModel.WorkspaceProjectsModel ? model.ProjectName : model.ProjectFullName
@@ -202,7 +202,7 @@ Item {
 
       topPadding: noLocalProjectsMessageContainer.visible ? noLocalProjectsMessageContainer.height + __style.margin40 : 0
 
-      width: ListView.view.width - ListView.view.scrollSpace
+      width: ListView.view.width - ListView.view.scrollBarWidth
 
       Item {
         width: parent.width

--- a/app/qml/project/MMProjectList.qml
+++ b/app/qml/project/MMProjectList.qml
@@ -94,6 +94,7 @@ Item {
     delegate: MMProjectComponents.MMProjectDelegate {
       id: projectDelegate
 
+      width: ListView.view.width - ListView.view.scrollSpace
       height: visible ? implicitHeight : 0
 
       projectDisplayName: root.projectModelType === MM.ProjectsModel.WorkspaceProjectsModel ? model.ProjectName : model.ProjectFullName

--- a/app/qml/project/MMProjectList.qml
+++ b/app/qml/project/MMProjectList.qml
@@ -94,7 +94,6 @@ Item {
     delegate: MMProjectComponents.MMProjectDelegate {
       id: projectDelegate
 
-      width: ListView.view.width
       height: visible ? implicitHeight : 0
 
       projectDisplayName: root.projectModelType === MM.ProjectsModel.WorkspaceProjectsModel ? model.ProjectName : model.ProjectFullName
@@ -202,7 +201,7 @@ Item {
 
       topPadding: noLocalProjectsMessageContainer.visible ? noLocalProjectsMessageContainer.height + __style.margin40 : 0
 
-      width: ListView.view.width
+      width: ListView.view.width - ListView.view.scrollSpace
 
       Item {
         width: parent.width

--- a/app/qml/project/MMProjectWizardPage.qml
+++ b/app/qml/project/MMProjectWizardPage.qml
@@ -70,7 +70,7 @@ MMComponents.MMPage {
         delegate: MMProjectComponents.MMProjectWizardDelegate {
           id: fieldDelegate
 
-          width: ListView.view.width - ListView.view.width
+          width: ListView.view.width - ListView.view.scrollSpace
 
           // find current index in the model
           comboboxField.comboboxModel: typesmodel

--- a/app/qml/project/MMProjectWizardPage.qml
+++ b/app/qml/project/MMProjectWizardPage.qml
@@ -70,7 +70,7 @@ MMComponents.MMPage {
         delegate: MMProjectComponents.MMProjectWizardDelegate {
           id: fieldDelegate
 
-          width: ListView.view.width
+          width: ListView.view.width - ListView.view.width
 
           // find current index in the model
           comboboxField.comboboxModel: typesmodel

--- a/app/qml/project/MMProjectWizardPage.qml
+++ b/app/qml/project/MMProjectWizardPage.qml
@@ -70,7 +70,7 @@ MMComponents.MMPage {
         delegate: MMProjectComponents.MMProjectWizardDelegate {
           id: fieldDelegate
 
-          width: ListView.view.width - ListView.view.scrollSpace
+          width: ListView.view.width - ListView.view.scrollBarWidth
 
           // find current index in the model
           comboboxField.comboboxModel: typesmodel

--- a/app/qml/project/components/MMProjectDelegate.qml
+++ b/app/qml/project/components/MMProjectDelegate.qml
@@ -37,6 +37,7 @@ Control {
   signal showChangesRequested()
 
   height: implicitHeight
+  width: ListView.view.width - ListView.view.scrollSpace
 
   topPadding: __style.margin20
   rightPadding: __style.margin20

--- a/app/qml/project/components/MMProjectDelegate.qml
+++ b/app/qml/project/components/MMProjectDelegate.qml
@@ -37,7 +37,7 @@ Control {
   signal showChangesRequested()
 
   height: implicitHeight
-  width: ListView.view.width - ListView.view.scrollSpace
+  width: ListView.view.width - ListView.view.scrollBarWidth
 
   topPadding: __style.margin20
   rightPadding: __style.margin20

--- a/app/qml/settings/MMLogPage.qml
+++ b/app/qml/settings/MMLogPage.qml
@@ -54,7 +54,7 @@ MMPage {
       }
 
       ScrollBar.vertical: ScrollBar {
-        opacity: (root.pressed || root.moving) ? 0.7 : 0.4
+        opacity: active ? 0.7 : 0.4
 
         contentItem: Rectangle {
           implicitWidth: 5

--- a/app/qml/settings/MMLogPage.qml
+++ b/app/qml/settings/MMLogPage.qml
@@ -53,7 +53,15 @@ MMPage {
         width: parent.width
       }
 
-      ScrollBar.vertical: ScrollBar { }
+      ScrollBar.vertical: ScrollBar {
+        opacity: (root.pressed || root.moving) ? 0.7 : 0.4
+
+        contentItem: Rectangle {
+          implicitWidth: 5
+          radius: width / 2
+          color: __style.darkGreenColor
+        }
+      }
     }
 
     MMButton {


### PR DESCRIPTION
Case:  Missing scrollbar for the desktop version for all the ListView components.

What has be been done:
Added slim scrollbar on the right side of the lists. 
Scroll bar only activates for desktops; ex(macos, window, linux) and not any mobile builds
Scrollbar always visibile, but highlights on active more and passive on inactive.


**Tested for mutiple page which uses ListView and the work of scrollbar**

https://github.com/user-attachments/assets/9012e551-c937-40b7-a732-eedef8f9e79b



