### PR TITLE
Fix antenna height value sometimes showing floating point noise

### DIFF
--- a/app/appsettings.cpp
+++ b/app/appsettings.cpp
@@ -353,10 +353,10 @@ void AppSettings::setGpsAntennaHeight( const double gpsAntennaHeight )
   }
   if ( mGpsAntennaHeight != height )
   {
-    mGpsAntennaHeight = gpsAntennaHeight;
+    mGpsAntennaHeight = height;
     setValue( "gpsHeight", height );
 
-    emit gpsAntennaHeightChanged( gpsAntennaHeight );
+    emit gpsAntennaHeightChanged( height );
   }
 }
 

--- a/app/qml/settings/MMSettingsPage.qml
+++ b/app/qml/settings/MMSettingsPage.qml
@@ -106,7 +106,7 @@ MMPage {
           title: qsTr("GPS antenna height")
           description: qsTr("Includes pole height and GPS receiver’s antenna height")
           valueDescription: qsTr("GPS antenna height, in meters")
-          value: AppSettings.gpsAntennaHeight
+          value: __inputUtils.formatNumber(AppSettings.gpsAntennaHeight, 3)
           suffix: " m"
 
           onValueWasChanged: function( newValue ) {


### PR DESCRIPTION
The antenna height setting in _Settings_ sometimes didn't round the value to 3 decimal places and instead showed floating points noise as well (e.g. `1.45000000000000002`). Apparently QML was completely okay with use supplying double to string :). Added another guard (`InputUtils::formatNumber()`) to fix it.