### PR TITLE
Fix literal wildcards in text filters

### DIFF
--- a/app/filter/filtercontroller.cpp
+++ b/app/filter/filtercontroller.cpp
@@ -234,7 +234,11 @@ QString FilterController::buildFieldExpression( const FieldFilter &filter ) cons
       QString textValue = QgsExpression::quotedString( filter.value.toList().at( 0 ).toString() );
       // remove single quotes from the beginning and end of returned string
       textValue = textValue.slice( 1, textValue.size() - 2 );
+      textValue.replace( QStringLiteral( "!" ), QStringLiteral( "!!" ) );
+      textValue.replace( QStringLiteral( "%" ), QStringLiteral( "!%" ) );
+      textValue.replace( QStringLiteral( "_" ), QStringLiteral( "!_" ) );
       expressionCopy.replace( QStringLiteral( "@@value@@" ), textValue );
+      expressionCopy.append( QStringLiteral( " ESCAPE '!'" ) );
       break;
     }
     case FieldFilter::CheckboxFilter:

--- a/app/test/testfiltercontroller.cpp
+++ b/app/test/testfiltercontroller.cpp
@@ -13,6 +13,8 @@
 
 #include <QtTest/QtTest>
 #include <QDateTime>
+#include <QFile>
+#include <QTemporaryDir>
 
 #include <qgsproject.h>
 #include <qgsvectorlayer.h>
@@ -554,9 +556,71 @@ void TestFilterController::testTextFilter()
   filterValues[filterId] = QVariantList{ QStringLiteral( "great" ) };
   mController->processFilters( filterValues );
 
-  const QString expected = QStringLiteral( "(\"Condition\" LIKE '%great%')" );
+  const QString expected = QStringLiteral( "(\"Condition\" LIKE '%great%' ESCAPE '!')" );
   QCOMPARE( layer->subsetString(), expected );
   QCOMPARE( layer->featureCount(), ( long long ) 14 );
+}
+
+void TestFilterController::testTextFilterWildcards_data()
+{
+  QTest::addColumn<QString>( "searchValue" );
+  QTest::addColumn<QString>( "expectedPattern" );
+  QTest::addColumn<qlonglong>( "expectedCount" );
+
+  QTest::newRow( "percent" ) << QStringLiteral( "%" ) << QStringLiteral( "%!%%" ) << 2LL;
+  QTest::newRow( "underscore" ) << QStringLiteral( "_" ) << QStringLiteral( "%!_%" ) << 2LL;
+  QTest::newRow( "escape-character" ) << QStringLiteral( "!" ) << QStringLiteral( "%!!%" ) << 1LL;
+  QTest::newRow( "combined-wildcards" ) << QStringLiteral( "%_" ) << QStringLiteral( "%!%!_%" ) << 1LL;
+}
+
+void TestFilterController::testTextFilterWildcards()
+{
+  QFETCH( QString, searchValue );
+  QFETCH( QString, expectedPattern );
+  QFETCH( qlonglong, expectedCount );
+
+  QTemporaryDir tempDir;
+  QVERIFY( tempDir.isValid() );
+  const QString layerPath = tempDir.filePath( QStringLiteral( "roads.gpkg" ) );
+  QVERIFY( QFile::copy( TestUtils::testDataDir() + QStringLiteral( "/filtering/roads.gpkg" ), layerPath ) );
+
+  const QString fieldName = QStringLiteral( "Condition" );
+  QgsVectorLayer *layer = new QgsVectorLayer(
+    layerPath + QStringLiteral( "|layername=roads" ),
+    QStringLiteral( "text-filter-wildcards" ),
+    QStringLiteral( "ogr" )
+  );
+  QVERIFY( layer );
+  QVERIFY( layer->isValid() );
+  QgsProject::instance()->addMapLayer( layer );
+
+  const QStringList values =
+  {
+    QStringLiteral( "plain" ),
+    QStringLiteral( "percent%only" ),
+    QStringLiteral( "under_score" ),
+    QStringLiteral( "bang!mark" ),
+    QStringLiteral( "both%_chars" )
+  };
+  for ( const QString &value : values )
+  {
+    QVERIFY( TestUtils::addFeatureToLayer( layer, fieldName, value ) );
+  }
+
+  const QString sql = QStringLiteral( "\"Condition\" LIKE '%@@value@@%'" );
+  const QString filterId = TestUtils::setupControllerWithFilter(
+                             mController.get(), FieldFilter::TextFilter, layer->id(), fieldName, sql );
+  QVERIFY( !filterId.isEmpty() );
+
+  QVariantMap filterValues;
+  filterValues[filterId] = QVariantList{ searchValue };
+  mController->processFilters( filterValues );
+
+  const QString expected = QStringLiteral( "(\"Condition\" LIKE '%1' ESCAPE '!')" ).arg( expectedPattern );
+  QCOMPARE( layer->subsetString(), expected );
+  QCOMPARE( layer->featureCount(), expectedCount );
+
+  QgsProject::instance()->removeMapLayer( layer );
 }
 
 // Checkbox filter

--- a/app/test/testfiltercontroller.h
+++ b/app/test/testfiltercontroller.h
@@ -56,6 +56,8 @@ class TestFilterController : public QObject
 
     // Text filter
     void testTextFilter();
+    void testTextFilterWildcards_data();
+    void testTextFilterWildcards();
 
     // Checkbox filter
     void testCheckboxFilter();


### PR DESCRIPTION
## Summary

- escape user-entered `!`, `%`, and `_` before substituting text filter values into `LIKE` expressions
- add an explicit `ESCAPE '!'` clause so `%` and `_` are matched literally while the surrounding `%...%` still performs substring matching
- add OGR/GeoPackage regression coverage for percent, underscore, the escape character itself, and combined `%_` input

## Root cause

Text filter values were quoted for SQL string safety, but SQL `LIKE` metacharacters were left unchanged. As a result, `%` matched any sequence and `_` matched any single character instead of the characters users typed.

Closes #4517.

## Validation

- project `astyle` check on all changed C++/header files
- `git diff --check`
- SQLite verification of the generated `LIKE ... ESCAPE '!'` patterns for `%`, `_`, `!`, and `%_`
- regression test uses a temporary copy of the project's real `roads.gpkg` through the OGR provider

The full Mergin Maps native test binary was not built locally because this host does not have the repository's Qt/QGIS/vcpkg toolchain.

## AI assistance disclosure

OpenAI Codex assisted with issue triage, implementation, regression-test drafting, and validation. The contribution was reviewed against the repository policies and the generated SQL behavior was independently checked locally.