### PR TITLE
Remove height override causing layout break

### DIFF
--- a/app/qml/map/MMMapController.qml
+++ b/app/qml/map/MMMapController.qml
@@ -925,9 +925,6 @@ Item {
       list.delegate: MMListDelegate {
         text: model.layerName
 
-        // TODO: why we need to set hight here?
-        height: __style.menuDrawerHeight
-
         leftContent: MMIcon {
           source: model.iconSource
         }


### PR DESCRIPTION
### Description
The "Choose Active Layer" drawer broke visually for layers with long, multi-line names - rows overlapped instead of expanding.

Fixes: https://github.com/MerginMaps/mobile/issues/4653

### What changed
Removed a hardcoded `height: __style.menuDrawerHeight` on the drawer's list delegate in `MMMapController.qml`, letting `MMListDelegate`'s own content-based height (which already supports wrapped multi-line text) take over.

### Behaviour
Rows in the active-layer dropdown now grow to fit multi-line layer names instead of overlapping.

<img width="333" alt="image" src="https://github.com/user-attachments/assets/a6e8a35e-4f38-43aa-8613-eed94f9b59af" />
