### PR TITLE
Fixed filters activated status for map floating button

### DIFF
--- a/app/filtercontroller.cpp
+++ b/app/filtercontroller.cpp
@@ -28,6 +28,20 @@ FilterController::FilterController( QObject *parent )
 {
 }
 
+void FilterController::updateFiltersActivated()
+{
+  bool anyActivated = false;
+  for ( const FieldFilter &filter : std::as_const( mFieldFilters ) )
+  {
+    if ( filter.value.isValid() && !filter.value.isNull() )
+    {
+      anyActivated = true;
+      break;
+    }
+  }
+  setFiltersActivated( anyActivated );
+}
+
 void FilterController::clearLayerFilters( const QString &layerId )
 {
   QgsMapLayer *layer = QgsProject::instance()->mapLayer( layerId );
@@ -51,6 +65,8 @@ void FilterController::clearLayerFilters( const QString &layerId )
       filter.value.clear();
     }
   }
+
+  updateFiltersActivated();
 }
 
 void FilterController::clearAllFilters()
@@ -454,17 +470,7 @@ void FilterController::processFilters( const QVariantMap &newFilters )
   }
 
   applyFiltersToAllLayers();
-
-  bool anyActivated = false;
-  for ( const QVariant &value : std::as_const( newFilters ) )
-  {
-    if ( value.isValid() && !value.isNull() )
-    {
-      anyActivated = true;
-      break;
-    }
-  }
-  setFiltersActivated( anyActivated );
+  updateFiltersActivated();
 }
 
 bool FilterController::hasActiveFilterOnLayer( const QString &layerId )

--- a/app/filtercontroller.h
+++ b/app/filtercontroller.h
@@ -143,6 +143,8 @@ class FilterController : public QObject
     void loadFilterConfig( const QgsProject *project );
 
   private:
+    void updateFiltersActivated(); // updates filtersActivated based on current mFieldFilters
+
     /**
      * @brief Applies filters to all vector layers in the current project
      */


### PR DESCRIPTION
Bug scenario:
- have filters from only one layer applied to the whole project
- reset/ clear the filters for only that layer via the filter banner Reset button

Actual result: the filters are cleared but the map floating button is still showing active filters, even though no filters are active

Expected result: when clearing a layer's filters and these are the only filters project wise, the map floating button should disappear and the status of the active filters be updated

Fix:
- created a function to check updates on the field filters member variable based on existing code
- Called this function at the end of clearLayersFilters to properly update the status and thus the floating button visibility