### PR TITLE
Fix wrong tab highlighted after swiping between Features/Layer info

### DIFF
--- a/app/qml/layers/MMLayerDetailPage.qml
+++ b/app/qml/layers/MMLayerDetailPage.qml
@@ -54,6 +54,11 @@ Page {
     anchors.fill: parent
 
     interactive: layerDetailData.isVectorLayer
+
+    // Keep the bottom toolbar's highlighted button in sync with the visible
+    // page when the user changes page by swiping (onClicked handlers below
+    // already take care of the case when a toolbar button is tapped).
+    onCurrentIndexChanged: selectableToolbar.index = content.currentIndex
   }
 
   Component {


### PR DESCRIPTION
## Summary
Closes #4464. When switching between the "Features" and "Layer info" tabs by swiping (rather than tapping), the bottom toolbar's highlighted tab didn't match the visible page.

## Root cause
`MMLayerDetailPage.qml` hosts a `SwipeView` (`content`) plus a custom bottom `MMToolbar` (`selectableToolbar`). The toolbar's highlight is driven entirely by its own `index` property (see `MMToolbar.qml`: `onIndexChanged: toolbar.currentIndex = index`, and `MMToolbarShortButton.selected: model.index === ListView.view.currentIndex`).

`selectableToolbar.index` was only ever updated from each toolbar button's `onClicked` handler — the tap path. Nothing observed `content.currentIndex` changing from a swipe gesture, so after swiping, the `SwipeView` moved to the new page but the toolbar's highlighted tab stayed on the old one.

## Fix
```qml
SwipeView {
  id: content
  anchors.fill: parent
  interactive: layerDetailData.isVectorLayer

  // Keep the bottom toolbar's highlighted button in sync with the visible
  // page when the user changes page by swiping (onClicked handlers below
  // already take care of the case when a toolbar button is tapped).
  onCurrentIndexChanged: selectableToolbar.index = content.currentIndex
}
```

One line added to `MMLayerDetailPage.qml`.

## How I tested this
I don't have a Qt/QML build environment set up on this machine, so I verified by tracing both interaction paths through the code:
- **Swipe:** gesture changes `content.currentIndex` → new handler fires → `selectableToolbar.index` updates → `MMToolbar.onIndexChanged` sets `toolbar.currentIndex` → the correct button's `selected` binding recomputes.
- **Tap:** unchanged — `MMToolbar.qml`'s internal `onClicked` sets `root.index`, and the button's own `onClicked` handler in this file also sets `selectableToolbar.index` and calls `content.setCurrentIndex()`, which now also triggers the new handler. All writes land on the same value, so there's no oscillation or loop.

I also grepped every `currentIndex`/`.index` assignment in both files to confirm there's no third code path that could re-desync the two (the `closePage()` `takeItem(0)` call is immediately followed by `root.close()`, so it's inert here).

Given I couldn't run the app, a manual click-through on device/simulator during review would be appreciated to confirm the fix behaves as expected in practice.