### PR TITLE
Fix automatic sync on cold start to open project

### DIFF
--- a/app/main.cpp
+++ b/app/main.cpp
@@ -560,10 +560,10 @@ int main( int argc, char *argv[] )
   // after server ping is done
   if ( activeProject.autosyncController() )
   {
-    QObject::connect(ma.get(), &MerginApi::pingMerginFinished, &lambdaContext, [&activeProject]
+    QObject::connect( ma.get(), &MerginApi::pingMerginFinished, &lambdaContext, [&activeProject]
     {
-      activeProject.requestSync(SyncOptions::AutomaticRequest);
-    }, Qt::SingleShotConnection);
+      activeProject.requestSync( SyncOptions::AutomaticRequest );
+    }, Qt::SingleShotConnection );
   }
 
   QObject::connect( &app, &QGuiApplication::applicationStateChanged, &lambdaContext, []( Qt::ApplicationState state )


### PR DESCRIPTION
fixes this issue found while testing the RC:

> If the user kills the app while autosync is enabled, the app is not synced automatically after reopening. The sync occurs after max. 1 min