### PR TITLE
Foreign key child feature fix

### DIFF
--- a/app/attributes/attributecontroller.cpp
+++ b/app/attributes/attributecontroller.cpp
@@ -129,10 +129,10 @@ void AttributeController::prefillRelationReferenceField()
   {
     QVariant foreignKey = mParentController->featureLayerPair().feature().attribute( fieldPair.referencedField() );
     QString referencingField = fieldPair.referencingField();
-    QgsVectorLayer *childLayer = mLinkedRelation.referencingLayer();
+    const QgsVectorLayer *childLayer = mLinkedRelation.referencingLayer();
     if ( childLayer )
     {
-      int fieldIndex = childLayer->fields().lookupField( referencingField );
+      const int fieldIndex = childLayer->fields().lookupField( referencingField );
       if ( fieldIndex != -1 )
       {
         mFeatureLayerPair.featureRef().setAttribute( fieldIndex, foreignKey );


### PR DESCRIPTION
Modified logic in attribute controller as such:
- if the child feature form has the foreign key field visible, keep the code as it was
- if the field is not visible, search for the field in the child layer (not only in the visible form fields), and pre-fill the relation