### PR TITLE
Allow adding geometry parts in Record mode

### DIFF
--- a/app/qml/map/MMMapController.qml
+++ b/app/qml/map/MMMapController.qml
@@ -1152,6 +1152,7 @@ Item {
       activeFeature: root.state === "edit" ? internal.featurePairToEdit.feature : __inputUtils.emptyFeature()
 
       onCanceled: {
+        internal.featurePairToEdit = null
         root.hideInfoTextMessage()
 
         if ( root.state === "record" )
@@ -1171,6 +1172,7 @@ Item {
       }
 
       onDone: function( featureLayerPair ) {
+        internal.featurePairToEdit = null
         root.hideInfoTextMessage()
 
         if ( root.state === "record" )
@@ -1226,6 +1228,7 @@ Item {
       featureToSplit: internal.featurePairToEdit
 
       onDone: function (success) {
+        internal.featurePairToEdit = null
         // close all feature forms, show banner if it went fine or not
         root.hideInfoTextMessage()
 
@@ -1245,6 +1248,7 @@ Item {
       }
 
       onCanceled: {
+        internal.featurePairToEdit = null
         // go back to feature form
         root.hideInfoTextMessage()
 
@@ -1311,7 +1315,6 @@ Item {
   }
 
   function record() {
-    internal.featurePairToEdit = null
     state = "record"
   }
 

--- a/app/qml/map/MMMapController.qml
+++ b/app/qml/map/MMMapController.qml
@@ -1285,7 +1285,7 @@ Item {
 
     // visibility of buttons in "more" menu
     property bool splitGeometryButtonVisible: !internal.isPointLayer && !root.isStreaming && root.state === "edit"
-    property bool addPartButtonVisible: internal.isMultiPartLayer && !root.isStreaming && root.state === "edit"
+    property bool addPartButtonVisible: internal.isMultiPartLayer && !root.isStreaming && isInRecordState
     property bool redrawGeometryButtonVisible: root.state === "edit"
     property bool streamingModeButtonVisible: !internal.isPointLayer || internal.isMultiPartLayer
 
@@ -1311,6 +1311,7 @@ Item {
   }
 
   function record() {
+    internal.featurePairToEdit = null
     state = "record"
   }
 
@@ -1352,10 +1353,13 @@ Item {
   }
 
   function addPart( featurepair) {
-    __activeProject.setActiveLayer( featurepair.layer )
+    if ( featurepair )
+    {
+      __activeProject.setActiveLayer( featurepair.layer )
+      internal.featurePairToEdit = featurepair
+    }
     root.showInfoTextMessage( qsTr( "Add new part to the geometry" ) )
 
-    internal.featurePairToEdit = featurepair
 
     // You should be already in state == "edit"
     if ( recordingToolsLoader.active ) {


### PR DESCRIPTION
Follow up #4496 , _Add part_ button is now available and functional in `Record` mode too, in addition to `Edit` mode.