### PR TITLE
Fix automatic sync crash

### DIFF
--- a/app/activeproject.cpp
+++ b/app/activeproject.cpp
@@ -328,7 +328,7 @@ void ActiveProject::setAutosyncEnabled( bool enabled )
       mAutosyncController.reset();
     }
 
-    mAutosyncController = std::make_unique<AutosyncController>( mQgsProject, this );
+    mAutosyncController = std::make_unique<AutosyncController>( mQgsProject );
 
     connect( mAutosyncController.get(), &AutosyncController::projectSyncRequested, this, &ActiveProject::requestSync );
     connect( this, &ActiveProject::appStateChanged, mAutosyncController.get(), &AutosyncController::checkSyncRequiredAfterAppStateChange );


### PR DESCRIPTION
Added a check when manually syncing.
The crash was occurring for projects that did not have auto sync enabled, as the autosync controller was not initialised.