### PR TITLE
Prevent propagating focus to readonly form editors - fix iOS crashing

### DIFF
--- a/app/qml/components/private/MMBaseSingleLineInput.qml
+++ b/app/qml/components/private/MMBaseSingleLineInput.qml
@@ -145,6 +145,7 @@ MMBaseInput {
         implicitWidth: width
 
         readOnly: root.editState === "readOnly" || root.editState === "disabled"
+        activeFocusOnPress: !readOnly // Important due to crashes on iOS, see https://github.com/MerginMaps/mobile/pull/4561
 
         // Ensure the text is scrolled to the beginning
         Component.onCompleted: ensureVisible( 0 )


### PR DESCRIPTION
Fixes the crash mentioned here https://github.com/MerginMaps/releases/issues/147#issuecomment-4779566892 (problem num. 2)

This seems to be a Qt bug and will be reported. 

Looks like a dangling pointer when combining `QIOSTapRecognizer` and drawers. The fix is to not accept focus for `readonly` form items (which is a correct step regardless the crash). 

As a side effect, this https://github.com/MerginMaps/mobile/issues/4522 now results in even worse UX, so I will fix it in a standalone PR and we add it to the release.