### PR TITLE
Fix position provider name variable

### DIFF
--- a/app/variablesmanager.cpp
+++ b/app/variablesmanager.cpp
@@ -59,7 +59,7 @@ QgsExpressionContextScope *VariablesManager::positionScope()
   if ( mPositionKit->positionProvider() )
   {
     providerId = mPositionKit->positionProvider()->id();
-    providerName = mPositionKit->positionProvider()->name();
+    providerName = mPositionKit->positionProviderName();
     providerType = mPositionKit->positionProvider()->type();
   }
 


### PR DESCRIPTION
Fixes the issue where `position_provider_name` variable wouldn't return _Mock provider_ name even if app was showing it is mocked position in GPS panel.