### PR TITLE
Set previous focus target to editor that opens drawer

### DIFF
--- a/app/qml/filters/components/MMFilterDateInput.qml
+++ b/app/qml/filters/components/MMFilterDateInput.qml
@@ -58,7 +58,11 @@ Column {
           return Qt.formatDate( root.currentValue[0] )
         }
 
-        onTextClicked: fromCalendarLoader.active = true
+        onTextClicked: {
+          root.forceActiveFocus()
+          fromCalendarLoader.active = true
+        }
+        
         onRightContentClicked: {
           if (checked) {
             textField.clear()
@@ -149,7 +153,11 @@ Column {
           return Qt.formatDate( root.currentValue[1] )
         }
 
-        onTextClicked: toCalendarLoader.active = true
+        onTextClicked: {
+          root.forceActiveFocus()
+          toCalendarLoader.active = true
+        }
+
         onRightContentClicked: {
           if (checked) {
             textField.clear()

--- a/app/qml/filters/components/MMFilterDropdownUniqueValuesInput.qml
+++ b/app/qml/filters/components/MMFilterDropdownUniqueValuesInput.qml
@@ -124,6 +124,7 @@ Column {
   }
 
   function openDrawer() {
+    forceActiveFocus()
     dropdownDrawerLoader.active = true
     dropdownDrawerLoader.focus = true
   }

--- a/app/qml/filters/components/MMFilterDropdownValueMapInput.qml
+++ b/app/qml/filters/components/MMFilterDropdownValueMapInput.qml
@@ -112,6 +112,7 @@ Column {
   }
 
   function openDrawer() {
+    forceActiveFocus()
     dropdownDrawerLoader.active = true
     dropdownDrawerLoader.focus = true
   }

--- a/app/qml/filters/components/MMFilterDropdownValueRelationInput.qml
+++ b/app/qml/filters/components/MMFilterDropdownValueRelationInput.qml
@@ -138,6 +138,7 @@ Column {
   }
 
   function openDrawer() {
+    forceActiveFocus()
     dropdownDrawerLoader.active = true
     dropdownDrawerLoader.focus = true
   }

--- a/app/qml/form/editors/MMFormCalendarEditor.qml
+++ b/app/qml/form/editors/MMFormCalendarEditor.qml
@@ -112,6 +112,8 @@ MMPrivateComponents.MMBaseSingleLineInput {
   }
 
   function openCalendar() {
+    forceActiveFocus()
+
     if (root._fieldValueIsNull || _fieldHasMixedValues) {
       root.openPicker( new Date() )
     }

--- a/app/qml/form/editors/MMFormComboboxBaseEditor.qml
+++ b/app/qml/form/editors/MMFormComboboxBaseEditor.qml
@@ -47,6 +47,8 @@ MMPrivateComponents.MMBaseSingleLineInput {
   }
 
   function openDrawer() {
+    forceActiveFocus()
+    
     drawerLoader.active = true
     drawerLoader.focus = true
   }

--- a/app/qml/form/editors/MMFormGalleryEditor.qml
+++ b/app/qml/form/editors/MMFormGalleryEditor.qml
@@ -70,6 +70,7 @@ MMPrivateComponents.MMBaseInput {
       text: model.FeatureTitle
 
       onClicked: function( path ) {
+        root.forceActiveFocus()
         root.openLinkedFeature( model.FeaturePair )
       }
     }
@@ -98,7 +99,10 @@ MMPrivateComponents.MMBaseInput {
 
         MMComponents.MMSingleClickMouseArea {
           anchors.fill: parent
-          onSingleClicked: root.createLinkedFeature( root._fieldController.featureLayerPair, root._fieldAssociatedRelation )
+          onSingleClicked: {
+            root.forceActiveFocus()
+            root.createLinkedFeature( root._fieldController.featureLayerPair, root._fieldAssociatedRelation )
+          }
         }
       }
 

--- a/app/qml/form/editors/MMFormPhotoEditor.qml
+++ b/app/qml/form/editors/MMFormPhotoEditor.qml
@@ -287,6 +287,7 @@ MMFormPhotoViewer {
      * Called when clicked on the camera icon to capture an image.
      */
     function capturePhoto() {
+      forceActiveFocus()
       updateTargetDir()
       if ( !__inputUtils.createDirectory( targetDir ) )
       {
@@ -317,6 +318,7 @@ MMFormPhotoViewer {
      * Then "imageSelected" caught the signal, handles changes and sends signal "valueChanged".
      */
     function chooseFromGallery() {
+      forceActiveFocus()
       updateTargetDir()
       if ( __androidUtils.isAndroid ) {
         __androidUtils.callImagePicker( targetDir, root._fieldIndex )
@@ -336,6 +338,7 @@ MMFormPhotoViewer {
      * \param imagePath Absolute path to an image.
      */
     function removeImage( path ) {
+      forceActiveFocus()
       if ( __inputUtils.fileExists( path ) ) {
         imageDeleteDialog.imagePath = path
         imageDeleteDialog.open()

--- a/app/qml/form/editors/MMFormPhotoViewer.qml
+++ b/app/qml/form/editors/MMFormPhotoViewer.qml
@@ -128,6 +128,7 @@ MMPrivateComponents.MMBaseInput {
         visible: root.editState === "enabled" && photoStateGroup.state !== "notSet" && __activeProject.photoSketchingEnabled && root.photoUrl.startsWith("file:///")
 
         onClicked: {
+          root.forceActiveFocus()
           sketchingLoader.active = true
           sketchingLoader.focus = true
         }

--- a/app/qml/form/editors/MMFormRelationEditor.qml
+++ b/app/qml/form/editors/MMFormRelationEditor.qml
@@ -57,6 +57,7 @@ MMPrivateComponents.MMBaseInput {
     MouseArea {
       anchors.fill: parent
       onClicked: function( mouse ) {
+        root.forceActiveFocus()
         mouse.accepted = true
         listLoader.active = true
         listLoader.focus = true
@@ -146,7 +147,10 @@ MMPrivateComponents.MMBaseInput {
 
           MMComponents.MMSingleClickMouseArea {
             anchors.fill: parent
-            onSingleClicked: root.openLinkedFeature( model.FeaturePair )
+            onSingleClicked: {
+              root.forceActiveFocus()
+              root.openLinkedFeature( model.FeaturePair )
+            }
           }
 
           onVisibleChanged: root.recalculateVisibleItems()

--- a/app/qml/form/editors/MMFormRelationReferenceEditor.qml
+++ b/app/qml/form/editors/MMFormRelationReferenceEditor.qml
@@ -73,6 +73,7 @@ MMPrivateComponents.MMBaseSingleLineInput {
   }
 
   onRightContentClicked: {
+    forceActiveFocus()
     listLoader.active = true
     listLoader.focus = true
   }

--- a/app/qml/form/editors/MMFormScannerEditor.qml
+++ b/app/qml/form/editors/MMFormScannerEditor.qml
@@ -77,6 +77,7 @@ MMPrivateComponents.MMBaseSingleLineInput  {
     if (!__inputUtils.acquireCameraPermission())
       return
 
+    forceActiveFocus()
     codeScannerLoader.active = true
     codeScannerLoader.focus = true
   }


### PR DESCRIPTION
Qt's `Popup` (and its subclasses `Drawer`, `Dialog`) saves `Window.activeFocusItem` when `open()` is called and restores it when the popup closes. In forms with a text editor above a dropdown or date field, the editor often held active focus at the moment the drawer opened - so on close, focus was returned to it, raising the on-screen keyboard and pushing content out of view.

**Fix:** call `forceActiveFocus()` on the editor component immediately before activating the Loader. This moves active focus to the component that logically "owns" the interaction, so the Popup saves it as the restore target. On close, focus returns to that component - not to a text editor further up the form.

Applied to:
- Form editors: dropdowns, calendar, relation, relation reference, scanner, photo viewer
- Filter inputs: dropdowns, calendar

Fixes https://github.com/MerginMaps/mobile/issues/4522