### PR TITLE
Fixed silent crash and filter input behaviour for numbers

### DIFF
--- a/app/filtercontroller.cpp
+++ b/app/filtercontroller.cpp
@@ -131,12 +131,37 @@ void FilterController::loadFilterConfig( const QgsProject *project )
       newFieldFilter.sqlExpression = filterObject.value( QStringLiteral( "sql_expression" ) ).toString();
       newFieldFilter.layerId = filterObject.value( QStringLiteral( "layer_id" ) ).toString();
 
+      // check for missing filter fields
+      QStringList missingFilterFields;
+      if ( newFieldFilter.layerId.isEmpty() ) missingFilterFields << QStringLiteral( "'layer_id'" );
+      if ( newFieldFilter.fieldName.isEmpty() ) missingFilterFields << QStringLiteral( "'field_name'" );
+      if ( newFieldFilter.sqlExpression.isEmpty() ) missingFilterFields << QStringLiteral( "'sql_expression'" );
+
+      if ( !missingFilterFields.isEmpty() )
+      {
+        CoreUtils::log( QStringLiteral( "Feature Filtering" ),
+                        QStringLiteral( "Filter '%1' is missing required filter field(s): %2. Skipping." )
+                        .arg( newFieldFilter.filterName, missingFilterFields.join( QStringLiteral( ", " ) ) ) );
+        continue;
+      }
+
+      // check if target layer exists
       const QgsVectorLayer *filterLayer = qobject_cast<QgsVectorLayer *>( project->mapLayer( newFieldFilter.layerId ) );
       if ( !filterLayer )
       {
         CoreUtils::log( QStringLiteral( "Feature Filtering" ),
-                        QStringLiteral( "Filter '%1' is not properly configured in the project. Skipping filter." )
-                        .arg( newFieldFilter.filterName ) );
+                        QStringLiteral( "Filter '%1' has no layer with ID '%2' found in project. Skipping." )
+                        .arg( newFieldFilter.filterName, newFieldFilter.layerId ) );
+        continue;
+      }
+
+      // check if target field of target layer exists
+      if ( filterLayer->fields().lookupField( newFieldFilter.fieldName ) < 0 )
+      {
+        CoreUtils::log( QStringLiteral( "Feature Filtering" ),
+                        QStringLiteral( "Filter '%1' has no target field '%2' found on layer '%3' (%4). Skipping." )
+                        .arg( newFieldFilter.filterName, newFieldFilter.fieldName,
+                              filterLayer->name(), newFieldFilter.layerId ) );
         continue;
       }
 

--- a/app/filtercontroller.cpp
+++ b/app/filtercontroller.cpp
@@ -32,9 +32,15 @@ void FilterController::clearLayerFilters( const QString &layerId )
 {
   QgsMapLayer *layer = QgsProject::instance()->mapLayers().value( layerId );
   QgsVectorLayer *vectorLayer = qobject_cast<QgsVectorLayer *>( layer );
+  if ( !vectorLayer )
+  {
+    CoreUtils::log( QStringLiteral( "Feature Filtering" ),
+                    QStringLiteral( "Layer '%1' is not available. Cannot clear its filters." ).arg( layerId ) );
+    return;
+  }
   vectorLayer->setSubsetString( QStringLiteral( "" ) );
 
-  for ( FieldFilter filter : mFieldFilters )
+  for ( FieldFilter &filter : mFieldFilters )
   {
     if ( filter.layerId == layerId )
     {
@@ -131,6 +137,15 @@ void FilterController::loadFilterConfig( const QgsProject *project )
       newFieldFilter.sqlExpression = filterObject.value( QStringLiteral( "sql_expression" ) ).toString();
       newFieldFilter.layerId = filterObject.value( QStringLiteral( "layer_id" ) ).toString();
 
+      const QgsVectorLayer *filterLayer = qobject_cast<QgsVectorLayer *>( QgsProject::instance()->mapLayer( newFieldFilter.layerId ) );
+      if ( !filterLayer )
+      {
+        CoreUtils::log( QStringLiteral( "Feature Filtering" ),
+                        QStringLiteral( "Layer '%1' for filter '%2' is not available in the project. Skipping filter." )
+                        .arg( newFieldFilter.layerId, newFieldFilter.filterName ) );
+        continue;
+      }
+
       mFieldFilters.append( newFieldFilter );
     }
   }
@@ -157,9 +172,12 @@ QString FilterController::buildFieldExpression( const FieldFilter &filter ) cons
     }
     case FieldFilter::NumberFilter:
     {
-      const QVariant &variantFrom = filter.value.toList().at( 0 );
+      const QVariantList values = filter.value.toList();
+      if ( values.size() < 2 )
+        return {};
+      const QVariant variantFrom = values.at( 0 );
       const QString valueFrom = variantFrom.isValid() ? variantFrom.toString() : QString::number( std::numeric_limits<int>::min() );
-      const QVariant &variantTo = filter.value.toList().at( 1 );
+      const QVariant variantTo = values.at( 1 );
       const QString valueTo = variantTo.isValid() ? variantTo.toString() : QString::number( std::numeric_limits<int>::max() );
 
       expressionCopy.replace( QStringLiteral( "@@value_from@@" ), valueFrom );
@@ -175,8 +193,13 @@ QString FilterController::buildFieldExpression( const FieldFilter &filter ) cons
       const QString minimumDateTime = QStringLiteral( "0001-01-01T00:00:00.000" );
       const QString maximumDateTime = QStringLiteral( "9999-12-31T23:59:59.999" );
 
+      const QVariantList values = filter.value.toList();
+      if ( values.size() < 2 )
+        return {};
+      const QVariant variantFrom = values.at( 0 );
+      const QVariant variantTo = values.at( 1 );
+
       QString dateFrom;
-      const QVariant &variantFrom = filter.value.toList().at( 0 );
       if ( variantFrom.isValid() )
       {
         QDateTime dateTimeFrom = variantFrom.toDateTime( );
@@ -190,21 +213,20 @@ QString FilterController::buildFieldExpression( const FieldFilter &filter ) cons
         dateFrom = minimumDateTime;
       }
 
-      const QVariant &variantTo = filter.value.toList().at( 1 );
       QString dateTo;
       if ( variantTo.isValid() )
       {
         if ( variantTo.toDateTime().time().hour() > 0 || variantTo.toDateTime().time().minute() > 0 )
         {
-          QDateTime dateTimeTo = variantFrom.toDateTime( );
-          QTime timeFrom = dateTimeTo.time();
-          timeFrom.setHMS( timeFrom.hour(), timeFrom.minute(), 59, 999 );
-          dateTimeTo.setTime( timeFrom );
+          QDateTime dateTimeTo = variantTo.toDateTime( );
+          QTime timeTo = dateTimeTo.time();
+          timeTo.setHMS( timeTo.hour(), timeTo.minute(), 59, 999 );
+          dateTimeTo.setTime( timeTo );
           dateTo = dateTimeTo.toString( isoFormat );
         }
         else
         {
-          dateTo = variantFrom.toDateTime().toString( isoFormat );
+          dateTo = variantTo.toDateTime().toString( isoFormat );
         }
       }
       else
@@ -359,6 +381,12 @@ bool FilterController::hasActiveFilterOnLayer( const QString &layerId )
     return false;
 
   const QgsVectorLayer *layer = qobject_cast<QgsVectorLayer *>( project->mapLayers().value( layerId ) );
+  if ( !layer )
+  {
+    CoreUtils::log( QStringLiteral( "Feature Filtering" ),
+                    QStringLiteral( "Layer '%1' is not available. Cannot check active filter." ).arg( layerId ) );
+    return false;
+  }
   return !layer->subsetString().isEmpty();
 }
 
@@ -369,6 +397,13 @@ bool FilterController::isDateFilterDateTime( const QString &filterId )
     if ( filter.filterId == filterId )
     {
       const QgsVectorLayer *layer = qobject_cast<QgsVectorLayer *>( QgsProject::instance()->mapLayer( filter.layerId ) );
+      if ( !layer )
+      {
+        CoreUtils::log( QStringLiteral( "Feature Filtering" ),
+                        QStringLiteral( "Layer '%1' for filter '%2' is not available." )
+                        .arg( filter.layerId, filter.filterName ) );
+        return false;
+      }
       const QMetaType::Type fieldType = layer->fields().field( filter.fieldName ).type();
       return fieldType == QMetaType::QDateTime;
     }

--- a/app/filtercontroller.cpp
+++ b/app/filtercontroller.cpp
@@ -32,12 +32,6 @@ void FilterController::clearLayerFilters( const QString &layerId )
 {
   QgsMapLayer *layer = QgsProject::instance()->mapLayers().value( layerId );
   QgsVectorLayer *vectorLayer = qobject_cast<QgsVectorLayer *>( layer );
-  if ( !vectorLayer )
-  {
-    CoreUtils::log( QStringLiteral( "Feature Filtering" ),
-                    QStringLiteral( "Layer '%1' is not available. Cannot clear its filters." ).arg( layerId ) );
-    return;
-  }
   vectorLayer->setSubsetString( QStringLiteral( "" ) );
 
   for ( FieldFilter &filter : mFieldFilters )
@@ -137,7 +131,7 @@ void FilterController::loadFilterConfig( const QgsProject *project )
       newFieldFilter.sqlExpression = filterObject.value( QStringLiteral( "sql_expression" ) ).toString();
       newFieldFilter.layerId = filterObject.value( QStringLiteral( "layer_id" ) ).toString();
 
-      const QgsVectorLayer *filterLayer = qobject_cast<QgsVectorLayer *>( QgsProject::instance()->mapLayer( newFieldFilter.layerId ) );
+      const QgsVectorLayer *filterLayer = qobject_cast<QgsVectorLayer *>( project->mapLayer( newFieldFilter.layerId ) );
       if ( !filterLayer )
       {
         CoreUtils::log( QStringLiteral( "Feature Filtering" ),
@@ -381,12 +375,6 @@ bool FilterController::hasActiveFilterOnLayer( const QString &layerId )
     return false;
 
   const QgsVectorLayer *layer = qobject_cast<QgsVectorLayer *>( project->mapLayers().value( layerId ) );
-  if ( !layer )
-  {
-    CoreUtils::log( QStringLiteral( "Feature Filtering" ),
-                    QStringLiteral( "Layer '%1' is not available. Cannot check active filter." ).arg( layerId ) );
-    return false;
-  }
   return !layer->subsetString().isEmpty();
 }
 
@@ -397,13 +385,6 @@ bool FilterController::isDateFilterDateTime( const QString &filterId )
     if ( filter.filterId == filterId )
     {
       const QgsVectorLayer *layer = qobject_cast<QgsVectorLayer *>( QgsProject::instance()->mapLayer( filter.layerId ) );
-      if ( !layer )
-      {
-        CoreUtils::log( QStringLiteral( "Feature Filtering" ),
-                        QStringLiteral( "Layer '%1' for filter '%2' is not available." )
-                        .arg( filter.layerId, filter.filterName ) );
-        return false;
-      }
       const QMetaType::Type fieldType = layer->fields().field( filter.fieldName ).type();
       return fieldType == QMetaType::QDateTime;
     }

--- a/app/filtercontroller.cpp
+++ b/app/filtercontroller.cpp
@@ -135,8 +135,8 @@ void FilterController::loadFilterConfig( const QgsProject *project )
       if ( !filterLayer )
       {
         CoreUtils::log( QStringLiteral( "Feature Filtering" ),
-                        QStringLiteral( "Layer '%1' for filter '%2' is not available in the project. Skipping filter." )
-                        .arg( newFieldFilter.layerId, newFieldFilter.filterName ) );
+                        QStringLiteral( "Filter '%1' is not properly configured in the project. Skipping filter." )
+                        .arg( newFieldFilter.filterName ) );
         continue;
       }
 

--- a/app/qml/filters/components/MMFilterRangeInput.qml
+++ b/app/qml/filters/components/MMFilterRangeInput.qml
@@ -45,7 +45,7 @@ Column {
       width: ( parent.width - __style.margin12 ) / 2
       type: MMFilterTextInput.InputType.Number
       placeholderText: qsTr( "Min" )
-      text: root.currentValue && root.currentValue[0] ? root.currentValue[0] : ""
+      text: root.currentValue && root.currentValue[0] !== undefined ? root.currentValue[0] : ""
       errorMsg: rangeRow.rangeInvalid ? qsTr( "\"Min\" must be less than \"Max\"" ) : ""
 
       onTextChanged: {
@@ -59,7 +59,7 @@ Column {
       width: ( parent.width - __style.margin12 ) / 2
       type: MMFilterTextInput.InputType.Number
       placeholderText: qsTr( "Max" )
-      text: root.currentValue && root.currentValue[1] ? root.currentValue[1] : ""
+      text: root.currentValue && root.currentValue[1] !== undefined ? root.currentValue[1] : ""
       errorMsg: rangeRow.rangeInvalid ? qsTr( "\"Min\" must be less than \"Max\"" ) : ""
 
       onTextChanged: {
@@ -73,19 +73,33 @@ Column {
     interval: 300
     repeat: false
     onTriggered: {
-      let newValues = []
-      const valueFrom = parseFloat(fromInput.text)
-      if ( !isNaN(valueFrom) ) {
-        newValues[0] = valueFrom
-      } else {
+      let newValues = [
+        root.currentValue ? root.currentValue[0] : undefined,
+        root.currentValue ? root.currentValue[1] : undefined
+      ]
+
+      const fromText = fromInput.text
+      if ( fromText.length === 0 ) {
         newValues[0] = undefined
+      } else {
+        const valueFrom = parseFloat( fromText )
+        if ( !isNaN( valueFrom ) ) {
+          newValues[0] = valueFrom
+        } else {
+          return  // partial input, such as "-"
+        }
       }
 
-      const valueTo = parseFloat(toInput.text)
-      if ( !isNaN(valueTo) ) {
-        newValues[1] = valueTo
-      } else {
+      const toText = toInput.text
+      if ( toText.length === 0 ) {
         newValues[1] = undefined
+      } else {
+        const valueTo = parseFloat( toText )
+        if ( !isNaN( valueTo ) ) {
+          newValues[1] = valueTo
+        } else {
+          return  // partial input: same reason 
+        }
       }
 
       if ( newValues[0] === undefined && newValues[1] === undefined ) {

--- a/app/qml/filters/components/MMFilterTextInput.qml
+++ b/app/qml/filters/components/MMFilterTextInput.qml
@@ -72,8 +72,11 @@ MMPrivateComponents.MMBaseSingleLineInput {
   }
 
   // keep checked in sync with whether the field has a value
+  // dropdown type manages checked via the parent's binding
   onTextChanged: {
-    root.checked = root.text.length > 0
+    if ( root.type !== MMFilterTextInput.InputType.Dropdown ) {
+      root.checked = root.text.length > 0
+    }
   }
 
   // clear the field when tapping the close icon
@@ -84,9 +87,4 @@ MMPrivateComponents.MMBaseSingleLineInput {
     }
   }
 
-  Component.onCompleted: {
-    if ( root.text ) {
-      root.checked = true
-    }
-  }
 }

--- a/app/qml/filters/components/MMFilterTextInput.qml
+++ b/app/qml/filters/components/MMFilterTextInput.qml
@@ -26,6 +26,7 @@ MMPrivateComponents.MMBaseSingleLineInput {
 
   // date and dropdown types open pickers instead of accepting keyboard input
   textField.readOnly: root.type === MMFilterTextInput.InputType.Date || root.type === MMFilterTextInput.InputType.Dropdown
+  textField.inputMethodHints: root.type === MMFilterTextInput.InputType.Number ? Qt.ImhFormattedNumbersOnly : Qt.ImhNone
   textField.color: {
     if ( root.editState === "readOnly" ) return __style.nightColor
     if ( root.editState === "enabled" ) return __style.nightColor
@@ -72,9 +73,7 @@ MMPrivateComponents.MMBaseSingleLineInput {
 
   // keep checked in sync with whether the field has a value
   onTextChanged: {
-    if ( root.type === MMFilterTextInput.InputType.Text || root.type === MMFilterTextInput.InputType.Number ) {
-      root.checked = false
-    }
+    root.checked = root.text.length > 0
   }
 
   // clear the field when tapping the close icon


### PR DESCRIPTION
- Fixed silent crashes that occurred when a filter was added to the project without a layer or field in plugin, that would lead to a silent crash in the app. Now we skip these filters and I added logging messages for them. Also, I added some guards for other potential silent crashes.
- Fixed checked status for filter inputs which was broken when inputting text, numbers or dates.
- Added support for negative numbers and 0 as inputs for number range filters
- fixed the false checked status for dropdown filter types