### PR TITLE
Fix autosync timer restart from suspend

### DIFF
--- a/app/autosynccontroller.cpp
+++ b/app/autosynccontroller.cpp
@@ -76,7 +76,7 @@ void AutosyncController::checkSyncRequiredAfterAppStateChange( const Qt::Applica
     mTimer->stop();
     return;
   }
-  if ( !mTimer->isActive())
+  if ( !mTimer->isActive() )
   {
     mTimer->start();
   }


### PR DESCRIPTION
fixes this issue found in testing:

> If the user minimize the app, after reopening, the project is synced. But the next sync does not occur. Steps to reproduce:
> 1. allow autosync for project
> 2. open project in mobile app
> 3. minimize app
> 4. wait 1 min and reopen the app -> project is synced
> 5. add some points in MM plugin to the project, save and sync
> 6. in mobile app wait for next round of sync and verify the added points are there -> **NOK**
