### PR TITLE
Build all libraries with 16kb pages support

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -37,8 +37,8 @@ jobs:
 
     runs-on: macos-26
     env:
-      NDK_VERSION: 'r27' # '27.2.12479018'
-      NDK_VERSION_FULL: r27c
+      NDK_VERSION: 'r28' # '28.2.13676358'
+      NDK_VERSION_FULL: r28c
       JDK_VERSION: 17
       SDK_PLATFORM: android-36
       VCPKG_BINARY_SOURCES: 'clear;nuget,GitHub,readwrite'

--- a/vcpkg/ports/README.md
+++ b/vcpkg/ports/README.md
@@ -7,3 +7,4 @@
 - qtdeclarative - optimization to decrease package size
 - qtpositioning - Android service fix & iOS orthometric position hack
 - libsecret - Build with -Dbash_completion=disabled to avoid PermissionError: [Errno 13] Permission denied: '/usr/share/bash-completion/completions/secret-tool'
+- libaec - Change from Gitlab to Github oficial repository as Gitlab was ratelimiting strongly and upstream didn't swap yet 

--- a/vcpkg/ports/libaec/portfile.cmake
+++ b/vcpkg/ports/libaec/portfile.cmake
@@ -1,0 +1,44 @@
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO Deutsches-Klimarechenzentrum/libaec
+    REF "v${VERSION}"
+    SHA512 76df7501d1b7d91a43b525ba828f092f18d83f8ab09a9331e5758f93942a9758ad580baca8f9316b92a98639bde2e23cacbc2f33f52d0dd98ce7efe412cf43cd
+    HEAD_REF main
+)
+
+string(COMPARE EQUAL "${VCPKG_LIBRARY_LINKAGE}" "static" BUILD_STATIC)
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS
+        -DBUILD_STATIC_LIBS=${BUILD_STATIC}
+        -Dlibaec_INSTALL_CMAKEDIR=share/${PORT}
+)
+vcpkg_cmake_install()
+vcpkg_copy_pdbs()
+vcpkg_cmake_config_fixup()
+vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/share/libaec/libaec-config.cmake"
+    "if(libaec_USE_STATIC_LIBS)"
+    "if(\"${BUILD_STATIC}\") # forced by vcpkg"
+)
+
+# Compatibility with user's CMake < 3.18 (vcpkg claims support for >= 3.16):
+# Make imported targets global so that libaec-config.cmake can create ALIAS targets.
+set(_target_file "libaec_shared-targets")
+if(BUILD_STATIC)
+    set(_target_file "libaec_static-targets")
+endif()
+file(READ "${CURRENT_PACKAGES_DIR}/share/libaec/${_target_file}.cmake" libaec_targets)
+string(REGEX REPLACE " (SHARED|STATIC) IMPORTED" " \\1 IMPORTED \${libaec_maybe_global}" libaec_targets "${libaec_targets}")
+file(WRITE "${CURRENT_PACKAGES_DIR}/share/libaec/${_target_file}.cmake" "set(libaec_maybe_global \"\")
+if(CMAKE_VERSION VERSION_LESS 3.18)
+    set(libaec_maybe_global \"GLOBAL\")
+endif()
+${libaec_targets}
+"
+)
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+
+file(INSTALL "${CURRENT_PORT_DIR}/usage" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE.txt")

--- a/vcpkg/ports/libaec/usage
+++ b/vcpkg/ports/libaec/usage
@@ -1,0 +1,7 @@
+libaec provides CMake targets:
+
+  find_package(libaec CONFIG REQUIRED)
+  # libaec API
+  target_link_libraries(main PRIVATE libaec::aec)
+  # szip compatible API
+  target_link_libraries(main PRIVATE libaec::sz)

--- a/vcpkg/ports/libaec/vcpkg.json
+++ b/vcpkg/ports/libaec/vcpkg.json
@@ -1,0 +1,17 @@
+{
+  "name": "libaec",
+  "version": "1.1.6",
+  "description": "Adaptive Entropy Coding library",
+  "homepage": "https://gitlab.dkrz.de/k202009/libaec",
+  "license": "BSD-2-Clause",
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ]
+}


### PR DESCRIPTION
The changes done in #4463 didn't build all dependencies with support of 16kb pages required by google play. The new version of NDK does that by default.

Also we are just creating overlay port for libaec to change the source repo see https://github.com/microsoft/vcpkg/issues/51921