### PR TITLE
Feature/multiline description support

### DIFF
--- a/app/qml/components/MMListDelegate.qml
+++ b/app/qml/components/MMListDelegate.qml
@@ -87,6 +87,10 @@ Item {
           textFormat: Text.PlainText
 
           color: __style.nightColor
+
+          elide: Text.ElideRight
+          wrapMode: Text.Wrap
+          maximumLineCount: 3
         }
 
         MMText {
@@ -98,6 +102,10 @@ Item {
           text: root.secondaryText
 
           color: __style.nightColor
+
+          elide: Text.ElideRight
+          wrapMode: Text.Wrap
+          maximumLineCount: 3
         }
       }
 

--- a/app/qml/gps/MMSelectionDrawer.qml
+++ b/app/qml/gps/MMSelectionDrawer.qml
@@ -76,6 +76,7 @@ MMComponents.MMDrawer {
           color: __style.nightColor
 
           elide: Text.ElideRight
+          wrapMode: Text.NoWrap
         }
 
         MMComponents.MMText {
@@ -85,6 +86,7 @@ MMComponents.MMDrawer {
           color: __style.nightColor
 
           elide: Text.ElideRight
+          wrapMode: Text.NoWrap
         }
       }
     }

--- a/app/qml/gps/MMSelectionDrawer.qml
+++ b/app/qml/gps/MMSelectionDrawer.qml
@@ -76,7 +76,6 @@ MMComponents.MMDrawer {
           color: __style.nightColor
 
           elide: Text.ElideRight
-          wrapMode: Text.NoWrap
         }
 
         MMComponents.MMText {
@@ -86,7 +85,6 @@ MMComponents.MMDrawer {
           color: __style.nightColor
 
           elide: Text.ElideRight
-          wrapMode: Text.NoWrap
         }
       }
     }


### PR DESCRIPTION
### Description
Long description values in value map or value relation fields were truncated in the selection dialog, with no way to add line breaks. This forced users to shorten their descriptions to avoid cut-off text.

**Ticket:** https://github.com/MerginMaps/mobile/issues/4502

<img width="255" alt="IMG_4764" src="https://github.com/user-attachments/assets/2940d449-b2a9-4d11-a982-90c12286b2ba" />
<img width="255" alt="IMG_4763" src="https://github.com/user-attachments/assets/af6e07b4-efad-4b65-93bf-f720a20a424e" />
<img width="255" alt="IMG_4762" src="https://github.com/user-attachments/assets/db05ae8e-0852-405c-b68d-2dd83f6f5d93" />


### What changed
In `app/qml/components/MMListDelegate.qml`, both the primary and secondary `Text` elements now support multi-line wrapping instead of single-line truncation.
`Text.Wrap` was selected as it seemed the most appropriate of the three wrap methods, since users may use `snake_case` or similar naming conventions in their descriptions.

<img width="255" alt="Screenshot_20260712-194517" src="https://github.com/user-attachments/assets/60c5b4a7-e2ba-48d8-9458-f2c8d125a809" />
<img width="255" alt="Screenshot_20260712-194508" src="https://github.com/user-attachments/assets/d2e5e74f-ea7d-4153-9159-272bc57efc22" />
<img width="255" alt="Screenshot_20260712-194458" src="https://github.com/user-attachments/assets/caa7da4a-a331-4161-8a94-d8d95c288f7a" />




### Expected behaviour
Descriptions now support line breaks/wrapping so multi-line text displays properly
List item height expands to accommodate up to 3 lines of text without truncation
Only descriptions exceeding 3 lines get truncated with an ellipsis (...), instead of the previous 1-line limit
