### PR TITLE
Fix disappearing bg and wrong padding on widnows for reset button

### DIFF
--- a/app/qml/components/MMButton.qml
+++ b/app/qml/components/MMButton.qml
@@ -166,8 +166,8 @@ Button {
 
   implicitWidth: {
     let margin = __style.margin20
-    if ( root.type === MMButton.Types.Tertiary ) margin = 0
-    else if ( root.size === MMButton.Sizes.ExtraSmall ) margin = __style.margin8
+    if ( root.size === MMButton.Sizes.ExtraSmall ) margin = __style.margin8
+    else if ( root.type === MMButton.Types.Tertiary ) margin = 0
     else if ( root.size === MMButton.Sizes.Small ) margin = __style.margin16
     return row.paintedChildrenWidth + 2 * margin
   }
@@ -214,9 +214,9 @@ Button {
 
       property real paintedChildrenWidth: buttonIconLeft.paintedWidth + buttonContent.implicitWidth + buttonIconRight.paintedWidth + spacing
       property real maxWidth: {
-        let margin = __style.margin20 
-        if ( root.type === MMButton.Types.Tertiary ) margin = 0
-        else if ( root.size === MMButton.Sizes.ExtraSmall ) margin = __style.margin8
+        let margin = __style.margin20
+        if ( root.size === MMButton.Sizes.ExtraSmall ) margin = __style.margin8
+        else if ( root.type === MMButton.Types.Tertiary ) margin = 0
         else if ( root.size === MMButton.Sizes.Small ) margin = __style.margin16
         return parent.width - 2 * margin
       }

--- a/app/qml/filters/components/MMFilterBanner.qml
+++ b/app/qml/filters/components/MMFilterBanner.qml
@@ -59,6 +59,8 @@ Rectangle {
       text: root.actionText
       fontColor: __style.skyColor
       bgndColor: __style.deepOceanColor
+      bgndColorHover: __style.deepOceanColor
+      fontColorHover: __style.skyColor
 
       onClicked: root.actionClicked()
     }


### PR DESCRIPTION
### Description
The filter reset button's background was disappearing on hover. This caused inconsistent behavior between platforms, since mobile devices did not exhibit this issue.

### What changed
1. Added `bgndColorHover` and `fontColorHover` to the action button, since `type: Tertiary` had its own styling that was overriding the defaults on hover. Explicitly setting these values aligns desktop behavior with mobile.
&nbsp; <img width="444" alt="image" src="https://github.com/user-attachments/assets/19b8aeea-36fc-44cf-9f42-4c41a3edbdad" />

2. Swapped the order of the `if` statements. Previously, `type: Tertiary` was checked before `size: ExtraSmall`, causing the margin to be set to `0` instead of the intended value. Since margins were handled per-platform rather than in shared code, this meant the button had correct margins on mobile but appeared as a circle instead of a pill shape on Windows.
&nbsp; <img width="444" alt="image" src="https://github.com/user-attachments/assets/9ccf2eb1-0381-4e4e-bfc9-80f5d02f4783" />

### Behaviour
The button no longer has hover-specific styling logic, so the background no longer disappears on mouse hover. Margins are also fixed, giving the action button its intended pill shape.

<img width="444" alt="image" src="https://github.com/user-attachments/assets/bfa4a6fb-9190-43d4-82a6-f1bafb87e9c4" />