### PR TITLE
Add option to start app in Home/Last project

### DIFF
--- a/app/appsettings.cpp
+++ b/app/appsettings.cpp
@@ -20,7 +20,7 @@ AppSettings::AppSettings( QObject *parent ): QObject( parent )
   QSettings settings;
   settings.beginGroup( CoreUtils::QSETTINGS_APP_GROUP_NAME );
   const QString path = settings.value( QStringLiteral( "defaultProject" ), "" ).toString();
-  const QString layer = settings.value( "defaultLayer/"  + path, "" ).toString();
+  const QString layer = settings.value( QStringLiteral( "defaultLayer/" ) + path, "" ).toString();
   const double gpsTolerance = settings.value( QStringLiteral( "gpsTolerance" ), 10 ).toDouble();
   const int lineRecordingInterval = settings.value( QStringLiteral( "lineRecordingInterval" ), 3 ).toInt();
   int streamingIntervalType = settings.value( QStringLiteral( "intervalType" ), 0 ).toInt();
@@ -65,7 +65,7 @@ void AppSettings::setDefaultLayer( const QString &value )
 {
   if ( defaultLayer() != value )
   {
-    setValue( "defaultLayer/" + mActiveProject, value );
+    setValue( QStringLiteral( "defaultLayer/" ) + mActiveProject, value );
     mDefaultLayers.insert( mActiveProject, value );
     emit defaultLayerChanged();
   }

--- a/app/appsettings.cpp
+++ b/app/appsettings.cpp
@@ -34,6 +34,8 @@ AppSettings::AppSettings( QObject *parent ): QObject( parent )
   const bool autolockPosition = settings.value( QStringLiteral( "autolockPosition" ), true ).toBool();
   int hapticsTypeInt = settings.value( "hapticsType", 0 ).toInt();
   const HapticsType hapticsType = static_cast<HapticsType>( hapticsTypeInt );
+  int startupBehaviourInt = settings.value( "startupBehaviour", 0 ).toInt();
+  const StartupBehaviour startupBehaviour = static_cast<StartupBehaviour>( startupBehaviourInt );
 
   settings.endGroup();
 
@@ -51,6 +53,7 @@ AppSettings::AppSettings( QObject *parent ): QObject( parent )
   setIgnoreMigrateVersion( ignoreMigrateVersion );
   setAutolockPosition( autolockPosition );
   setHapticsType( hapticsType );
+  setStartupBehaviour( startupBehaviour );
 }
 
 QString AppSettings::defaultLayer() const
@@ -314,6 +317,21 @@ void AppSettings::setHapticsType( const HapticsType hapticsType )
   setValue( QStringLiteral( "hapticsType" ), hapticsType );
   mHapticsType = hapticsType;
   emit hapticsTypeChanged( hapticsType );
+}
+
+AppSettings::StartupBehaviour AppSettings::startupBehaviour() const
+{
+  return mStartupBehaviour;
+}
+
+void AppSettings::setStartupBehaviour( const StartupBehaviour startupBehaviour )
+{
+  if ( mStartupBehaviour == startupBehaviour )
+    return;
+
+  setValue( QStringLiteral( "startupBehaviour" ), startupBehaviour );
+  mStartupBehaviour = startupBehaviour;
+  emit startupBehaviourChanged( startupBehaviour );
 }
 
 double AppSettings::gpsAntennaHeight() const

--- a/app/appsettings.cpp
+++ b/app/appsettings.cpp
@@ -19,23 +19,23 @@ AppSettings::AppSettings( QObject *parent ): QObject( parent )
 {
   QSettings settings;
   settings.beginGroup( CoreUtils::QSETTINGS_APP_GROUP_NAME );
-  const QString path = settings.value( "defaultProject", "" ).toString();
+  const QString path = settings.value( QStringLiteral( "defaultProject" ), "" ).toString();
   const QString layer = settings.value( "defaultLayer/"  + path, "" ).toString();
-  const double gpsTolerance = settings.value( "gpsTolerance", 10 ).toDouble();
-  const int lineRecordingInterval = settings.value( "lineRecordingInterval", 3 ).toInt();
-  int streamingIntervalType = settings.value( "intervalType", 0 ).toInt();
+  const double gpsTolerance = settings.value( QStringLiteral( "gpsTolerance" ), 10 ).toDouble();
+  const int lineRecordingInterval = settings.value( QStringLiteral( "lineRecordingInterval" ), 3 ).toInt();
+  int streamingIntervalType = settings.value( QStringLiteral( "intervalType" ), 0 ).toInt();
   const StreamingIntervalType::IntervalType intervalType = static_cast<StreamingIntervalType::IntervalType>( streamingIntervalType );
-  const bool reuseLastEnteredValues = settings.value( "reuseLastEnteredValues", false ).toBool();
+  const bool reuseLastEnteredValues = settings.value( QStringLiteral( "reuseLastEnteredValues" ), false ).toBool();
   const QString savedAppVersion = settings.value( QStringLiteral( "appVersion" ), QString() ).toString();
   const QString activeProviderId = settings.value( QStringLiteral( "activePositionProviderId" ) ).toString();
   const bool autosync = settings.value( QStringLiteral( "autosyncAllowed" ), false ).toBool();
-  const double gpsHeight = settings.value( "gpsHeight", 0 ).toDouble();
+  const double gpsHeight = settings.value( QStringLiteral( "gpsHeight" ), 0 ).toDouble();
   const QString ignoreMigrateVersion = settings.value( QStringLiteral( "ignoreMigrateVersion" ) ).toString();
   const bool autolockPosition = settings.value( QStringLiteral( "autolockPosition" ), true ).toBool();
-  int hapticsTypeInt = settings.value( "hapticsType", 0 ).toInt();
+  int hapticsTypeInt = settings.value( QStringLiteral( "hapticsType" ), 0 ).toInt();
   const HapticsType hapticsType = static_cast<HapticsType>( hapticsTypeInt );
-  int startupBehaviourInt = settings.value( "startupBehaviour", 0 ).toInt();
-  const StartupBehaviour startupBehaviour = static_cast<StartupBehaviour>( startupBehaviourInt );
+  int startupBehaviorInt = settings.value( QStringLiteral( "startupBehavior" ), 0 ).toInt();
+  const StartupBehavior startupBehavior = static_cast<StartupBehavior>( startupBehaviorInt );
 
   settings.endGroup();
 
@@ -53,7 +53,7 @@ AppSettings::AppSettings( QObject *parent ): QObject( parent )
   setIgnoreMigrateVersion( ignoreMigrateVersion );
   setAutolockPosition( autolockPosition );
   setHapticsType( hapticsType );
-  setStartupBehaviour( startupBehaviour );
+  setStartupBehavior( startupBehavior );
 }
 
 QString AppSettings::defaultLayer() const
@@ -319,19 +319,19 @@ void AppSettings::setHapticsType( const HapticsType hapticsType )
   emit hapticsTypeChanged( hapticsType );
 }
 
-AppSettings::StartupBehaviour AppSettings::startupBehaviour() const
+AppSettings::StartupBehavior AppSettings::startupBehavior() const
 {
-  return mStartupBehaviour;
+  return mStartupBehavior;
 }
 
-void AppSettings::setStartupBehaviour( const StartupBehaviour startupBehaviour )
+void AppSettings::setStartupBehavior( const StartupBehavior startupBehavior )
 {
-  if ( mStartupBehaviour == startupBehaviour )
+  if ( mStartupBehavior == startupBehavior )
     return;
 
-  setValue( QStringLiteral( "startupBehaviour" ), startupBehaviour );
-  mStartupBehaviour = startupBehaviour;
-  emit startupBehaviourChanged( startupBehaviour );
+  setValue( QStringLiteral( "startupBehavior" ), startupBehavior );
+  mStartupBehavior = startupBehavior;
+  emit startupBehaviorChanged( startupBehavior );
 }
 
 double AppSettings::gpsAntennaHeight() const

--- a/app/appsettings.h
+++ b/app/appsettings.h
@@ -38,7 +38,7 @@ class AppSettings: public QObject
     Q_PROPERTY( bool autolockPosition READ autolockPosition WRITE setAutolockPosition NOTIFY autolockPositionChanged )
     Q_PROPERTY( QList<QVariant> windowPosition READ windowPosition WRITE setWindowPosition NOTIFY windowPositionChanged )
     Q_PROPERTY( HapticsType hapticsType READ hapticsType WRITE setHapticsType NOTIFY hapticsTypeChanged )
-    Q_PROPERTY( StartupBehaviour startupBehaviour READ startupBehaviour WRITE setStartupBehaviour NOTIFY startupBehaviourChanged )
+    Q_PROPERTY( StartupBehavior startupBehavior READ startupBehavior WRITE setStartupBehavior NOTIFY startupBehaviorChanged )
 
   public:
     // enum of haptic modes we support
@@ -57,12 +57,12 @@ class AppSettings: public QObject
     Q_ENUM( HapticsType )
 
     // enum of options for what should open when the app starts
-    enum StartupBehaviour
+    enum StartupBehavior
     {
       StartupRecentProject = 0,
       StartupProjectHome
     };
-    Q_ENUM( StartupBehaviour )
+    Q_ENUM( StartupBehavior )
 
     explicit AppSettings( QObject *parent = nullptr );
 
@@ -119,8 +119,8 @@ class AppSettings: public QObject
     HapticsType hapticsType() const;
     void setHapticsType( HapticsType hapticsType );
 
-    StartupBehaviour startupBehaviour() const;
-    void setStartupBehaviour( StartupBehaviour startupBehaviour );
+    StartupBehavior startupBehavior() const;
+    void setStartupBehavior( StartupBehavior startupBehavior );
 
   public slots:
     void setReuseLastEnteredValues( bool reuseLastEnteredValues );
@@ -141,7 +141,7 @@ class AppSettings: public QObject
     void autosyncAllowedChanged( bool autosyncAllowed );
     void autolockPositionChanged( bool autolockPosition );
     void hapticsTypeChanged( HapticsType hapticsType );
-    void startupBehaviourChanged( StartupBehaviour startupBehaviour );
+    void startupBehaviorChanged( StartupBehavior startupBehavior );
 
     void ignoreMigrateVersionChanged();
 
@@ -182,7 +182,7 @@ class AppSettings: public QObject
     QString mIgnoreMigrateVersion;
 
     HapticsType mHapticsType;
-    StartupBehaviour mStartupBehaviour;
+    StartupBehavior mStartupBehavior;
 };
 
 #endif // APPSETTINGS_H

--- a/app/appsettings.h
+++ b/app/appsettings.h
@@ -38,6 +38,7 @@ class AppSettings: public QObject
     Q_PROPERTY( bool autolockPosition READ autolockPosition WRITE setAutolockPosition NOTIFY autolockPositionChanged )
     Q_PROPERTY( QList<QVariant> windowPosition READ windowPosition WRITE setWindowPosition NOTIFY windowPositionChanged )
     Q_PROPERTY( HapticsType hapticsType READ hapticsType WRITE setHapticsType NOTIFY hapticsTypeChanged )
+    Q_PROPERTY( StartupBehaviour startupBehaviour READ startupBehaviour WRITE setStartupBehaviour NOTIFY startupBehaviourChanged )
 
   public:
     // enum of haptic modes we support
@@ -54,6 +55,14 @@ class AppSettings: public QObject
 #endif
     };
     Q_ENUM( HapticsType )
+
+    // enum of options for what should open when the app starts
+    enum StartupBehaviour
+    {
+      StartupRecentProject = 0,
+      StartupProjectHome
+    };
+    Q_ENUM( StartupBehaviour )
 
     explicit AppSettings( QObject *parent = nullptr );
 
@@ -110,6 +119,9 @@ class AppSettings: public QObject
     HapticsType hapticsType() const;
     void setHapticsType( HapticsType hapticsType );
 
+    StartupBehaviour startupBehaviour() const;
+    void setStartupBehaviour( StartupBehaviour startupBehaviour );
+
   public slots:
     void setReuseLastEnteredValues( bool reuseLastEnteredValues );
 
@@ -129,6 +141,7 @@ class AppSettings: public QObject
     void autosyncAllowedChanged( bool autosyncAllowed );
     void autolockPositionChanged( bool autolockPosition );
     void hapticsTypeChanged( HapticsType hapticsType );
+    void startupBehaviourChanged( StartupBehaviour startupBehaviour );
 
     void ignoreMigrateVersionChanged();
 
@@ -169,6 +182,7 @@ class AppSettings: public QObject
     QString mIgnoreMigrateVersion;
 
     HapticsType mHapticsType;
+    StartupBehaviour mStartupBehaviour;
 };
 
 #endif // APPSETTINGS_H

--- a/app/qml/main.qml
+++ b/app/qml/main.qml
@@ -119,7 +119,10 @@ ApplicationWindow {
   Component.onCompleted: {
 
     // load default project
-    if ( AppSettings.defaultProject ) {
+    if ( AppSettings.startupBehaviour === AppSettings.StartupProjectHome ) {
+      stateManager.state = "projects"
+    }
+    else if ( AppSettings.defaultProject ) {
       let path = AppSettings.defaultProject
 
       if ( __localProjectsManager.projectIsValid( path ) && __activeProject.load( path ) ) {

--- a/app/qml/main.qml
+++ b/app/qml/main.qml
@@ -119,10 +119,10 @@ ApplicationWindow {
   Component.onCompleted: {
 
     // load default project
-    if ( AppSettings.startupBehaviour === AppSettings.StartupProjectHome ) {
+    if ( AppSettings.startupBehavior === AppSettings.StartupProjectHome || !AppSettings.defaultProject ) {
       stateManager.state = "projects"
     }
-    else if ( AppSettings.defaultProject ) {
+    else {
       let path = AppSettings.defaultProject
 
       if ( __localProjectsManager.projectIsValid( path ) && __activeProject.load( path ) ) {
@@ -133,9 +133,6 @@ ApplicationWindow {
         AppSettings.defaultProject = ""
         stateManager.state = "projects"
       }
-    }
-    else {
-      stateManager.state = "projects"
     }
 
     // Catch back button click (if no other component catched it so far)

--- a/app/qml/settings/MMSettingsPage.qml
+++ b/app/qml/settings/MMSettingsPage.qml
@@ -41,8 +41,8 @@ MMPage {
   ListModel {
     id: startupBehaviorModel
 
-    ListElement { text: qsTr("Recent project"); description: qsTr("Jump back into your last project") }
-    ListElement { text: qsTr("Project home"); description: qsTr("See all your downloaded projects") }
+    ListElement { text: qsTr("Recent project"); description: qsTr("Jump back into your last project") } // AppSettings.StartupRecentProject
+    ListElement { text: qsTr("Project home"); description: qsTr("See all your downloaded projects") } // AppSettings.StartupProjectHome
   }
 
   pageBottomMarginPolicy: MMPage.BottomMarginPolicy.PaintBehindSystemBar

--- a/app/qml/settings/MMSettingsPage.qml
+++ b/app/qml/settings/MMSettingsPage.qml
@@ -37,6 +37,15 @@ MMPage {
     }
   }
 
+  ListModel {
+    id: startupBehaviourModel
+
+    Component.onCompleted: {
+      startupBehaviourModel.append({ value: AppSettings.StartupRecentProject, text: qsTr("Recent project"), description: qsTr("Jump back into your last project") });
+      startupBehaviourModel.append({ value: AppSettings.StartupProjectHome, text: qsTr("Project home"), description: qsTr("See all your downloaded projects") });
+    }
+  }
+
   pageBottomMarginPolicy: MMPage.BottomMarginPolicy.PaintBehindSystemBar
 
   pageContent: MMScrollView {
@@ -215,6 +224,23 @@ MMPage {
       }
 
       Item { width: 1; height: 1 }
+
+      MMSettingsComponents.MMSettingsDropdown {
+        width: parent.width
+
+        title: qsTr("On app startup")
+        description: qsTr("Choose what opens when you launch the app")
+        drawerTitle: qsTr("Open on startup")
+
+        value: AppSettings.startupBehaviour === AppSettings.StartupProjectHome ? qsTr("Project home") : qsTr("Recent project")
+        currentIndex: AppSettings.startupBehaviour
+
+        model: startupBehaviourModel
+
+        onCurrentIndexChanged: AppSettings.startupBehaviour = currentIndex
+      }
+
+      MMLine {}
 
       MMSettingsComponents.MMSettingsItem {
         width: parent.width

--- a/app/qml/settings/MMSettingsPage.qml
+++ b/app/qml/settings/MMSettingsPage.qml
@@ -229,14 +229,14 @@ MMPage {
       MMSettingsComponents.MMSettingsDropdown {
         width: parent.width
 
-        title: qsTr("On app startup")
+        title: qsTr("Startup behaviour")
         description: qsTr("Choose what opens when you launch the app")
         drawerTitle: qsTr("Open on startup")
 
         currentIndex: AppSettings.startupBehavior
 
         model: startupBehaviorModel
-        value: model.count > 0 ? model.get(currentIndex).text : ""
+        value: model.get(currentIndex).text
 
         onCurrentIndexChanged: AppSettings.startupBehavior = currentIndex
       }

--- a/app/qml/settings/MMSettingsPage.qml
+++ b/app/qml/settings/MMSettingsPage.qml
@@ -41,10 +41,8 @@ MMPage {
   ListModel {
     id: startupBehaviorModel
 
-    Component.onCompleted: {
-      startupBehaviorModel.append({ value: AppSettings.StartupRecentProject, text: qsTr("Recent project"), description: qsTr("Jump back into your last project") });
-      startupBehaviorModel.append({ value: AppSettings.StartupProjectHome, text: qsTr("Project home"), description: qsTr("See all your downloaded projects") });
-    }
+    ListElement { text: qsTr("Recent project"); description: qsTr("Jump back into your last project") }
+    ListElement { text: qsTr("Project home"); description: qsTr("See all your downloaded projects") }
   }
 
   pageBottomMarginPolicy: MMPage.BottomMarginPolicy.PaintBehindSystemBar
@@ -231,7 +229,6 @@ MMPage {
 
         title: qsTr("Startup behaviour")
         description: qsTr("Choose what opens when you launch the app")
-        drawerTitle: qsTr("Open on startup")
 
         currentIndex: AppSettings.startupBehavior
 

--- a/app/qml/settings/MMSettingsPage.qml
+++ b/app/qml/settings/MMSettingsPage.qml
@@ -9,6 +9,7 @@
 
 import QtQuick
 import QtQuick.Controls
+import QtQml.Models
 
 import mm 1.0 as MM
 import MMInput
@@ -38,11 +39,11 @@ MMPage {
   }
 
   ListModel {
-    id: startupBehaviourModel
+    id: startupBehaviorModel
 
     Component.onCompleted: {
-      startupBehaviourModel.append({ value: AppSettings.StartupRecentProject, text: qsTr("Recent project"), description: qsTr("Jump back into your last project") });
-      startupBehaviourModel.append({ value: AppSettings.StartupProjectHome, text: qsTr("Project home"), description: qsTr("See all your downloaded projects") });
+      startupBehaviorModel.append({ value: AppSettings.StartupRecentProject, text: qsTr("Recent project"), description: qsTr("Jump back into your last project") });
+      startupBehaviorModel.append({ value: AppSettings.StartupProjectHome, text: qsTr("Project home"), description: qsTr("See all your downloaded projects") });
     }
   }
 
@@ -232,12 +233,12 @@ MMPage {
         description: qsTr("Choose what opens when you launch the app")
         drawerTitle: qsTr("Open on startup")
 
-        value: AppSettings.startupBehaviour === AppSettings.StartupProjectHome ? qsTr("Project home") : qsTr("Recent project")
-        currentIndex: AppSettings.startupBehaviour
+        currentIndex: AppSettings.startupBehavior
 
-        model: startupBehaviourModel
+        model: startupBehaviorModel
+        value: model.count > 0 ? model.get(currentIndex).text : ""
 
-        onCurrentIndexChanged: AppSettings.startupBehaviour = currentIndex
+        onCurrentIndexChanged: AppSettings.startupBehavior = currentIndex
       }
 
       MMLine {}

--- a/app/qml/settings/components/MMSettingsDropdown.qml
+++ b/app/qml/settings/components/MMSettingsDropdown.qml
@@ -17,7 +17,7 @@ MMSettingsItem {
 
   property var model
   property int currentIndex: -1
-  property string drawerTitle: root.title
+  property string drawerTitle: title
 
   onClicked: {
     if(root.model?.count > 0) {

--- a/app/qml/settings/components/MMSettingsDropdown.qml
+++ b/app/qml/settings/components/MMSettingsDropdown.qml
@@ -17,6 +17,7 @@ MMSettingsItem {
 
   property var model
   property int currentIndex: -1
+  property string drawerTitle: root.title
 
   onClicked: {
     if(root.model?.count > 0) {
@@ -37,12 +38,13 @@ MMSettingsItem {
 
     MMComponents.MMListDrawer {
 
-      drawerHeader.title: root.title
+      drawerHeader.title: root.drawerTitle
 
       list.model: root.model
 
       list.delegate: MMComponents.MMListDelegate {
         text: model.text
+        secondaryText: model.description ?? ""
 
         rightContent: MMComponents.MMIcon {
           source: __style.doneCircleIcon


### PR DESCRIPTION
### Description

Currently the app always auto-loads the last-opened project on startup, with no way to change this. For users with large/complex projects, this means every launch pays the load cost of a project they may just want to switch away from.

This PR adds a setting under **Settings -> General -> On app startup** that lets the user pick between:
- **Recent project** - jump back into the last project (default, unchanged behaviour)
- **Project home** - go straight to the list of downloaded projects, skipping any project load

Fixes: https://github.com/MerginMaps/mobile/issues/4621

### What changed

- `app/appsettings.h` / `app/appsettings.cpp` - new `AppSettings::StartupBehaviour` enum (`StartupRecentProject` / `StartupProjectHome`), exposed as `startupBehaviour` property, persisted under the `startupBehaviour` key, following the same pattern as the existing `hapticsType` setting.
- `app/qml/settings/components/MMSettingsDropdown.qml` - added optional `drawerTitle` (falls back to the row's `title`, so existing usages are unaffected) and `secondaryText` support on drawer options, needed to show the per-option subtitles in the new drawer.
- `app/qml/settings/MMSettingsPage.qml` - new **On app startup** row under the General section (first item, before About), opening an **Open on startup** drawer with the two options and their subtitles, mirroring the existing "Touch Feedback" / "Interval threshold type" dropdown rows.
- `app/qml/main.qml` - `Component.onCompleted` now checks `AppSettings.startupBehaviour` first; if `Project home` is selected it skips loading the default project and goes straight to the projects list. The `Recent project` path is untouched.

### Behaviour

- Default is **Recent project** - existing users see no change.
- Switching to **Project home**: on the *next* app launch, the app opens directly to the downloaded projects list instead of loading a project. No project is loaded, so there's no load-time cost.
- Switching back to **Recent project**: resumes the previously remembered project, since `defaultProject` is never cleared when in Project home mode.
- The choice persists across restarts (`QSettings`) and only takes effect on the next launch, not immediately.

**Video 1:** _App launch with "Recent project" selected - shows current/default behaviour, opens straight into the last project._

[Screencast From 2026-08-07 18-43-08.webm](https://github.com/user-attachments/assets/edfdd08e-8c26-4d41-9626-34447958ca81)


**Video 2:** _App launch with "Project home" selected - shows the app opening directly to the projects list, no project load._

[Screencast From 2026-08-07 18-42-43.webm](https://github.com/user-attachments/assets/f8d13ecf-e441-41e4-bd4d-1bd79df08306)

<img width="333" alt="Screenshot From 2026-08-07 18-43-26" src="https://github.com/user-attachments/assets/4b887611-0653-4d03-9892-592a0178fba7" />

<img width="333" alt="Screenshot From 2026-08-07 18-43-43" src="https://github.com/user-attachments/assets/7e572fd6-1c06-4be5-ae8b-9a9d1aea62bd" />


### TLDR @Withalion 

Adds an **"On app startup"** setting so users can choose whether the app opens their **Recent project** (current, default behaviour) or **Project home** (list of downloaded projects) on launch. New `AppSettings::StartupBehaviour` enum persisted via `QSettings`, one new settings row + drawer reusing existing `MMSettingsDropdown`/`MMListDrawer` components, and a small gate in `main.qml`'s startup logic. No new components, no CMake changes.