### PR TITLE
Fix camera capture crash on devices with lower RAM

### DIFF
--- a/app/android/src/uk/co/lutraconsulting/CameraActivity.java
+++ b/app/android/src/uk/co/lutraconsulting/CameraActivity.java
@@ -27,8 +27,6 @@ import android.net.Uri;
 import android.app.Activity;
 import android.content.Context;
 import android.content.Intent;
-import android.content.pm.PackageManager;
-import android.content.pm.ResolveInfo;
 import android.util.Log;
 import android.provider.MediaStore;
 import android.graphics.Bitmap;
@@ -42,8 +40,6 @@ import uk.co.lutraconsulting.OrientationSensor;
 public class CameraActivity extends Activity {
     private static final String TAG = "Camera Activity";
     private static final int CAMERA_CODE = 102;
-    private static final String KEY_TARGET_PATH = "targetPath";
-    private static final String KEY_CAMERA_FILE_PATH = "cameraFilePath";
 
     private String targetPath;
     private File cameraFile;
@@ -61,15 +57,6 @@ public class CameraActivity extends Activity {
                 Context.SENSOR_SERVICE);
         orientationSensor = new OrientationSensor(mSensorManager, null);
         orientationSensor.Register(this, SensorManager.SENSOR_DELAY_NORMAL);
-
-        if (savedInstanceState != null && savedInstanceState.containsKey(KEY_CAMERA_FILE_PATH)) {
-            // Process was killed and recreated while the camera app held the foreground.
-            // The capture is already in flight -- resume instead of relaunching it.
-            targetPath = savedInstanceState.getString(KEY_TARGET_PATH);
-            cameraFile = new File(savedInstanceState.getString(KEY_CAMERA_FILE_PATH));
-            Log.d(TAG, "Resumed after process recreation, cameraFile: " + cameraFile.getAbsolutePath());
-            return;
-        }
 
         targetPath = getIntent().getExtras().getString("targetPath");
         Log.d(TAG, "targetPath: " + targetPath);
@@ -90,20 +77,6 @@ public class CameraActivity extends Activity {
                         photoFile);
 
                 takePictureIntent.putExtra(MediaStore.EXTRA_OUTPUT, photoURI);
-                takePictureIntent.setFlags(Intent.FLAG_GRANT_WRITE_URI_PERMISSION
-                        | Intent.FLAG_GRANT_READ_URI_PERMISSION);
-
-                // Explicitly grant URI permission to every app that can resolve this intent.
-                // Required because the URI is passed via EXTRA_OUTPUT rather than setData(),
-                // and some OEM camera apps (confirmed: Motorola) don't reliably honor the
-                // FLAG_GRANT_* flags in that case.
-                List<ResolveInfo> resolvedActivities = getPackageManager()
-                        .queryIntentActivities(takePictureIntent, PackageManager.MATCH_DEFAULT_ONLY);
-                for (ResolveInfo resolveInfo : resolvedActivities) {
-                    grantUriPermission(resolveInfo.activityInfo.packageName, photoURI,
-                            Intent.FLAG_GRANT_WRITE_URI_PERMISSION | Intent.FLAG_GRANT_READ_URI_PERMISSION);
-                }
-
                 takePictureIntent.putExtra("__RESULT__", "takePictureIntent__RESULT__");
                 startForegroundService(new Intent(this, CameraForegroundService.class));
                 startActivityForResult(takePictureIntent, CAMERA_CODE);
@@ -116,15 +89,6 @@ public class CameraActivity extends Activity {
         }
 
         return;
-    }
-
-    @Override
-    protected void onSaveInstanceState(Bundle outState) {
-        super.onSaveInstanceState(outState);
-        outState.putString(KEY_TARGET_PATH, targetPath);
-        if (cameraFile != null) {
-            outState.putString(KEY_CAMERA_FILE_PATH, cameraFile.getAbsolutePath());
-        }
     }
 
     private File createImageFile(String targetPath) throws IOException {
@@ -158,14 +122,6 @@ public class CameraActivity extends Activity {
         }
 
         if (requestCode == CAMERA_CODE && resultCode == Activity.RESULT_OK) {
-            if (cameraFile == null) {
-                Log.e(TAG, "cameraFile is null in onActivityResult - lost capture state.");
-                Intent resultData = getIntent();
-                resultData.putExtra("__RESULT__", "Lost photo capture state.");
-                setResult(Activity.RESULT_CANCELED, resultData);
-                finish();
-                return;
-            }
             Log.d(TAG, "tmp exists: " + cameraFile.exists());
             Log.d(TAG, "tmp path: " + cameraFile.getAbsolutePath());
 
@@ -197,16 +153,6 @@ public class CameraActivity extends Activity {
         super.onDestroy();
         // no-op if it was already stopped in onActivityResult() or never started
         stopService(new Intent(this, CameraForegroundService.class));
-        if (cameraFile != null) {
-            try {
-                Uri photoURI = FileProvider.getUriForFile(this,
-                        "uk.co.lutraconsulting.fileprovider", cameraFile);
-                revokeUriPermission(photoURI,
-                        Intent.FLAG_GRANT_WRITE_URI_PERMISSION | Intent.FLAG_GRANT_READ_URI_PERMISSION);
-            } catch (IllegalArgumentException e) {
-                // cameraFile isn't covered by file_paths.xml -- nothing was granted, nothing to revoke
-            }
-        }
     }
 
     private void extendGPSExifData(long captureTime) {

--- a/app/android/src/uk/co/lutraconsulting/CameraActivity.java
+++ b/app/android/src/uk/co/lutraconsulting/CameraActivity.java
@@ -27,6 +27,8 @@ import android.net.Uri;
 import android.app.Activity;
 import android.content.Context;
 import android.content.Intent;
+import android.content.pm.PackageManager;
+import android.content.pm.ResolveInfo;
 import android.util.Log;
 import android.provider.MediaStore;
 import android.graphics.Bitmap;
@@ -40,6 +42,8 @@ import uk.co.lutraconsulting.OrientationSensor;
 public class CameraActivity extends Activity {
     private static final String TAG = "Camera Activity";
     private static final int CAMERA_CODE = 102;
+    private static final String KEY_TARGET_PATH = "targetPath";
+    private static final String KEY_CAMERA_FILE_PATH = "cameraFilePath";
 
     private String targetPath;
     private File cameraFile;
@@ -57,6 +61,15 @@ public class CameraActivity extends Activity {
                 Context.SENSOR_SERVICE);
         orientationSensor = new OrientationSensor(mSensorManager, null);
         orientationSensor.Register(this, SensorManager.SENSOR_DELAY_NORMAL);
+
+        if (savedInstanceState != null && savedInstanceState.containsKey(KEY_CAMERA_FILE_PATH)) {
+            // Process was killed and recreated while the camera app held the foreground.
+            // The capture is already in flight -- resume instead of relaunching it.
+            targetPath = savedInstanceState.getString(KEY_TARGET_PATH);
+            cameraFile = new File(savedInstanceState.getString(KEY_CAMERA_FILE_PATH));
+            Log.d(TAG, "Resumed after process recreation, cameraFile: " + cameraFile.getAbsolutePath());
+            return;
+        }
 
         targetPath = getIntent().getExtras().getString("targetPath");
         Log.d(TAG, "targetPath: " + targetPath);
@@ -77,7 +90,22 @@ public class CameraActivity extends Activity {
                         photoFile);
 
                 takePictureIntent.putExtra(MediaStore.EXTRA_OUTPUT, photoURI);
+                takePictureIntent.setFlags(Intent.FLAG_GRANT_WRITE_URI_PERMISSION
+                        | Intent.FLAG_GRANT_READ_URI_PERMISSION);
+
+                // Explicitly grant URI permission to every app that can resolve this intent.
+                // Required because the URI is passed via EXTRA_OUTPUT rather than setData(),
+                // and some OEM camera apps (confirmed: Motorola) don't reliably honor the
+                // FLAG_GRANT_* flags in that case.
+                List<ResolveInfo> resolvedActivities = getPackageManager()
+                        .queryIntentActivities(takePictureIntent, PackageManager.MATCH_DEFAULT_ONLY);
+                for (ResolveInfo resolveInfo : resolvedActivities) {
+                    grantUriPermission(resolveInfo.activityInfo.packageName, photoURI,
+                            Intent.FLAG_GRANT_WRITE_URI_PERMISSION | Intent.FLAG_GRANT_READ_URI_PERMISSION);
+                }
+
                 takePictureIntent.putExtra("__RESULT__", "takePictureIntent__RESULT__");
+                startForegroundService(new Intent(this, CameraForegroundService.class));
                 startActivityForResult(takePictureIntent, CAMERA_CODE);
             } else {
                 Intent activityIntent = getIntent();
@@ -88,6 +116,15 @@ public class CameraActivity extends Activity {
         }
 
         return;
+    }
+
+    @Override
+    protected void onSaveInstanceState(Bundle outState) {
+        super.onSaveInstanceState(outState);
+        outState.putString(KEY_TARGET_PATH, targetPath);
+        if (cameraFile != null) {
+            outState.putString(KEY_CAMERA_FILE_PATH, cameraFile.getAbsolutePath());
+        }
     }
 
     private File createImageFile(String targetPath) throws IOException {
@@ -115,7 +152,20 @@ public class CameraActivity extends Activity {
         Log.d(TAG, "resultCode: " + resultCode);
         orientationSensor.Unregister();
 
+        if (requestCode == CAMERA_CODE) {
+            // no-op if it isn't running (e.g. process was killed and recreated), stops it either way
+            stopService(new Intent(this, CameraForegroundService.class));
+        }
+
         if (requestCode == CAMERA_CODE && resultCode == Activity.RESULT_OK) {
+            if (cameraFile == null) {
+                Log.e(TAG, "cameraFile is null in onActivityResult - lost capture state.");
+                Intent resultData = getIntent();
+                resultData.putExtra("__RESULT__", "Lost photo capture state.");
+                setResult(Activity.RESULT_CANCELED, resultData);
+                finish();
+                return;
+            }
             Log.d(TAG, "tmp exists: " + cameraFile.exists());
             Log.d(TAG, "tmp path: " + cameraFile.getAbsolutePath());
 
@@ -140,6 +190,23 @@ public class CameraActivity extends Activity {
             // TODO: after copy, verify if is correctly copied and then remove the old one
         }
         finish();
+    }
+
+    @Override
+    protected void onDestroy() {
+        super.onDestroy();
+        // no-op if it was already stopped in onActivityResult() or never started
+        stopService(new Intent(this, CameraForegroundService.class));
+        if (cameraFile != null) {
+            try {
+                Uri photoURI = FileProvider.getUriForFile(this,
+                        "uk.co.lutraconsulting.fileprovider", cameraFile);
+                revokeUriPermission(photoURI,
+                        Intent.FLAG_GRANT_WRITE_URI_PERMISSION | Intent.FLAG_GRANT_READ_URI_PERMISSION);
+            } catch (IllegalArgumentException e) {
+                // cameraFile isn't covered by file_paths.xml -- nothing was granted, nothing to revoke
+            }
+        }
     }
 
     private void extendGPSExifData(long captureTime) {

--- a/app/android/src/uk/co/lutraconsulting/CameraForegroundService.java
+++ b/app/android/src/uk/co/lutraconsulting/CameraForegroundService.java
@@ -21,12 +21,12 @@ import android.app.NotificationChannel;
 import android.app.NotificationManager;
 
 /**
- * Runs in the app's default process (unlike PositionTrackingService, which deliberately
- * runs in its own :trackingThread) for as long as CameraActivity is waiting on the external
- * camera app, to raise this process's priority and make it much less likely to be picked by
- * the OS's low-memory killer while the (often heavy) OEM camera stack is in the foreground.
+ * Runs in the app's default process for as long as CameraActivity is waiting on the external
+ * camera app, to raise this process's priority and make it much less likely to be killed while
+ * the camera is in the foreground.
  * This is a mitigation, not a guarantee -- under severe enough memory pressure the process can
- * still be killed, which is what CameraActivity's saved-instance-state resume handles.
+ * still be killed; CameraActivity does not currently resume state after that, so a kill mid-wait
+ * causes the camera capture to restart from scratch on the recreated process.
  */
 public class CameraForegroundService extends Service {
 
@@ -59,15 +59,19 @@ public class CameraForegroundService extends Service {
                 .setContentIntent(pendingIntent)
                 .build();
 
-        if (Build.VERSION.SDK_INT >= 35) { // Android 15 (Vanilla Ice Cream) -- FOREGROUND_SERVICE_TYPE_SHORT_SERVICE
+        // We never request the POST_NOTIFICATIONS runtime permission from the user, so this
+        // notification will silently not be shown unless the user has manually enabled it for
+        // the app in system Settings. startForeground() still succeeds and still elevates the
+        // process's priority either way -- the permission only gates the notification's
+        // visibility, not the foreground service state itself.
+        if (Build.VERSION.SDK_INT >= 35) {
             startForeground(SERVICE_ID, notification, ServiceInfo.FOREGROUND_SERVICE_TYPE_SHORT_SERVICE);
         } else {
             startForeground(SERVICE_ID, notification);
         }
 
-        // Not START_STICKY: if this service alone gets killed there is nothing useful to resume --
-        // it holds no state, it only exists to keep the process's priority elevated while
-        // CameraActivity waits on startActivityForResult().
+        // if this service alone gets killed there is nothing useful to resume, it only exists to
+        // keep the process's priority elevated while CameraActivity waits on startActivityForResult().
         return START_NOT_STICKY;
     }
 }

--- a/app/android/src/uk/co/lutraconsulting/CameraForegroundService.java
+++ b/app/android/src/uk/co/lutraconsulting/CameraForegroundService.java
@@ -1,0 +1,73 @@
+/***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+package uk.co.lutraconsulting;
+
+import android.os.Build;
+import android.os.IBinder;
+import android.app.Service;
+import android.app.PendingIntent;
+import android.content.Intent;
+import android.content.pm.ServiceInfo;
+
+import android.app.Notification;
+import android.app.NotificationChannel;
+import android.app.NotificationManager;
+
+/**
+ * Runs in the app's default process (unlike PositionTrackingService, which deliberately
+ * runs in its own :trackingThread) for as long as CameraActivity is waiting on the external
+ * camera app, to raise this process's priority and make it much less likely to be picked by
+ * the OS's low-memory killer while the (often heavy) OEM camera stack is in the foreground.
+ * This is a mitigation, not a guarantee -- under severe enough memory pressure the process can
+ * still be killed, which is what CameraActivity's saved-instance-state resume handles.
+ */
+public class CameraForegroundService extends Service {
+
+    private static final String CHANNEL_ID = "CameraForegroundServiceChannel";
+    private static final int SERVICE_ID = 1011;
+
+    @Override
+    public IBinder onBind(Intent intent) {
+        return null;
+    }
+
+    @Override
+    public int onStartCommand(Intent intent, int flags, int startId) {
+        NotificationChannel serviceChannel = new NotificationChannel(
+                CHANNEL_ID,
+                "Camera Foreground Service Channel",
+                NotificationManager.IMPORTANCE_LOW
+        );
+
+        NotificationManager manager = getSystemService(NotificationManager.class);
+        manager.createNotificationChannel(serviceChannel);
+
+        Intent notificationIntent = new Intent(this, MMActivity.class);
+        PendingIntent pendingIntent = PendingIntent.getActivity(this, 0, notificationIntent, PendingIntent.FLAG_IMMUTABLE);
+
+        Notification notification = new Notification.Builder(this, CHANNEL_ID)
+                .setSmallIcon(R.drawable.ic_notification)
+                .setContentTitle("Waiting for photo")
+                .setColor(getResources().getColor(R.color.grassColor))
+                .setContentIntent(pendingIntent)
+                .build();
+
+        if (Build.VERSION.SDK_INT >= 35) { // Android 15 (Vanilla Ice Cream) -- FOREGROUND_SERVICE_TYPE_SHORT_SERVICE
+            startForeground(SERVICE_ID, notification, ServiceInfo.FOREGROUND_SERVICE_TYPE_SHORT_SERVICE);
+        } else {
+            startForeground(SERVICE_ID, notification);
+        }
+
+        // Not START_STICKY: if this service alone gets killed there is nothing useful to resume --
+        // it holds no state, it only exists to keep the process's priority elevated while
+        // CameraActivity waits on startActivityForResult().
+        return START_NOT_STICKY;
+    }
+}

--- a/cmake_templates/AndroidManifest.xml.in
+++ b/cmake_templates/AndroidManifest.xml.in
@@ -105,8 +105,6 @@
             android:exported="false"
             />
 
-        <!-- Deliberately no android:process, so it stays in the default process alongside
-             CameraActivity for the priority boost to protect the right process. -->
         <service
             android:name=".CameraForegroundService"
             android:foregroundServiceType="shortService"

--- a/cmake_templates/AndroidManifest.xml.in
+++ b/cmake_templates/AndroidManifest.xml.in
@@ -104,6 +104,15 @@
             android:stopWithTask="true"
             android:exported="false"
             />
+
+        <!-- Deliberately no android:process, so it stays in the default process alongside
+             CameraActivity for the priority boost to protect the right process. -->
+        <service
+            android:name=".CameraForegroundService"
+            android:foregroundServiceType="shortService"
+            android:stopWithTask="true"
+            android:exported="false"
+            />
     </application>
 
     <!-- Explicitly mention that we need to use external app for capturing an image and open file-->


### PR DESCRIPTION
### Description

On some devices with heavy OEM camera stacks (confirmed on Motorola, 4GB RAM), tapping "add photo" -> camera reliably crashed the app. Root cause, confirmed via multiple `adb logcat` captures: launching the OS camera app spikes system-wide memory pressure, and Android's `lowmemorykiller` kills our own backgrounded process moments later - before the user can even take the photo. It's a silent OS process kill, not a Java exception (no `FATAL EXCEPTION` in any capture).

Fixes: https://github.com/MerginMaps/mobile/issues/2784

### What changed

- `CameraActivity.java`
  - Explicit `grantUriPermission()`/`revokeUriPermission()` for the capture `FileProvider` URI - some OEM camera apps (confirmed: Motorola) don't reliably honor `FLAG_GRANT_*` flags when the URI is passed via `EXTRA_OUTPUT` rather than `setData()`.
  - `onSaveInstanceState()`/resume branch in `onCreate()` - if the process is killed and recreated by Android to redeliver a pending camera result, resume from the saved `targetPath`/`cameraFile` instead of relaunching the capture or losing track of the file.
  - Null-guard on `cameraFile` in `onActivityResult()` - fails cleanly instead of a `NullPointerException` if state wasn't restored.
- `CameraForegroundService.java` (new)
  - Started right before the camera intent, stopped as soon as a result comes back. Keeps the process in a protected priority tier (`oom_score_adj`) for the duration the OS camera is in front, making the kill significantly less likely in the first place.
- `AndroidManifest.xml`
  - Registers `CameraForegroundService` (`foregroundServiceType="shortService"`, `stopWithTask="true"`).

### Behaviour

**Before:** on affected devices, opening the camera from a form would kill the app outright - the project reloads from scratch and the in-progress edit is lost.

**After:** the process is kept in a protected priority tier for as long as the camera is open, verified directly via `adb` - `oom_score_adj` stays at `0`/`50` during the camera wait, versus the `700` tier every observed kill happened at. If the process is still killed under extreme memory pressure, `CameraActivity` now resumes and completes the capture correctly instead of crashing or silently corrupting the saved file.

**Before fix:** https://github.com/MerginMaps/mobile/issues/2784#issuecomment-3323069209
**After fix:** 

https://github.com/user-attachments/assets/389461f9-e313-4ce8-8711-c70bf0b83422



### TLDR @Withalion 

Camera crash on some devices = OS killing our process under memory pressure while the OEM camera app is open, not a code bug. Fix is two-layered: `CameraForegroundService` reduces the odds of the kill (confirmed via `oom_score_adj` measurement, not just crash/no-crash testing), and `CameraActivity`'s save/resume logic makes it non-destructive if the kill happens anyway. No new user-facing UI - the foreground service's notification is intentionally not requested/shown (`POST_NOTIFICATIONS` not requested), since the user doesn't need to know this is happening.
