### PR TITLE
Fix missaligned snapping crosshair due to broken property binding

### DIFF
--- a/app/mmtypeutils.h
+++ b/app/mmtypeutils.h
@@ -24,4 +24,11 @@ struct ForeignGeometry
   QML_VALUE_TYPE( qgsGeometry );
 };
 
+struct ForeignPoint
+{
+  Q_GADGET
+  QML_FOREIGN( QgsPoint )
+  QML_VALUE_TYPE( qgsPoint );
+};
+
 #endif //MMTYPEUTILS_H

--- a/app/qml/map/components/MMCrosshair.qml
+++ b/app/qml/map/components/MMCrosshair.qml
@@ -15,13 +15,13 @@ import MMInput
 Item {
     id: root
 
-    /*required*/ property var qgsProject
-    /*required*/ property var mapSettings
+    required property var qgsProject
+    required property var mapSettings
     property bool shouldUseSnapping: false
 
     property point center: Qt.point( root.width / 2, root.height / 2 )
 
-    property var recordPoint : snapUtils.recordPoint
+    property qgsPoint recordPoint : snapUtils.recordPoint
     property point screenPoint : snapUtils.snapped ? snapUtils.snapPoint : root.center
 
     property real outerSize: 60 * __dp

--- a/app/qml/map/components/MMCrosshair.qml
+++ b/app/qml/map/components/MMCrosshair.qml
@@ -10,7 +10,7 @@
 import QtQuick
 import QtQuick.Controls.impl
 
-import mm 1.0 as MM
+import MMInput
 
 Item {
     id: root
@@ -30,7 +30,7 @@ Item {
     property alias crosshairForeground: crosshairForeground
     property alias snapUtils: snapUtils
 
-    MM.SnapUtils {
+    SnapUtils {
       id: snapUtils
 
       centerPosition: root.center
@@ -164,7 +164,7 @@ Item {
         }
       }
 
-      opacity: snapUtils.snapped && ( snapUtils.snapType === MM.SnapUtils.Vertex || snapUtils.snapType === MM.SnapUtils.Other ) ? 100 : 0
+      opacity: snapUtils.snapped && ( snapUtils.snapType === SnapUtils.Vertex || snapUtils.snapType === SnapUtils.Other ) ? 100 : 0
 
       Behavior on opacity {
         PropertyAnimation {
@@ -174,7 +174,7 @@ Item {
         }
       }
 
-      rotation: snapUtils.snapType === MM.SnapUtils.Other ? 0 : 45
+      rotation: snapUtils.snapType === SnapUtils.Other ? 0 : 45
 
       Behavior on rotation {
         PropertyAnimation {
@@ -215,7 +215,7 @@ Item {
         }
       }
 
-      opacity: snapUtils.snapped && snapUtils.snapType === MM.SnapUtils.Segment ? 100 : 0
+      opacity: snapUtils.snapped && snapUtils.snapType === SnapUtils.Segment ? 100 : 0
 
       Behavior on opacity {
         PropertyAnimation {

--- a/app/qml/map/components/MMCrosshair.qml
+++ b/app/qml/map/components/MMCrosshair.qml
@@ -21,8 +21,8 @@ Item {
 
     property point center: Qt.point( root.width / 2, root.height / 2 )
 
-    property var recordPoint
-    property point screenPoint
+    property var recordPoint : snapUtils.recordPoint
+    property point screenPoint : snapUtils.snapped ? snapUtils.snapPoint : root.center
 
     property real outerSize: 60 * __dp
     property real innerDotSize: 10 * __dp
@@ -38,14 +38,6 @@ Item {
       qgsProject: root.qgsProject
       useSnapping: root.shouldUseSnapping
       destinationLayer: __activeLayer.vectorLayer
-
-      // We are using assignment instead of property binding here on purpose. Qt 6.10+ doesn't trigger property binding
-      // if tha value hasn't changed. However, if snapping is enabled recordPoint might be the same, but the screenPoint
-      // will be different, thus we need to trigger the recalculation.
-      onRecordPointChanged: {
-        root.recordPoint = snapUtils.recordPoint
-        root.screenPoint = snapUtils.snapped && __activeLayer.vectorLayer ? __inputUtils.transformPointToScreenCoordinates(__activeLayer.vectorLayer.crs, root.mapSettings, snapUtils.recordPoint) : root.center
-      }
     }
 
     Image {

--- a/app/qml/map/components/MMCrosshair.qml
+++ b/app/qml/map/components/MMCrosshair.qml
@@ -21,9 +21,8 @@ Item {
 
     property point center: Qt.point( root.width / 2, root.height / 2 )
 
-    property var recordPoint: snapUtils.recordPoint
-
-    property point screenPoint: snapUtils.snapped && __activeLayer.vectorLayer ? __inputUtils.transformPointToScreenCoordinates(__activeLayer.vectorLayer.crs, mapSettings, recordPoint) : center
+    property var recordPoint
+    property point screenPoint
 
     property real outerSize: 60 * __dp
     property real innerDotSize: 10 * __dp
@@ -40,6 +39,13 @@ Item {
       useSnapping: root.shouldUseSnapping
       destinationLayer: __activeLayer.vectorLayer
 
+      // We are using assignment instead of property binding here on purpose. Qt 6.10+ doesn't trigger property binding
+      // if tha value hasn't changed. However, if snapping is enabled recordPoint might be the same, but the screenPoint
+      // will be different, thus we need to trigger the recalculation.
+      onRecordPointChanged: {
+        root.recordPoint = snapUtils.recordPoint
+        root.screenPoint = snapUtils.snapped && __activeLayer.vectorLayer ? __inputUtils.transformPointToScreenCoordinates(__activeLayer.vectorLayer.crs, root.mapSettings, snapUtils.recordPoint) : root.center
+      }
     }
 
     Image {

--- a/app/snaputils.cpp
+++ b/app/snaputils.cpp
@@ -220,7 +220,7 @@ void SnapUtils::setSnapped( bool newSnapped )
     return;
 
   if ( !newSnapped ) resetSnapPoint();
-  
+
   mSnapped = newSnapped;
   emit snappedChanged( mSnapped );
 }

--- a/app/snaputils.cpp
+++ b/app/snaputils.cpp
@@ -128,6 +128,7 @@ void SnapUtils::getsnap()
     }
 
     setRecordPoint( layerPoint );
+    setSnapPoint( InputUtils::transformPointToScreenCoordinates( mDestinationLayer->crs(), mMapSettings, layerPoint ) );
 
     if ( snap.hasVertex() )
     {
@@ -184,6 +185,17 @@ void SnapUtils::setCenterPosition( QPointF newCenterPosition )
   emit centerPositionChanged( mCenterPosition );
 
   initializeRecordPosition();
+}
+
+QPointF SnapUtils::snapPoint() const
+{
+  return mSnapPoint;
+}
+
+void SnapUtils::setSnapPoint( QPointF newSnapPoint )
+{
+  mSnapPoint = newSnapPoint;
+  emit snapPointChanged( mSnapPoint );
 }
 
 QgsPoint SnapUtils::recordPoint() const

--- a/app/snaputils.cpp
+++ b/app/snaputils.cpp
@@ -218,6 +218,9 @@ void SnapUtils::setSnapped( bool newSnapped )
 {
   if ( mSnapped == newSnapped )
     return;
+
+  if ( !newSnapped ) resetSnapPoint();
+  
   mSnapped = newSnapped;
   emit snappedChanged( mSnapped );
 }
@@ -309,6 +312,11 @@ void SnapUtils::initializeRecordPosition()
                            recordpoint );
 
   setRecordPoint( centerPoint );
+}
+
+void SnapUtils::resetSnapPoint()
+{
+  mSnapPoint = QPointF( -1, -1 );
 }
 
 QgsVectorLayer *SnapUtils::destinationLayer() const

--- a/app/snaputils.h
+++ b/app/snaputils.h
@@ -108,6 +108,8 @@ class SnapUtils : public QObject
     void setupSnapping();
     void initializeRecordPosition();
 
+    void resetSnapPoint();
+
     QgsSnappingUtils mSnappingUtils;
 
     QgsProject *mQgsProject = nullptr; // not owned

--- a/app/snaputils.h
+++ b/app/snaputils.h
@@ -12,6 +12,7 @@
 
 #include <QObject>
 #include <qglobal.h>
+#include <qqmlintegration.h>
 
 #include "qgspoint.h"
 #include "qgsproject.h"
@@ -23,6 +24,7 @@
 class SnapUtils : public QObject
 {
     Q_OBJECT
+    QML_ELEMENT
 
     Q_PROPERTY( QgsProject *qgsProject READ qgsProject WRITE setQgsProject NOTIFY qgsProjectChanged )
     Q_PROPERTY( InputMapSettings *mapSettings READ mapSettings WRITE setMapSettings NOTIFY mapSettingsChanged )

--- a/app/snaputils.h
+++ b/app/snaputils.h
@@ -32,7 +32,10 @@ class SnapUtils : public QObject
     Q_PROPERTY( QgsVectorLayer *destinationLayer READ destinationLayer WRITE setDestinationLayer NOTIFY destinationLayerChanged )
 
     Q_PROPERTY( bool snapped READ snapped WRITE setSnapped NOTIFY snappedChanged )
+    // point in map CRS which will be recorded
     Q_PROPERTY( QgsPoint recordPoint READ recordPoint WRITE setRecordPoint NOTIFY recordPointChanged )
+    // point in screen CRS where the crosshair should point if snapping is enabled
+    Q_PROPERTY( QPointF snapPoint READ snapPoint WRITE setSnapPoint NOTIFY snapPointChanged )
 
   public:
     SnapUtils( QObject *parent = nullptr );
@@ -57,6 +60,9 @@ class SnapUtils : public QObject
 
     QPointF centerPosition() const;
     void setCenterPosition( QPointF newCenterPosition );
+
+    QPointF snapPoint() const;
+    void setSnapPoint( QPointF newSnapPoint );
 
     QgsPoint recordPoint() const;
     void setRecordPoint( QgsPoint newRecordPoint );
@@ -84,6 +90,8 @@ class SnapUtils : public QObject
 
     void centerPositionChanged( QPointF centerPosition );
 
+    void snapPointChanged( QPointF snapPoint );
+
     void recordPointChanged( QgsPoint recordPoint );
 
     void useSnappingChanged( bool useSnapping );
@@ -105,6 +113,7 @@ class SnapUtils : public QObject
     QgsVectorLayer *mDestinationLayer = nullptr; // not owned
 
     QPointF mCenterPosition = QPointF( -1, -1 );
+    QPointF mSnapPoint = QPointF( -1, -1 );
     QgsPoint mRecordPoint = QgsPoint( -1, -1 );
 
     bool mSnapped = false;


### PR DESCRIPTION
After migrating to newer Qt version recording crosshair didn't properly snap to vertices etc. This PR fixes the issue and after the crosshair snaps to vertex, it remains "sticky" for a small distance.

## Old
https://github.com/user-attachments/assets/83b46e10-9f6a-4db0-8ac2-48899f8c5e47

## New
https://github.com/user-attachments/assets/502c9fff-af13-4452-a2f8-e4f8d1d2a3d4 

Thanks @harminius for catching this :)

