### PR TITLE
Fix missing/white photo in forms on some android 9 devices

### DIFF
--- a/app/qml/components/MMPhoto.qml
+++ b/app/qml/components/MMPhoto.qml
@@ -37,7 +37,26 @@ Image {
     height: root.height
     radius: 20 * __dp
     visible: false
-    layer.enabled: true 
+    layer.enabled: true
+  }
+
+  // On Android, backgrounding/resuming the app (e.g. while picking a photo) can tear down and
+  // recreate the EGL surface. If this item's layer renders while that surface is still settling,
+  // the resulting texture can be corrupted (seen as a blank/white photo on some Android 9 devices),
+  // and nothing else triggers a re-render afterwards. Force the layer to regenerate once the app
+  // is confirmed active again.
+  Connections {
+    target: Qt.application
+    function onStateChanged() {
+      if ( Qt.application.state === Qt.ApplicationActive ) {
+        root.layer.enabled = false
+        maskRect.layer.enabled = false
+        Qt.callLater( function() {
+          root.layer.enabled = true
+          maskRect.layer.enabled = true
+        } )
+      }
+    }
   }
 
   Rectangle {


### PR DESCRIPTION
fixes [this issue found in regression testing](https://github.com/MerginMaps/releases/issues/147#issuecomment-4779566892)

**Bug description by claude**
Root cause: not a masking/shader bug — the mask/MultiEffect shader
  itself renders correctly. The actual trigger is Android tearing
  down and recreating the EGL surface across an app pause/resume (makeCurrent(): no EGLSurface,
  DequeueBuffer: dequeueBuffer failed, eglSwapBuffers failed: 300d = EGL_BAD_SURFACE). The
  photo's source gets (re)assigned right in that unstable window — before Qt::ApplicationActive
  is even reported — so the layer's first real render for that photo lands on a dead surface and
  produces a corrupted/blank (white) texture that nothing subsequently invalidates.

  I checked upstream: QTBUG-118231 (hello Trimble :) )covers this exact symptom family (matches your log lines
  closely) but was fixed in 6.8+, and you're on 6.10.3 — so the general surface-recreation fix is
  already in your Qt build. What's left is the residual case Qt's fix doesn't cover: a layered
  item's texture specifically going stale/corrupt for that one bad frame, with nothing telling it
  to redraw afterward. I didn't find that specific case already filed.

  Fix watches Qt.application.stateChanged, and
  once the app reports ApplicationActive again, disables and re-enables both layers (root and
  maskRect) via Qt.callLater to force the scene graph to regenerate their offscreen textures
  against the now-stable surface.