### PR TITLE
Fix white map sketching bugs

### DIFF
--- a/app/mapsketchingcontroller.cpp
+++ b/app/mapsketchingcontroller.cpp
@@ -147,7 +147,13 @@ QgsGeometry MapSketchingController::highlightGeometry() const
 QStringList MapSketchingController::availableColors() const
 {
   const QStringList defaultColors = { "#FFFFFF", "#12181F", "#5E9EE4", "#57B46F", "#FDCB2A", "#FF9C40", "#FF8F93" };
-  return mMapSettings->project()->readListEntry( QStringLiteral( "Mergin" ), QStringLiteral( "MapSketching/Colors" ), defaultColors );
+
+if ( mMapSettings && mMapSettings->project() )
+    {
+        return mMapSettings->project()->readListEntry( QStringLiteral( "Mergin" ), QStringLiteral( "MapSketching/Colors" ), defaultColors );
+    }
+
+    return defaultColors;
 }
 
 void MapSketchingController::clearHighlight()
@@ -187,6 +193,8 @@ void MapSketchingController::setMapSettings( InputMapSettings *settings )
 
   mMapSettings = settings;
   emit mapSettingsChanged();
+
+  setActiveColor( availableColors().first() );
 }
 
 InputMapSettings *MapSketchingController::mapSettings() const

--- a/app/mapsketchingcontroller.cpp
+++ b/app/mapsketchingcontroller.cpp
@@ -148,12 +148,12 @@ QStringList MapSketchingController::availableColors() const
 {
   const QStringList defaultColors = { "#FFFFFF", "#12181F", "#5E9EE4", "#57B46F", "#FDCB2A", "#FF9C40", "#FF8F93" };
 
-if ( mMapSettings && mMapSettings->project() )
-    {
-        return mMapSettings->project()->readListEntry( QStringLiteral( "Mergin" ), QStringLiteral( "MapSketching/Colors" ), defaultColors );
-    }
+  if ( mMapSettings && mMapSettings->project() )
+  {
+    return mMapSettings->project()->readListEntry( QStringLiteral( "Mergin" ), QStringLiteral( "MapSketching/Colors" ), defaultColors );
+  }
 
-    return defaultColors;
+  return defaultColors;
 }
 
 void MapSketchingController::clearHighlight()

--- a/app/qml/components/MMColorButton.qml
+++ b/app/qml/components/MMColorButton.qml
@@ -20,8 +20,6 @@ RoundButton {
   implicitWidth: __style.margin48
   implicitHeight: __style.margin48
 
-  anchors.verticalCenter: parent.verticalCenter
-
   contentItem: Rectangle {
     color: root.buttonColor
     radius: width / 2

--- a/app/qml/components/MMColorPicker.qml
+++ b/app/qml/components/MMColorPicker.qml
@@ -18,6 +18,8 @@ ScrollView {
 
   property color activeColor
 
+  signal activeColorChangeRequested( color newColor )
+
   height: scrollRow.height
   ScrollBar.vertical.policy: ScrollBar.AlwaysOff
   ScrollBar.horizontal.policy: ScrollBar.AlwaysOff
@@ -29,6 +31,7 @@ ScrollView {
 
     Repeater {
       model: root.colors
+
       MMColorButton{
         required property color modelData
         required property int index
@@ -36,16 +39,7 @@ ScrollView {
         buttonColor: modelData
         isSelected: root.activeColor === modelData
                 
-        onClicked: {
-          root.activeColor = modelData;
-        }
-        Component.onCompleted: {
-        // set the initial color to be the first one in the list
-          if ( index === 0 )
-          {
-            root.activeColor = modelData
-          }    
-        }  
+        onClicked: root.activeColorChangeRequested( modelData )
       } 
     }
   }

--- a/app/qml/map/MMMapSketchesDrawer.qml
+++ b/app/qml/map/MMMapSketchesDrawer.qml
@@ -79,15 +79,17 @@ MMComponents.MMDrawer {
       
       MMComponents.MMColorPicker {
         id: colorPicker
-        colors: root.sketchingController?.availableColors() ?? __style.photoSketchingWhiteColor
+
+        colors: root.sketchingController?.availableColors() ?? null
+        activeColor: root.sketchingController?.activeColor ?? null
 
         Layout.alignment: Qt.AlignHCenter
         Layout.maximumWidth: parent.width
 
-        onActiveColorChanged: {
+        onActiveColorChangeRequested: {
           if ( root.sketchingController )
           {
-            root.sketchingController.activeColor = colorPicker.activeColor
+            root.sketchingController.activeColor = newColor
             root.sketchingController.eraserActive = false
           }
         }

--- a/app/qml/map/MMMapSketchesDrawer.qml
+++ b/app/qml/map/MMMapSketchesDrawer.qml
@@ -80,8 +80,8 @@ MMComponents.MMDrawer {
       MMComponents.MMColorPicker {
         id: colorPicker
 
-        colors: root.sketchingController?.availableColors() ?? null
-        activeColor: root.sketchingController?.activeColor ?? null
+        colors: root.sketchingController?.availableColors()
+        activeColor: root.sketchingController?.activeColor
 
         Layout.alignment: Qt.AlignHCenter
         Layout.maximumWidth: parent.width


### PR DESCRIPTION
### Description

This PR fixes several issues in map sketches related to color selection and eraser state:
1. When opening map sketches and drawing with the preselected white color, the saved sketch would turn black instead of white.
2. The selection highlight for the white color was displayed as black.
3. When the eraser was selected, the previously selected color still appeared selected in the UI. This made it look like clicking the eraser again would deselect it and return to the previously selected color.

https://github.com/user-attachments/assets/49393d54-462d-4df2-9347-000b1f443b6a

### Changes

- Added explicit handling of the active sketch color.
- The active color is now initialized from the first available sketch color when map settings are set.
- The color picker now emits a color change request instead of changing internal state directly.
- The sketch drawer now updates the sketching controller with the selected color and disables the eraser when a color is selected.
- null is now used as fallback when the sketching controller or active color is not available.
- Removed a few redundant QML blocks, including anchors that had no effect.

### Final look

https://github.com/user-attachments/assets/6a5b257e-69bd-4019-a98f-ae369be1f45f

