### PR TITLE
Fix WMS/WMTS layers with uncommon CRS not rendering on desktop

### DIFF
--- a/app/main.cpp
+++ b/app/main.cpp
@@ -229,10 +229,8 @@ static void init_qgis( const QString &pkgPath )
 #ifdef MOBILE_OS
   // QGIS plugins on Android are in the same path as other libraries
   QgsApplication::setPluginPath( QApplication::applicationDirPath() );
-  QgsApplication::setPkgDataPath( pkgPath );
-#else
-  Q_UNUSED( pkgPath )
 #endif
+  QgsApplication::setPkgDataPath( pkgPath );
 
   QgsApplication::initQgis();
 


### PR DESCRIPTION
Fixes #4217 
Maybe #3924 

The requested WMS layer had swiss specific CRS (EPSG:21781). Normally QGIS would look for `srs.db` for CRS definitions, but on desktops the path to QGIS resources was wrongly setup and QGIS used `proj.db` as fallback instead, which doesn't have this definition. 