### PR TITLE
Fixed date and date time filtering

### DIFF
--- a/app/filtercontroller.cpp
+++ b/app/filtercontroller.cpp
@@ -259,19 +259,16 @@ QString FilterController::buildFieldExpression( const FieldFilter &filter ) cons
     }
     case FieldFilter::DateFilter:
     {
-      const QgsVectorLayer *filterLayer = qobject_cast<QgsVectorLayer *>( QgsProject::instance()->mapLayer( filter.layerId ) );
-      const bool isDateTimeField = filterLayer && filterLayer->fields().field( filter.fieldName ).type() == QMetaType::QDateTime;
-
       const QVariantList values = filter.value.toList();
       if ( values.size() < 2 )
         return {};
-      const QVariant variantFrom = values.at( 0 );
-      const QVariant variantTo = values.at( 1 );
+      const QVariant &variantFrom = values.at( 0 );
+      const QVariant &variantTo = values.at( 1 );
 
       QString dateFrom;
       QString dateTo;
 
-      if ( isDateTimeField )
+      if ( isDateFilterDateTime( filter.filterId ) )
       {
         // GeoPackage stores datetimes as timezone-naive strings (effectively UTC),
         // so we must convert local datetimes to UTC before comparing.
@@ -297,7 +294,6 @@ QString FilterController::buildFieldExpression( const FieldFilter &filter ) cons
         {
           QDateTime dateTimeTo = variantTo.toDateTime().toUTC();
           QTime timeTo = dateTimeTo.time();
-          // Round to end-of-minute so the "to" bound is inclusive regardless of whether the user picked midnight
           timeTo.setHMS( timeTo.hour(), timeTo.minute(), 59, 999 );
           dateTimeTo.setTime( timeTo );
           dateTo = dateTimeTo.toString( isoFormat );
@@ -486,9 +482,9 @@ bool FilterController::hasActiveFilterOnLayer( const QString &layerId )
   return !layer->subsetString().isEmpty();
 }
 
-bool FilterController::isDateFilterDateTime( const QString &filterId )
+bool FilterController::isDateFilterDateTime( const QString &filterId ) const
 {
-  for ( FieldFilter &filter : mFieldFilters )
+  for ( const FieldFilter &filter : mFieldFilters )
   {
     if ( filter.filterId == filterId )
     {

--- a/app/filtercontroller.cpp
+++ b/app/filtercontroller.cpp
@@ -259,12 +259,8 @@ QString FilterController::buildFieldExpression( const FieldFilter &filter ) cons
     }
     case FieldFilter::DateFilter:
     {
-      // GeoPackage stores datetimes as timezone-naive strings (effectively UTC),
-      // so we must convert local datetimes to UTC before comparing.
-      // Use a custom format to avoid the 'Z' suffix that Qt::ISODate adds for UTC.
-      const QString isoFormat = QStringLiteral( "yyyy-MM-ddTHH:mm:ss.zzz" );
-      const QString minimumDateTime = QStringLiteral( "0001-01-01T00:00:00.000" );
-      const QString maximumDateTime = QStringLiteral( "9999-12-31T23:59:59.999" );
+      const QgsVectorLayer *filterLayer = qobject_cast<QgsVectorLayer *>( QgsProject::instance()->mapLayer( filter.layerId ) );
+      const bool isDateTimeField = filterLayer && filterLayer->fields().field( filter.fieldName ).type() == QMetaType::QDateTime;
 
       const QVariantList values = filter.value.toList();
       if ( values.size() < 2 )
@@ -273,38 +269,51 @@ QString FilterController::buildFieldExpression( const FieldFilter &filter ) cons
       const QVariant variantTo = values.at( 1 );
 
       QString dateFrom;
-      if ( variantFrom.isValid() )
-      {
-        QDateTime dateTimeFrom = variantFrom.toDateTime( );
-        QTime timeFrom = dateTimeFrom.time();
-        timeFrom.setHMS( timeFrom.hour(), timeFrom.minute(), 0 );
-        dateTimeFrom.setTime( timeFrom );
-        dateFrom = dateTimeFrom.toString( isoFormat );
-      }
-      else
-      {
-        dateFrom = minimumDateTime;
-      }
-
       QString dateTo;
-      if ( variantTo.isValid() )
+
+      if ( isDateTimeField )
       {
-        if ( variantTo.toDateTime().time().hour() > 0 || variantTo.toDateTime().time().minute() > 0 )
+        // GeoPackage stores datetimes as timezone-naive strings (effectively UTC),
+        // so we must convert local datetimes to UTC before comparing.
+        // Use a custom format to avoid the 'Z' suffix that Qt::ISODate adds for UTC.
+        const QString isoFormat = QStringLiteral( "yyyy-MM-ddTHH:mm:ss.zzz" );
+        const QString maximumDateTime = QStringLiteral( "9999-12-31T23:59:59.999" );
+        const QString minimumDateTime = QStringLiteral( "0001-01-01T00:00:00.000" );
+
+        if ( variantFrom.isValid() )
         {
-          QDateTime dateTimeTo = variantTo.toDateTime( );
+          QDateTime dateTimeFrom = variantFrom.toDateTime().toUTC();
+          QTime timeFrom = dateTimeFrom.time();
+          timeFrom.setHMS( timeFrom.hour(), timeFrom.minute(), 0 );
+          dateTimeFrom.setTime( timeFrom );
+          dateFrom = dateTimeFrom.toString( isoFormat );
+        }
+        else
+        {
+          dateFrom = minimumDateTime;
+        }
+
+        if ( variantTo.isValid() )
+        {
+          QDateTime dateTimeTo = variantTo.toDateTime().toUTC();
           QTime timeTo = dateTimeTo.time();
+          // Round to end-of-minute so the "to" bound is inclusive regardless of whether the user picked midnight
           timeTo.setHMS( timeTo.hour(), timeTo.minute(), 59, 999 );
           dateTimeTo.setTime( timeTo );
           dateTo = dateTimeTo.toString( isoFormat );
         }
         else
         {
-          dateTo = variantTo.toDateTime().toString( isoFormat );
+          dateTo = maximumDateTime;
         }
       }
       else
       {
-        dateTo = maximumDateTime;
+        // date-only fields store values as YYYY-MM-DD strings — no time component
+        const QString dateFormat = QStringLiteral( "yyyy-MM-dd" );
+
+        dateFrom = variantFrom.isValid() ? variantFrom.toDateTime().toString( dateFormat ) : QStringLiteral( "0001-01-01" );
+        dateTo = variantTo.isValid() ? variantTo.toDateTime().toString( dateFormat ) : QStringLiteral( "9999-12-31" );
       }
 
       expressionCopy.replace( QStringLiteral( "@@value_from@@" ), dateFrom );

--- a/app/filtercontroller.h
+++ b/app/filtercontroller.h
@@ -120,7 +120,7 @@ class FilterController : public QObject
     /**
      * Returns whether the date filter is datetime or just date field. Used to show date or date & time UI for users.
      */
-    Q_INVOKABLE bool isDateFilterDateTime( const QString &filterId );
+    Q_INVOKABLE bool isDateFilterDateTime( const QString &filterId ) const;
 
     bool hasFiltersAvailable() const;
 


### PR DESCRIPTION
Fixed the date time filtering by:
- checking whether the filter input is DateTime or just normal date. Before we would convert date only inputs to dateTime and in some cases the filtering would fail, e.g., a lower-bound filter with today's date and 00:00:00 would exclude today's records if the field is date only. Now, the date only will not have any time component and dateTime behaves as before.
- convert local time to UTC