### PR TITLE
Rework system & navigation bar on android 10 and lower

### DIFF
--- a/app/android/src/uk/co/lutraconsulting/MMActivity.java
+++ b/app/android/src/uk/co/lutraconsulting/MMActivity.java
@@ -34,6 +34,7 @@ import android.graphics.Color;
 
 import android.app.Activity;
 import android.content.Intent;
+import android.content.res.Configuration;
 import android.net.Uri;
 import android.content.ActivityNotFoundException;
 import java.io.File;
@@ -78,38 +79,49 @@ public class MMActivity extends QtActivity
     return getFilesDir().getAbsolutePath();
   }
 
-  void setCustomStatusAndNavBar() 
+  @Override
+  public void onConfigurationChanged(Configuration newConfig)
   {
-    if (Build.VERSION.SDK_INT < Build.VERSION_CODES.R) {
-      Log.d( TAG, "Unsupported Android version for painting behind system bars." );
-      return;
-    } 
-    else {
-      WindowCompat.setDecorFitsSystemWindows(getWindow(), false);
+    super.onConfigurationChanged(newConfig);
 
-      Window window = getWindow();
+    setCustomStatusAndNavBar();
+  }
 
-      // on Android 15+ all apps are edge-to-edge
-      if (Build.VERSION.SDK_INT < Build.VERSION_CODES.VANILLA_ICE_CREAM) {
-        // draw app edge-to-edge
-        window.addFlags(WindowManager.LayoutParams.FLAG_DRAWS_SYSTEM_BAR_BACKGROUNDS);
+  @SuppressWarnings("deprecation")
+  void setCustomStatusAndNavBar()
+  {
+    WindowCompat.setDecorFitsSystemWindows(getWindow(), false);
 
-        // make the status bar background color transparent
-        window.setStatusBarColor(Color.TRANSPARENT);
+    Window window = getWindow();
 
-        // make the navigation button background color transparent
-        window.setNavigationBarColor(Color.TRANSPARENT);
-      }
+    // on Android 15+ all apps are edge-to-edge
+    if (Build.VERSION.SDK_INT < Build.VERSION_CODES.VANILLA_ICE_CREAM) {
+      // draw app edge-to-edge
+      window.addFlags(WindowManager.LayoutParams.FLAG_DRAWS_SYSTEM_BAR_BACKGROUNDS);
 
+      // make the status bar background color transparent
+      window.setStatusBarColor(Color.TRANSPARENT);
+
+      // make the navigation button background color transparent
+      window.setNavigationBarColor(Color.TRANSPARENT);
+    }
+
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
       // do not show background dim for the navigation buttons
-      window.setNavigationBarContrastEnforced(false); 
+      window.setNavigationBarContrastEnforced(false);
+    }
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
 
       // change the status bar text color to black
       WindowInsetsController insetsController = window.getDecorView().getWindowInsetsController();
-    
-      if (insetsController != null) {
-          insetsController.setSystemBarsAppearance(WindowInsetsController.APPEARANCE_LIGHT_STATUS_BARS, WindowInsetsController.APPEARANCE_LIGHT_STATUS_BARS);
-      }
+
+        if (insetsController != null) {
+            insetsController.setSystemBarsAppearance(WindowInsetsController.APPEARANCE_LIGHT_STATUS_BARS, WindowInsetsController.APPEARANCE_LIGHT_STATUS_BARS);
+        }
+    } else {
+      // Force the navigation bar icons back to light so they stay visible against the green background.
+      View decorView = getWindow().getDecorView();
+      decorView.setSystemUiVisibility( decorView.getSystemUiVisibility() & ~View.SYSTEM_UI_FLAG_LIGHT_NAVIGATION_BAR );
     }
   }
 


### PR DESCRIPTION
fixes #4586

Instead of just having black system bar on devices with android 9 & 10. We simulate edge to edge rendering for older devices as well.

|Before | After |
| --- | --- |
|<img width="250"  src="https://github.com/user-attachments/assets/505ae378-8a9b-434c-b956-a2d26259b01f" /> | <img width="250" src="https://github.com/user-attachments/assets/405f7fb3-5c8a-448a-a698-fcb868df604d" /> |
|<img width="250" src="https://github.com/user-attachments/assets/f7a2c673-b1f0-47ce-9108-36cbb357630f" /> | <img width="250" src="https://github.com/user-attachments/assets/07fa3965-1f6f-4f89-adf9-3ba39b5b2289" />|

The navigation bar previously would hide anything behind it as well, now it's transparent.



