### PR TITLE
Fixed iOS photo GPS information 

### DIFF
--- a/app/CMakeLists.txt
+++ b/app/CMakeLists.txt
@@ -574,6 +574,7 @@ endif ()
 if (IOS)
   target_link_libraries(
     MerginMaps PUBLIC AppleFrameworks::CoreLocation AppleFrameworks::CoreHaptics
+                      AppleFrameworks::Photos
   )
   # TODO is this needed? this change requires cmake 3.28+
   # qt_add_ios_ffmpeg_libraries(MerginMaps) # Qt Multimedia

--- a/app/CMakeLists.txt
+++ b/app/CMakeLists.txt
@@ -574,7 +574,7 @@ endif ()
 if (IOS)
   target_link_libraries(
     MerginMaps PUBLIC AppleFrameworks::CoreLocation AppleFrameworks::CoreHaptics
-                      AppleFrameworks::Photos
+                      AppleFrameworks::PhotosUI
   )
   # TODO is this needed? this change requires cmake 3.28+
   # qt_add_ios_ffmpeg_libraries(MerginMaps) # Qt Multimedia

--- a/app/inputexpressionfunctions.cpp
+++ b/app/inputexpressionfunctions.cpp
@@ -61,8 +61,11 @@ QVariant ReadExifLatitude::func( const QVariantList &values, const QgsExpression
 
   return QVariant( InputUtils::convertCoordinateString( resultString ) );
 #elif defined( Q_OS_IOS )
-  QString result = IosUtils::readExif( filepath, GPS_LAT_TAG );
-  return QVariant( result.toDouble() );
+  double lat = IosUtils::readExif( filepath, GPS_LAT_TAG ).toDouble();
+  QString latRef = IosUtils::readExif( filepath, QStringLiteral( "GPSLatitudeRef" ) );
+  if ( lat > 0.0 && latRef.startsWith( QLatin1Char( 'S' ), Qt::CaseInsensitive ) )
+    lat = -lat;
+  return QVariant( lat );
 # else
   return QString();
 #endif
@@ -80,8 +83,11 @@ QVariant ReadExifLongitude::func( const QVariantList &values, const QgsExpressio
 
   return QVariant( InputUtils::convertCoordinateString( resultString ) );
 #elif defined( Q_OS_IOS )
-  QString result = IosUtils::readExif( filepath, GPS_LON_TAG ) ;
-  return QVariant( result.toDouble() );
+  double lon = IosUtils::readExif( filepath, GPS_LON_TAG ).toDouble();
+  QString lonRef = IosUtils::readExif( filepath, QStringLiteral( "GPSLongitudeRef" ) );
+  if ( lon > 0.0 && lonRef.startsWith( QLatin1Char( 'W' ), Qt::CaseInsensitive ) )
+    lon = -lon;
+  return QVariant( lon );
 # else
   return QString();
 #endif

--- a/app/ios/iosimagepicker.mm
+++ b/app/ios/iosimagepicker.mm
@@ -16,7 +16,6 @@
 #include <QCoreApplication>
 #include <UIKit/UIKit.h>
 #include <QPointer>
-#include <QtCore>
 #include <QImage>
 
 #include "iosinterface.h"

--- a/app/ios/iosinterface.mm
+++ b/app/ios/iosinterface.mm
@@ -18,7 +18,6 @@
 #import <ImageIO/ImageIO.h>
 #import "ios/iosinterface.h"
 #include "iosviewdelegate.h"
-#include "inpututils.h"
 #import <MobileCoreServices/MobileCoreServices.h>
 #include "position/positionkit.h"
 #include "compass.h"
@@ -28,7 +27,6 @@
 #import <Foundation/Foundation.h>
 #import <CoreFoundation/CoreFoundation.h>
 #import <CoreLocation/CoreLocation.h>
-#import <Photos/Photos.h>
 
 @implementation IOSInterface
 
@@ -178,7 +176,26 @@ static NSMutableDictionary *getGPSData( PositionKit *positionKit, Compass *compa
   UIWindow *rootWindow = app.windows[0];
   UIViewController *rootViewController = rootWindow.rootViewController;
 
-  if ( ![UIImagePickerController isSourceTypeAvailable:( UIImagePickerControllerSourceType ) sourceType] )
+  bool isCamera = ( UIImagePickerControllerSourceType ) sourceType == UIImagePickerControllerSourceTypeCamera;
+
+  if ( !isCamera )
+  {
+    // Gallery: use PHPickerViewController
+    PHPickerConfiguration *config = [[PHPickerConfiguration alloc] init];
+    config.filter = [PHPickerFilter imagesFilter];
+    config.selectionLimit = 1;
+
+    PHPickerViewController *picker = [[PHPickerViewController alloc] initWithConfiguration:config];
+    static IOSGalleryPickerDelegate *galleryDelegate = nullptr;
+    galleryDelegate = [[IOSGalleryPickerDelegate alloc] initWithHandler:handler];
+    picker.delegate = galleryDelegate;
+
+    [rootViewController presentViewController:picker animated:YES completion:nil];
+    return;
+  }
+
+  // Camera: use UIImagePickerController
+  if ( ![UIImagePickerController isSourceTypeAvailable:UIImagePickerControllerSourceTypeCamera] )
   {
     NSString *alertTitle = @"Image picker";
     NSString *alertMessage = @"The functionality is not available";
@@ -189,7 +206,7 @@ static NSMutableDictionary *getGPSData( PositionKit *positionKit, Compass *compa
                                           preferredStyle:UIAlertControllerStyleAlert];
     UIAlertAction *actionOk = [UIAlertAction actionWithTitle:alertOkButtonText
                                style:UIAlertActionStyleDefault
-                               handler:nil]; //You can use a block here to handle a press on this button
+                               handler:nil];
     [alertController addAction:actionOk];
     [rootViewController presentViewController:alertController animated:YES completion:nil];
   }
@@ -197,14 +214,14 @@ static NSMutableDictionary *getGPSData( PositionKit *positionKit, Compass *compa
   {
     UIImagePickerController *picker = [[UIImagePickerController alloc] init];
     imagePickerController = picker;
-    picker.sourceType = ( UIImagePickerControllerSourceType ) sourceType;
+    picker.sourceType = UIImagePickerControllerSourceTypeCamera;
     static IOSViewDelegate *delegate = nullptr;
     delegate = [[IOSViewDelegate alloc] initWithHandler:handler];
 
     [[NSNotificationCenter defaultCenter] addObserverForName:@"_UIImagePickerControllerUserDidCaptureItem" object:nil queue:nil usingBlock: ^ ( NSNotification * _Nonnull notification )
     {
       Q_UNUSED( notification )
-      // Fetch GPS data when an image is captured
+      // Fetch GPS data from positionKit at the moment of capture
       mGpsData = getGPSData( delegate->handler->positionKit(), delegate->handler->compass() );
     }];
 
@@ -219,60 +236,13 @@ static NSMutableDictionary *getGPSData( PositionKit *positionKit, Compass *compa
       delegate->processingPicture = YES;
 
       NSString *imagePath = generateImagePath( delegate->handler->targetDir().toNSString() );
-      QString err;
-
-      bool isCameraPhoto = picker.sourceType == UIImagePickerControllerSourceType::UIImagePickerControllerSourceTypeCamera;
-      if ( isCameraPhoto )
-      {
-        // Camera handling
-        err = [IOSInterface handleCameraPhoto:info:imagePath];
-      }
-      else
-      {
-        // Gallery handling
-        // use PHAsset to request the original image data with full EXIF (including GPS).
-        PHAsset *asset = info[UIImagePickerControllerPHAsset];
-        if ( asset )
-        {
-          PHImageRequestOptions *options = [[PHImageRequestOptions alloc] init];
-          options.synchronous = YES;
-          options.deliveryMode = PHImageRequestOptionsDeliveryModeHighQualityFormat;
-          options.version = PHImageRequestOptionsVersionOriginal;
-          options.networkAccessAllowed = YES;
-
-          __block BOOL writeSuccess = NO;
-          [[PHImageManager defaultManager] requestImageDataAndOrientationForAsset:asset
-           options:options
-           resultHandler: ^ ( NSData * imageData, NSString *dataUTI, CGImagePropertyOrientation orientation, NSDictionary * requestInfo )
-          {
-            if ( imageData )
-            {
-              writeSuccess = [imageData writeToFile:imagePath atomically:YES];
-            }
-          }];
-
-          if ( !writeSuccess )
-          {
-            err = QStringLiteral( "Copying image from gallery failed." );
-          }
-        }
-        else
-        {
-          // fallback: copy file directly, even though GPS metadata might be deleted by iOS
-          NSURL *infoImageUrl = info[UIImagePickerControllerImageURL];
-          if ( !InputUtils::copyFile( QString::fromNSString( infoImageUrl.absoluteString ), QString::fromNSString( imagePath ) ) )
-          {
-            err = QStringLiteral( "Copying image from a gallery failed." );
-          }
-        }
-      }
+      QString err = [IOSInterface handleCameraPhoto:info:imagePath];
 
       [picker dismissViewControllerAnimated:YES completion:nil];
       if ( delegate->handler )
       {
         QVariantMap data;
-        QString imagePathData( [imagePath UTF8String] );
-        data["imagePath"] = imagePathData;
+        data["imagePath"] = QString( [imagePath UTF8String] );
         data["error"] = err;
         QMetaObject::invokeMethod( delegate->handler, "onImagePickerFinished", Qt::DirectConnection,
                                    Q_ARG( bool, err.isEmpty() ),

--- a/app/ios/iosinterface.mm
+++ b/app/ios/iosinterface.mm
@@ -221,7 +221,7 @@ static NSMutableDictionary *getGPSData( PositionKit *positionKit, Compass *compa
     [[NSNotificationCenter defaultCenter] addObserverForName:@"_UIImagePickerControllerUserDidCaptureItem" object:nil queue:nil usingBlock: ^ ( NSNotification * _Nonnull notification )
     {
       Q_UNUSED( notification )
-      // Fetch GPS data from positionKit at the moment of capture
+      // Fetch GPS data when an image is captured
       mGpsData = getGPSData( delegate->handler->positionKit(), delegate->handler->compass() );
     }];
 

--- a/app/ios/iosinterface.mm
+++ b/app/ios/iosinterface.mm
@@ -161,6 +161,14 @@ static NSMutableDictionary *getGPSData( PositionKit *positionKit, Compass *compa
     qWarning( "invalid compass, no GPS Direction" );
   }
 
+  NSDateFormatter *dateFormatter = [[NSDateFormatter alloc] init];
+  [dateFormatter setTimeZone:[NSTimeZone timeZoneWithName:@"UTC"]];
+  NSDate *now = [NSDate date];
+  [dateFormatter setDateFormat:@"yyyy:MM:dd"];
+  [gpsDict setValue:[dateFormatter stringFromDate:now] forKey:( NSString * )kCGImagePropertyGPSDateStamp];
+  [dateFormatter setDateFormat:@"HH:mm:ss"];
+  [gpsDict setValue:[dateFormatter stringFromDate:now] forKey:( NSString * )kCGImagePropertyGPSTimeStamp];
+
   return gpsDict;
 }
 

--- a/app/ios/iosinterface.mm
+++ b/app/ios/iosinterface.mm
@@ -129,11 +129,11 @@ static NSMutableDictionary *getGPSData( PositionKit *positionKit, Compass *compa
       @try
       {
         const QgsPoint position = positionKit->positionCoordinate();
-        [gpsDict setValue:[NSNumber numberWithFloat:position.x()] forKey:( NSString * )kCGImagePropertyGPSLongitude];
-        [gpsDict setValue:[NSNumber numberWithFloat:position.y()] forKey:( NSString * )kCGImagePropertyGPSLatitude];
+        [gpsDict setValue:[NSNumber numberWithDouble:fabs( position.x() )] forKey:( NSString * )kCGImagePropertyGPSLongitude];
+        [gpsDict setValue:[NSNumber numberWithDouble:fabs( position.y() )] forKey:( NSString * )kCGImagePropertyGPSLatitude];
         [gpsDict setValue:position.x() < 0.0 ? @"W" : @"E" forKey : ( NSString * )kCGImagePropertyGPSLongitudeRef];
         [gpsDict setValue:position.y() < 0.0 ? @"S" : @"N" forKey : ( NSString * )kCGImagePropertyGPSLatitudeRef];
-        [gpsDict setValue:[NSNumber numberWithFloat:position.z()] forKey:( NSString * )kCGImagePropertyGPSAltitude];
+        [gpsDict setValue:[NSNumber numberWithDouble:fabs( position.z() )] forKey:( NSString * )kCGImagePropertyGPSAltitude];
         [gpsDict setValue:[NSNumber numberWithShort:position.z() < 0.0 ? 1 : 0] forKey:( NSString * )kCGImagePropertyGPSAltitudeRef];
       }
       @catch ( NSException *exception )

--- a/app/ios/iosinterface.mm
+++ b/app/ios/iosinterface.mm
@@ -28,6 +28,7 @@
 #import <Foundation/Foundation.h>
 #import <CoreFoundation/CoreFoundation.h>
 #import <CoreLocation/CoreLocation.h>
+#import <Photos/Photos.h>
 
 @implementation IOSInterface
 
@@ -229,13 +230,41 @@ static NSMutableDictionary *getGPSData( PositionKit *positionKit, Compass *compa
       else
       {
         // Gallery handling
-        // Copy an image with metadata from imageURL to targetPath
-        NSURL *infoImageUrl = info[UIImagePickerControllerImageURL];
-        if ( !InputUtils::copyFile( QString::fromNSString( infoImageUrl.absoluteString ), QString::fromNSString( imagePath ) ) )
+        // use PHAsset to request the original image data with full EXIF (including GPS).
+        PHAsset *asset = info[UIImagePickerControllerPHAsset];
+        if ( asset )
         {
-          err = QStringLiteral( "Copying image from a gallery failed." );
+          PHImageRequestOptions *options = [[PHImageRequestOptions alloc] init];
+          options.synchronous = YES;
+          options.deliveryMode = PHImageRequestOptionsDeliveryModeHighQualityFormat;
+          options.version = PHImageRequestOptionsVersionOriginal;
+          options.networkAccessAllowed = YES;
+
+          __block BOOL writeSuccess = NO;
+          [[PHImageManager defaultManager] requestImageDataAndOrientationForAsset:asset
+           options:options
+           resultHandler: ^ ( NSData * imageData, NSString *dataUTI, CGImagePropertyOrientation orientation, NSDictionary * requestInfo )
+          {
+            if ( imageData )
+            {
+              writeSuccess = [imageData writeToFile:imagePath atomically:YES];
+            }
+          }];
+
+          if ( !writeSuccess )
+          {
+            err = QStringLiteral( "Copying image from gallery failed." );
+          }
         }
-        infoImageUrl = nil;
+        else
+        {
+          // fallback: copy file directly, even though GPS metadata might be deleted by iOS
+          NSURL *infoImageUrl = info[UIImagePickerControllerImageURL];
+          if ( !InputUtils::copyFile( QString::fromNSString( infoImageUrl.absoluteString ), QString::fromNSString( imagePath ) ) )
+          {
+            err = QStringLiteral( "Copying image from a gallery failed." );
+          }
+        }
       }
 
       [picker dismissViewControllerAnimated:YES completion:nil];

--- a/app/ios/iosviewdelegate.h
+++ b/app/ios/iosviewdelegate.h
@@ -17,6 +17,7 @@
 #define IOSVIEWDELEGATE_H
 
 #include <UIKit/UIKit.h>
+#import <PhotosUI/PhotosUI.h>
 
 #include "iosimagepicker.h"
 /**
@@ -34,6 +35,13 @@ UINavigationControllerDelegate>
   void ( ^ imagePickerControllerDidCancel )( UIImagePickerController * picker );
 }
 - ( id ) initWithHandler:( IOSImagePicker * )handler;
+@end
+
+/**
+ * we use PHPickerViewController delegate for gallery image selection, which keeps GPS metadata
+ */
+@interface IOSGalleryPickerDelegate : NSObject <PHPickerViewControllerDelegate>
+- ( instancetype ) initWithHandler:( IOSImagePicker * )handler;
 @end
 
 #endif // IOSVIEWDELEGATE_H

--- a/app/ios/iosviewdelegate.mm
+++ b/app/ios/iosviewdelegate.mm
@@ -14,11 +14,8 @@
  ***************************************************************************/
 
 #include <QtCore>
+#include <QPointer>
 #import "iosviewdelegate.h"
-
-@interface IOSViewDelegate()
-
-@end
 
 @implementation IOSViewDelegate
 
@@ -47,6 +44,66 @@
   {
     imagePickerControllerDidCancel( picker );
   }
+}
+
+@end
+
+@implementation IOSGalleryPickerDelegate
+{
+  QPointer<IOSImagePicker> _handler;
+}
+
+- ( instancetype ) initWithHandler:( IOSImagePicker * )handler
+{
+  self = [super init];
+  if ( self )
+  {
+    _handler = handler;
+  }
+  return self;
+}
+
+- ( void )picker:( PHPickerViewController * )picker didFinishPicking:( NSArray<PHPickerResult *> * )results
+{
+  [picker dismissViewControllerAnimated:YES completion:nil];
+
+  if ( results.count == 0 )
+  {
+    return; // user cancelled
+  }
+
+  PHPickerResult *result = results.firstObject;
+
+  NSDateFormatter *df = [[NSDateFormatter alloc] init];
+  [df setDateFormat:@"yyyyMMdd_HHmmss"];
+  NSString *fileName = [[df stringFromDate:[NSDate date]] stringByAppendingString:@".jpg"];
+  NSString *imagePath = [_handler->targetDir().toNSString() stringByAppendingPathComponent:fileName];
+
+  [result.itemProvider loadDataRepresentationForTypeIdentifier:@"public.jpeg"
+   completionHandler: ^ ( NSData * data, NSError * error )
+  {
+    BOOL writeSuccess = data && !error && [data writeToFile:imagePath atomically:YES];
+    if ( !writeSuccess )
+    {
+      qWarning() << "Gallery Picker: failed to write image data to" << QString::fromNSString( imagePath );
+    }
+
+    dispatch_async( dispatch_get_main_queue(), ^
+    {
+      if ( _handler )
+      {
+        QVariantMap resultData;
+        resultData["imagePath"] = QString::fromNSString( imagePath );
+        if ( !writeSuccess )
+        {
+          resultData["error"] = QStringLiteral( "Copying image from gallery failed." );
+        }
+        QMetaObject::invokeMethod( _handler, "onImagePickerFinished", Qt::DirectConnection,
+                                   Q_ARG( bool, writeSuccess ),
+                                   Q_ARG( const QVariantMap, resultData ) );
+      }
+    } );
+  }];
 }
 
 @end

--- a/app/ios/iosviewdelegate.mm
+++ b/app/ios/iosviewdelegate.mm
@@ -72,6 +72,11 @@
     return; // user cancelled
   }
 
+  if ( !_handler )
+  {
+    return;
+  }
+
   PHPickerResult *result = results.firstObject;
 
   NSDateFormatter *df = [[NSDateFormatter alloc] init];

--- a/app/ios/iosviewdelegate.mm
+++ b/app/ios/iosviewdelegate.mm
@@ -16,6 +16,7 @@
 #include <QtCore>
 #include <QPointer>
 #import "iosviewdelegate.h"
+#import "coreutils.h"
 
 @implementation IOSViewDelegate
 
@@ -90,7 +91,7 @@
     BOOL writeSuccess = data && !error && [data writeToFile:imagePath atomically:YES];
     if ( !writeSuccess )
     {
-      qWarning() << "Gallery Picker: failed to write image data to" << QString::fromNSString( imagePath );
+      CoreUtils::log( "iOS photo picker", QStringLiteral( "Gallery Picker: failed to write image data to %1" ).arg( QString::fromNSString( imagePath ) ) );
     }
 
     dispatch_async( dispatch_get_main_queue(), ^

--- a/cmake/FindAppleFrameworks.cmake
+++ b/cmake/FindAppleFrameworks.cmake
@@ -19,6 +19,7 @@ set(APPLE_FRAMEWORKS
     SystemConfiguration
     CoreLocation
     CoreHaptics
+    Photos
 )
 
 foreach (framework ${APPLE_FRAMEWORKS})

--- a/cmake/FindAppleFrameworks.cmake
+++ b/cmake/FindAppleFrameworks.cmake
@@ -19,7 +19,7 @@ set(APPLE_FRAMEWORKS
     SystemConfiguration
     CoreLocation
     CoreHaptics
-    Photos
+    PhotosUI
 )
 
 foreach (framework ${APPLE_FRAMEWORKS})


### PR DESCRIPTION
Modified the image picker logic for gallery and camera inputs.
- the camera logic use UIImagePickerController
- the gallery picker now uses PHPickerViewController instead of UIImagePickerController API. This controller preserves all the EXIF metadata from photos, thus the GPS information is kept.

Added IOSGalleryPickerDelegate, a PHPickerViewControllerDelegate implementation that retrieves the original image metadata via NSItemProvider, which preserves GPS data and calls back into the Qt layer on the main thread

Tested on iOS 26 using the clone of [this project](https://app.merginmaps.com/projects/documentation/exif-metadata/tree?_gl=1*1p36gcn*_gcl_au*MjA0OTkyNTczOC4xNzY4Mzg3NTU1*_ga*MjU4MjMwNTA3LjE3NjgzODc1NTU.*_ga_RKTVJMQ7R2*czE3NzM3NTg1NTckbzIyJGcxJHQxNzczNzU4NTc2JGo0MSRsMCRoMA..)

Edit after QA: added date exif data for the photo taken with camera
