### PR TITLE
Fixed delete button

### DIFF
--- a/app/qml/form/editors/MMFormPhotoEditor.qml
+++ b/app/qml/form/editors/MMFormPhotoEditor.qml
@@ -133,8 +133,8 @@ MMFormPhotoViewer {
     onDeleteImage: {
       // schedule the image for deletion
       internal.imageSourceToDelete = imageDeleteDialog.imagePath
-      root.sketchingController.removeBackupSketches()
-      root.sketchingController.clear()
+      root.sketchingController?.removeBackupSketches()
+      root.sketchingController?.clear()
       resetValueAndClose()
     }
 


### PR DESCRIPTION
Added check if the sketching controller is available or not, which fixes:

- the broken delete button when photo sketching is not selected
- reappearing sketches when deleting a photo with sketches and re-adding it in the project.

UI changes:

https://github.com/user-attachments/assets/3b4772aa-a900-49e5-a2b7-21317ec761e1
https://github.com/user-attachments/assets/28724eb1-1c9f-4498-bcd1-f333ad2adac7

