### PR TITLE
Bugfix/hide private layers from dropdown

### DIFF
--- a/app/activeproject.cpp
+++ b/app/activeproject.cpp
@@ -608,14 +608,11 @@ bool ActiveProject::recordingAllowed( QgsMapLayer *layer ) const
   if ( layer->readOnly() )
     return false;
 
-  if ( layer )
-  {
-    bool isPrivate = layer->flags() & QgsMapLayer::LayerFlag::Private;
+  bool isPrivate = layer->flags().testFlag( QgsMapLayer::LayerFlag::Private );
 
-    if ( isPrivate )
-    {
-      return false;
-    }
+  if ( isPrivate )
+  {
+    return false;
   }
 
   return QgsMapLayerProxyModel::layerMatchesFilters( layer, Qgis::LayerFilter::HasGeometry | Qgis::LayerFilter::WritableLayer ) && layer->id() != positionTrackingLayerId() && layer->id() != mapSketchesLayerId();

--- a/app/activeproject.cpp
+++ b/app/activeproject.cpp
@@ -608,6 +608,16 @@ bool ActiveProject::recordingAllowed( QgsMapLayer *layer ) const
   if ( layer->readOnly() )
     return false;
 
+  if ( layer )
+  {
+    bool isPrivate = layer->flags() & QgsMapLayer::LayerFlag::Private;
+
+    if ( isPrivate )
+    {
+      return false;
+    }
+  }
+
   return QgsMapLayerProxyModel::layerMatchesFilters( layer, Qgis::LayerFilter::HasGeometry | Qgis::LayerFilter::WritableLayer ) && layer->id() != positionTrackingLayerId() && layer->id() != mapSketchesLayerId();
 }
 

--- a/app/recordinglayersproxymodel.cpp
+++ b/app/recordinglayersproxymodel.cpp
@@ -33,7 +33,7 @@ bool RecordingLayersProxyModel::filterAcceptsRow( int source_row, const QModelIn
 
   if ( layer )
   {
-    bool isPrivate = layer->flags() & QgsMapLayer::LayerFlag::Private;
+    bool isPrivate = layer->flags().testFlag( QgsMapLayer::LayerFlag::Private );
 
     if ( isPrivate )
     {

--- a/app/recordinglayersproxymodel.cpp
+++ b/app/recordinglayersproxymodel.cpp
@@ -32,14 +32,14 @@ bool RecordingLayersProxyModel::filterAcceptsRow( int source_row, const QModelIn
   QgsMapLayer *layer = mModel->layerFromIndex( index );
 
   if ( layer )
-    {
-      bool isPrivate = layer->flags() & QgsMapLayer::LayerFlag::Private;
+  {
+    bool isPrivate = layer->flags() & QgsMapLayer::LayerFlag::Private;
 
-      if ( isPrivate )
-      {
-        return false;
-      }
+    if ( isPrivate )
+    {
+      return false;
     }
+  }
 
   return mModel->data( index, LayersModel::LayerVisible ).toBool();
 }

--- a/app/recordinglayersproxymodel.cpp
+++ b/app/recordinglayersproxymodel.cpp
@@ -31,6 +31,16 @@ bool RecordingLayersProxyModel::filterAcceptsRow( int source_row, const QModelIn
   QModelIndex index = mModel->index( source_row, 0, source_parent );
   QgsMapLayer *layer = mModel->layerFromIndex( index );
 
+  if ( layer )
+    {
+      bool isPrivate = layer->flags() & QgsMapLayer::LayerFlag::Private;
+
+      if ( isPrivate )
+      {
+        return false;
+      }
+    }
+
   return mModel->data( index, LayersModel::LayerVisible ).toBool();
 }
 


### PR DESCRIPTION
### Description
Layers set to private in QGIS were still visible in the add feature layer dropdown, which was inconsistent with the Layers tab, where private layers are correctly hidden.

Fixes: https://github.com/MerginMaps/mobile/issues/4486

### Problem
Users could still record new features on layers marked as private. This caused issues for admins who wanted to restrict users to adding features only as children of parent features, since the private-layer restriction was effectively bypassed in the recording flow.

### What changed
1. Added a check in `recordinglayersproxymodel` - `bool isPrivate = layer->flags() & QgsMapLayer::LayerFlag::Private` - for each layer. The app now checks whether a layer is private and excludes it from the dropdown if so.
2. Added the same guard to `activeproject`'s `recordingAllowed`. Even though the dropdown itself was filtering correctly, the app still fetched all layers on init - meaning a private layer could still be auto-selected as the active layer if it was the only layer present, or if it happened to be first in the layer list.

### Behaviour
On startup, the app now filters out private layers when iterating through available layers. When the add button is tapped, private layers no longer appear in the dropdown, matching the behavior of the Layers tab. If no eligible layers remain after filtering, the app shows the existing "No editable layers found" message.

<img width="350" src="https://github.com/user-attachments/assets/0c0c954e-3495-4042-9085-19b9886cb2a2" />