### PR TITLE
Pin openssl version to 3.3.2

### DIFF
--- a/vcpkg.json
+++ b/vcpkg.json
@@ -113,5 +113,12 @@
           "host": true,
           "default-features": false
         }
+    ],
+    "builtin-baseline": "d6995a0cf3cafda5e9e52749fad075dd62bfd90c",
+    "overrides": [
+        {
+            "name": "openssl",
+            "version": "3.3.2"
+        }
     ]
 }


### PR DESCRIPTION
This fixes crash on android ARM-v7 architecture. The app kept crashing on startup, the crash was triggered by doing https request. Stack trace pointed only towards `libcrypto.so`.

TODO: try version 3.4.1 (looked promising)