### PR TITLE
Fix compilation error in credential store keychain

### DIFF
--- a/core/credentialstorekeychain.cpp
+++ b/core/credentialstorekeychain.cpp
@@ -109,7 +109,7 @@ void CredentialStore::readKeyRecursively( const QString &key )
     if ( mReadJob->error() )
     {
       CoreUtils::log( "Auth", QString( "Keychain read error: %1" ).arg( mReadJob->errorString() ) );
-      emit authDataRead( QString(), QString(), -1, QString(), QDateTime() );
+      emit authDataRead( QString(), QString(), QString(), QDateTime(), -1 );
       return;
     }
 


### PR DESCRIPTION
Fixes type mismatch when emitting `authDataRead` signal with empty/error values. 
The token parameter expects `const QString&`, not `int`.