### PR TITLE
Fix: Update delete button pressed state color to darker rose (#4605)

### DIFF
--- a/app/qml/form/editors/MMFormPhotoViewer.qml
+++ b/app/qml/form/editors/MMFormPhotoViewer.qml
@@ -105,6 +105,7 @@ MMPrivateComponents.MMBaseInput {
         }
 
         bgndColor: __style.negativeColor
+        bgndHoverColor: Qt.darker( __style.negativeColor, 1.15 )
         iconSource: __style.deleteIcon
         iconColor: __style.grapeColor
 


### PR DESCRIPTION
Fixes #4605

**What changed:**
The delete button on the photo attachment was inheriting the default pale green `bgndHoverColor` from `MMRoundButton` on press/hover. 

This PR overrides the `bgndHoverColor` specifically for the delete button in `MMFormPhotoViewer.qml`. It now uses a 15% darker shade of the button's base `negativeColor` (`Qt.darker(__style.negativeColor, 1.15)`). 

This ensures the button provides clear visual feedback on tap without turning green, keeping the UI consistent.