### PR TITLE
Fix null values in filter dropdowns

### DIFF
--- a/app/filter/uniquevaluesfiltermodel.cpp
+++ b/app/filter/uniquevaluesfiltermodel.cpp
@@ -115,7 +115,16 @@ QVariantList UniqueValuesFilterModel::loadUniqueValues( QgsVectorLayer *layer, i
 {
   std::unique_ptr<QgsVectorLayer> l( layer );
 
-  const QSet<QVariant> uniqueValues = l->uniqueValues( fieldIndex, 1000000 );
+  QSet<QVariant> uniqueValues = l->uniqueValues( fieldIndex, 1000000 );
+
+  uniqueValues << QVariant( QString() );
+
+  // both empty string and null value show up in the same way, let's remove one to have only one "No value" option in UI
+  const QVariant nullValidQVariant = QVariant( QMetaType( QMetaType::QString ) );
+  if ( uniqueValues.contains( QVariant( "" ) ) && uniqueValues.contains( nullValidQVariant ) )
+  {
+    uniqueValues.remove( QVariant( "" ) );
+  }
 
   QVariantList results;
 

--- a/app/filter/uniquevaluesfiltermodel.cpp
+++ b/app/filter/uniquevaluesfiltermodel.cpp
@@ -20,6 +20,13 @@ UniqueValuesFilterModel::UniqueValuesFilterModel( QObject *parent ) : QAbstractL
   connect( &mResultWatcher, &QFutureWatcher<QVariantList>::finished, this, &UniqueValuesFilterModel::onLoadingFinished );
 }
 
+QHash<int, QByteArray> UniqueValuesFilterModel::roleNames() const
+{
+  QHash<int, QByteArray> roleMap = QAbstractListModel::roleNames();
+  roleMap.insert( ValueRole, QStringLiteral( "value" ).toLatin1() );
+  return roleMap;
+}
+
 int UniqueValuesFilterModel::rowCount( const QModelIndex &parent ) const
 {
   Q_UNUSED( parent )
@@ -34,6 +41,9 @@ QVariant UniqueValuesFilterModel::data( const QModelIndex &index, int role ) con
   switch ( role )
   {
     case Qt::DisplayRole:
+      // for NULL values, which are gotten as empty strings, we want to return some meaningful text for users
+      return mItems.at( index.row() ).toString().isEmpty() ? QVariant( tr( "No value" ) ) : mItems.at( index.row() );
+    case ValueRole:
       return mItems.at( index.row() );
     default:
       return {};

--- a/app/filter/uniquevaluesfiltermodel.h
+++ b/app/filter/uniquevaluesfiltermodel.h
@@ -28,9 +28,16 @@ class UniqueValuesFilterModel : public QAbstractListModel
     Q_PROPERTY( int count READ rowCount NOTIFY countChanged )
 
   public:
+    enum Roles
+    {
+      ValueRole = Qt::UserRole + 1, // DisplayRole is used for description
+    };
+    Q_ENUM( Roles )
+
     explicit UniqueValuesFilterModel( QObject *parent = nullptr );
     ~UniqueValuesFilterModel() override = default;
 
+    QHash<int, QByteArray> roleNames() const override;
     int rowCount( const QModelIndex &parent = QModelIndex() ) const override;
     QVariant data( const QModelIndex &index, int role = Qt::DisplayRole ) const override;
 

--- a/app/filtercontroller.cpp
+++ b/app/filtercontroller.cpp
@@ -455,9 +455,6 @@ QVariantMap FilterController::getDropdownConfiguration( const QString &filterId 
   QVariantMap map;
 
   const QgsProject *project = QgsProject::instance();
-
-  if ( !project ) return {};
-
   const QgsVectorLayer *layer = qobject_cast<QgsVectorLayer *>( project->mapLayers().value( fieldFilter.layerId ) );
 
   if ( !layer ) return {};

--- a/app/filtercontroller.cpp
+++ b/app/filtercontroller.cpp
@@ -150,9 +150,29 @@ QString FilterController::buildFieldExpression( const FieldFilter &filter ) cons
       break;
     }
     case FieldFilter::CheckboxFilter:
-    case FieldFilter::SingleSelectFilter:
     {
       expressionCopy.replace( QStringLiteral( "@@value@@" ), QgsExpression::quotedValue( filter.value.toList().at( 0 ) ) );
+      break;
+    }
+    case FieldFilter::SingleSelectFilter:
+    {
+      // check if the value is NULL and if it is search for both NULL and empty string
+      if ( QgsVariantUtils::isNull( filter.value.toList().at( 0 ) ) )
+      {
+        QStringList expressions;
+        QString expressionTemplate( expressionCopy );
+        expressionTemplate.replace( QStringLiteral( "@@value@@" ), QStringLiteral( "NULL" ) );
+        expressions << QStringLiteral( "(%1)" ).arg( expressionTemplate );
+        expressionTemplate = QString( expressionCopy );
+        expressionTemplate.replace( QStringLiteral( "@@value@@" ), QStringLiteral( "''" ) );
+        expressions << QStringLiteral( "(%1)" ).arg( expressionTemplate );
+
+        expressionCopy =  expressions.join( QStringLiteral( " OR " ) );
+      }
+      else
+      {
+        expressionCopy.replace( QStringLiteral( "@@value@@" ), QgsExpression::quotedValue( filter.value.toList().at( 0 ) ) );
+      }
       break;
     }
     case FieldFilter::NumberFilter:
@@ -228,9 +248,20 @@ QString FilterController::buildFieldExpression( const FieldFilter &filter ) cons
       QStringList expressions;
       for ( const QVariant &v : values )
       {
-        QString expressionTemplate = expressionCopy;
-        expressionTemplate.replace( QStringLiteral( "@@value@@" ), QgsExpression::quotedValue( v ) );
-        expressions << QStringLiteral( "(%1)" ).arg( expressionTemplate );
+        QString expressionTemplate( expressionCopy );
+        if ( QgsVariantUtils::isNull( v ) )
+        {
+          expressionTemplate.replace( QStringLiteral( "@@value@@" ), QStringLiteral( "NULL" ) );
+          expressions << QStringLiteral( "(%1)" ).arg( expressionTemplate );
+          expressionTemplate = QString( expressionCopy );
+          expressionTemplate.replace( QStringLiteral( "@@value@@" ), QStringLiteral( "''" ) );
+          expressions << QStringLiteral( "(%1)" ).arg( expressionTemplate );
+        }
+        else
+        {
+          expressionTemplate.replace( QStringLiteral( "@@value@@" ), QgsExpression::quotedValue( v ) );
+          expressions << QStringLiteral( "(%1)" ).arg( expressionTemplate );
+        }
       }
       expressionCopy =  expressions.join( QStringLiteral( " OR " ) );
       break;

--- a/app/filtercontroller.cpp
+++ b/app/filtercontroller.cpp
@@ -225,12 +225,14 @@ QString FilterController::buildFieldExpression( const FieldFilter &filter ) cons
         break;
       }
 
-      QStringList quotedValues;
+      QStringList expressions;
       for ( const QVariant &v : values )
       {
-        quotedValues << QgsExpression::quotedValue( v );
+        QString expressionTemplate = expressionCopy;
+        expressionTemplate.replace( QStringLiteral( "@@value@@" ), QgsExpression::quotedValue( v ) );
+        expressions << QStringLiteral( "(%1)" ).arg( expressionTemplate );
       }
-      expressionCopy.replace( QStringLiteral( "@@values@@" ), quotedValues.join( QStringLiteral( ", " ) ) );
+      expressionCopy =  expressions.join( QStringLiteral( " OR " ) );
       break;
     }
   }

--- a/app/qml/filters/MMFiltersPanel.qml
+++ b/app/qml/filters/MMFiltersPanel.qml
@@ -152,8 +152,7 @@ MMComponents.MMDrawer {
               {
                 // TODO: might be worth moving this logic to C++
 
-                const isMulti = filterType === FieldFilter.MultiSelectFilter
-                props['isMultiSelect'] = isMulti
+                props['isMultiSelect'] = filterType === FieldFilter.MultiSelectFilter
 
                 const dropdownConfig = __activeProject.filterController.getDropdownConfiguration( modelData.filterId )
 

--- a/app/qml/filters/components/MMFilterDropdownUniqueValuesInput.qml
+++ b/app/qml/filters/components/MMFilterDropdownUniqueValuesInput.qml
@@ -87,7 +87,7 @@ Column {
 
       textRole: "display"
       secondaryTextRole: ""
-      valueRole: "display"
+      valueRole: "value"
 
       onSelectionFinished: function( selectedItems ) {
         root.currentValue = selectedItems


### PR DESCRIPTION
This PR fixes 2 things:
- dropdowns showing unique values for field will instead of empty option show `No value` option as the first option if `NULL` values are stored in the field
- for multi select unique values dropdowns the filter expression generation changed, plugin now supplies only expression for a single value and the app needs to multiply this expression with as many values as selected and join it with ` OR `  