### PR TITLE
Update workflow yamls to support pull requests from forks

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -12,6 +12,9 @@ on:
       - 'cmake_templates/**'
       - 'CMakeLists.txt'
       - '.github/workflows/android.yml'
+  pull_request:
+    branches:
+      - master
 
   release:
     types:

--- a/.github/workflows/code_style.yml
+++ b/.github/workflows/code_style.yml
@@ -12,6 +12,9 @@ on:
     - 'cmake_templates/**'
     - 'CMakeLists.txt'
     - '.github/workflows/code_style.yml'
+  pull_request:
+    branches:
+      - master
     
   release:
     types:

--- a/.github/workflows/gallery.yml
+++ b/.github/workflows/gallery.yml
@@ -5,6 +5,9 @@ on:
     - 'app/qml/**'
     - 'gallery/**'
     - '.github/workflows/gallery.yml'
+  pull_request:
+    branches:
+      - master
 
   release:
     types:

--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -14,6 +14,9 @@ on:
       - 'CMakeLists.txt'
       - '.github/workflows/ios.yml'
       - '.github/secrets/ios/**'
+  pull_request:
+    branches:
+      - master
 
   release:
     types:

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -14,6 +14,9 @@ on:
     - 'test/**'
     - 'CMakeLists.txt'
     - '.github/workflows/linux.yml'
+  pull_request:
+    branches:
+      - master
 
   release:
     types:

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -13,6 +13,9 @@ on:
       - 'test/**'
       - 'CMakeLists.txt'
       - '.github/workflows/macos.yml'
+  pull_request:
+    branches:
+      - master
 
   release:
     types:

--- a/.github/workflows/win.yml
+++ b/.github/workflows/win.yml
@@ -13,6 +13,9 @@ on:
     - 'cmake_templates/**'
     - 'CMakeLists.txt'
     - '.github/workflows/win.yml'
+  pull_request:
+    branches:
+      - master
 
   release:
     types:


### PR DESCRIPTION
Currently CI runs only if the pull request is created from repository branch and doesn't support PR's from forks. Now all the CI checks should run on both.