### PR TITLE
Fix map sketching points order

### DIFF
--- a/app/mapsketchingcontroller.cpp
+++ b/app/mapsketchingcontroller.cpp
@@ -17,6 +17,7 @@
 #include "qgsvectorlayerutils.h"
 #include "qgslinestring.h"
 #include "qgsmultilinestring.h"
+#include "qgsvertexid.h"
 
 
 MapSketchingController::MapSketchingController( QObject *parent )
@@ -49,10 +50,13 @@ void MapSketchingController::updateHighlight( const QPointF &oldPoint, const QPo
     mScreenPoints = QgsGeometry( new QgsLineString( { QgsPointXY( oldPoint.x(), oldPoint.y() ) } ) );
   }
 
-  // TODO: append instead of insert to zero
-  mScreenPoints.insertVertex( newPoint.x(), newPoint.y(), 0 );
+  // Append point to the geometry
+  const QgsVertexId lastScreenVertex( 0, 0, mScreenPoints.constGet()->vertexCount() );
+  mScreenPoints.get()->insertVertex( lastScreenVertex, QgsPoint( newPoint.x(), newPoint.y() ) );
+
   const QgsPoint p1 = mMapSettings->screenToCoordinate( newPoint );
-  mHighlight.insertVertex( p1, 0 );
+  const QgsVertexId lastHighlightVertex( 0, 0, mHighlight.constGet()->vertexCount() );
+  mHighlight.get()->insertVertex( lastHighlightVertex, p1 );
 
   emit highlightGeometryChanged();
 }

--- a/app/qml/map/MMMapSketchesDrawer.qml
+++ b/app/qml/map/MMMapSketchesDrawer.qml
@@ -80,13 +80,13 @@ MMComponents.MMDrawer {
       MMComponents.MMColorPicker {
         id: colorPicker
 
-        colors: root.sketchingController?.availableColors()
-        activeColor: root.sketchingController?.activeColor
+        colors: root.sketchingController?.availableColors() ?? []
+        activeColor: root.sketchingController?.activeColor ?? null
 
         Layout.alignment: Qt.AlignHCenter
         Layout.maximumWidth: parent.width
 
-        onActiveColorChangeRequested: {
+        onActiveColorChangeRequested: function( newColor ) {
           if ( root.sketchingController )
           {
             root.sketchingController.activeColor = newColor


### PR DESCRIPTION
This PR reverts the order in which we add points to map sketching lines. Previously we prepended points, which resulted in points being stored in reversed order, starting with the last. Now we append points. This feels natural and it was a missed todo in map sketching code.

The request came from the community, see https://community.merginmaps.com/p/line-vertices - this will enable easy setup of arrow symbology.

There were a couple of JS runtime exceptions in the code that I fixed along the way:

On map sketching drawer open: 
```
qrc:/com.merginmaps/imports/MMInput/map/MMMapSketchesDrawer.qml:84:9: Unable to assign [undefined] to QColor
qrc:/com.merginmaps/imports/MMInput/map/MMMapSketchesDrawer.qml:83:9: Unable to assign [undefined] to QList<QColor>
```

On color selection:
```
qt.qml.context: qrc:/com.merginmaps/imports/MMInput/map/MMMapSketchesDrawer.qml:89:9 Parameter "newColor" is not declared. Injection of parameters into signal handlers is deprecated. Use JavaScript functions with formal parameters instead
```
---
No UI/UX change. Map sketching works just like before.