### PR TITLE
Reset missing position data if missing

### DIFF
--- a/app/position/geoposition.cpp
+++ b/app/position/geoposition.cpp
@@ -16,13 +16,10 @@ GeoPosition::GeoPosition() : QgsGpsInformation()
   longitude = std::numeric_limits<double>::quiet_NaN();
   elevation = std::numeric_limits<double>::quiet_NaN();
   elevation_diff = std::numeric_limits<double>::quiet_NaN();
-  direction = -1;
   speed = -1;
   pdop = -1;
   hdop = -1;
   vdop = -1;
-  hacc = -1;
-  vacc = -1;
   satellitesUsed = -1;
 }
 

--- a/app/position/providers/internalpositionprovider.cpp
+++ b/app/position/providers/internalpositionprovider.cpp
@@ -173,45 +173,51 @@ void InternalPositionProvider::parsePositionUpdate( const QGeoPositionInfo &posi
     positionDataHasChanged = true;
   }
 
-  const bool hasSpeedInfo = localPosition.hasAttribute( QGeoPositionInfo::GroundSpeed );
-  if ( hasSpeedInfo && !qgsDoubleNear( localPosition.attribute( QGeoPositionInfo::GroundSpeed ), mLastPosition.speed ) )
+  const double newSpeed = localPosition.hasAttribute( QGeoPositionInfo::GroundSpeed ) ?
+                          localPosition.attribute( QGeoPositionInfo::GroundSpeed ) * 3.6 : std::numeric_limits<double>::quiet_NaN(); // convert from m/s to km/h
+  if ( !qgsDoubleNear( newSpeed, mLastPosition.speed ) )
   {
-    mLastPosition.speed = localPosition.attribute( QGeoPositionInfo::GroundSpeed ) * 3.6; // convert from m/s to km/h
+    mLastPosition.speed = newSpeed;
     positionDataHasChanged = true;
   }
 
-  const bool hasVerticalSpeedInfo = localPosition.hasAttribute( QGeoPositionInfo::VerticalSpeed );
-  if ( hasVerticalSpeedInfo && !qgsDoubleNear( localPosition.attribute( QGeoPositionInfo::VerticalSpeed ), mLastPosition.verticalSpeed ) )
+  const double newVerticalSpeed = localPosition.hasAttribute( QGeoPositionInfo::VerticalSpeed ) ?
+                                  localPosition.attribute( QGeoPositionInfo::VerticalSpeed ) * 3.6 : std::numeric_limits<double>::quiet_NaN(); // convert from m/s to km/h
+  if ( !qgsDoubleNear( newVerticalSpeed, mLastPosition.verticalSpeed ) )
   {
-    mLastPosition.verticalSpeed = localPosition.attribute( QGeoPositionInfo::VerticalSpeed ) * 3.6; // convert from m/s to km/h
+    mLastPosition.verticalSpeed = newVerticalSpeed;
     positionDataHasChanged = true;
   }
 
-  const bool hasDirectionInfo = localPosition.hasAttribute( QGeoPositionInfo::Direction );
-  if ( hasDirectionInfo && !qgsDoubleNear( localPosition.attribute( QGeoPositionInfo::Direction ), mLastPosition.direction ) )
+  const double newDirection = localPosition.hasAttribute( QGeoPositionInfo::Direction ) ?
+                              localPosition.attribute( QGeoPositionInfo::Direction ) : std::numeric_limits<double>::quiet_NaN();
+  if ( !qgsDoubleNear( newDirection, mLastPosition.direction ) )
   {
-    mLastPosition.direction = localPosition.attribute( QGeoPositionInfo::Direction );
+    mLastPosition.direction = newDirection;
     positionDataHasChanged = true;
   }
 
-  const bool hasMagneticVariation = localPosition.hasAttribute( QGeoPositionInfo::MagneticVariation );
-  if ( hasMagneticVariation && !qgsDoubleNear( localPosition.attribute( QGeoPositionInfo::MagneticVariation ), mLastPosition.magneticVariation ) )
+  const double newMagneticVariation = localPosition.hasAttribute( QGeoPositionInfo::MagneticVariation ) ?
+                                      localPosition.attribute( QGeoPositionInfo::MagneticVariation ) : -1;
+  if ( !qgsDoubleNear( newMagneticVariation, mLastPosition.magneticVariation ) )
   {
-    mLastPosition.magneticVariation = localPosition.attribute( QGeoPositionInfo::MagneticVariation );
+    mLastPosition.magneticVariation = newMagneticVariation;
     positionDataHasChanged = true;
   }
 
-  const bool hasHacc = localPosition.hasAttribute( QGeoPositionInfo::HorizontalAccuracy );
-  if ( hasHacc && !qgsDoubleNear( localPosition.attribute( QGeoPositionInfo::HorizontalAccuracy ), mLastPosition.hacc ) )
+  const double newHorizontalAccuracy = localPosition.hasAttribute( QGeoPositionInfo::HorizontalAccuracy ) ?
+                                       localPosition.attribute( QGeoPositionInfo::HorizontalAccuracy ) : std::numeric_limits<double>::quiet_NaN();;
+  if ( !qgsDoubleNear( newHorizontalAccuracy, mLastPosition.hacc ) )
   {
-    mLastPosition.hacc = localPosition.attribute( QGeoPositionInfo::HorizontalAccuracy );
+    mLastPosition.hacc = newHorizontalAccuracy;
     positionDataHasChanged = true;
   }
 
-  const bool hasVacc = localPosition.hasAttribute( QGeoPositionInfo::VerticalAccuracy );
-  if ( hasVacc && !qgsDoubleNear( localPosition.attribute( QGeoPositionInfo::VerticalAccuracy ), mLastPosition.vacc ) )
+  const double newVerticalAccuracy = localPosition.hasAttribute( QGeoPositionInfo::VerticalAccuracy ) ?
+                                     localPosition.attribute( QGeoPositionInfo::VerticalAccuracy ) : std::numeric_limits<double>::quiet_NaN();;
+  if ( !qgsDoubleNear( newVerticalAccuracy, mLastPosition.vacc ) )
   {
-    mLastPosition.vacc = localPosition.attribute( QGeoPositionInfo::VerticalAccuracy );
+    mLastPosition.vacc = newVerticalAccuracy;
     positionDataHasChanged = true;
   }
 

--- a/app/position/providers/internalpositionprovider.cpp
+++ b/app/position/providers/internalpositionprovider.cpp
@@ -206,7 +206,7 @@ void InternalPositionProvider::parsePositionUpdate( const QGeoPositionInfo &posi
   }
 
   const double newHorizontalAccuracy = localPosition.hasAttribute( QGeoPositionInfo::HorizontalAccuracy ) ?
-                                       localPosition.attribute( QGeoPositionInfo::HorizontalAccuracy ) : std::numeric_limits<double>::quiet_NaN();;
+                                       localPosition.attribute( QGeoPositionInfo::HorizontalAccuracy ) : std::numeric_limits<double>::quiet_NaN();
   if ( !qgsDoubleNear( newHorizontalAccuracy, mLastPosition.hacc ) )
   {
     mLastPosition.hacc = newHorizontalAccuracy;
@@ -214,7 +214,7 @@ void InternalPositionProvider::parsePositionUpdate( const QGeoPositionInfo &posi
   }
 
   const double newVerticalAccuracy = localPosition.hasAttribute( QGeoPositionInfo::VerticalAccuracy ) ?
-                                     localPosition.attribute( QGeoPositionInfo::VerticalAccuracy ) : std::numeric_limits<double>::quiet_NaN();;
+                                     localPosition.attribute( QGeoPositionInfo::VerticalAccuracy ) : std::numeric_limits<double>::quiet_NaN();
   if ( !qgsDoubleNear( newVerticalAccuracy, mLastPosition.vacc ) )
   {
     mLastPosition.vacc = newVerticalAccuracy;

--- a/app/position/providers/internalpositionprovider.cpp
+++ b/app/position/providers/internalpositionprovider.cpp
@@ -174,7 +174,7 @@ void InternalPositionProvider::parsePositionUpdate( const QGeoPositionInfo &posi
   }
 
   const double newSpeed = localPosition.hasAttribute( QGeoPositionInfo::GroundSpeed ) ?
-                          localPosition.attribute( QGeoPositionInfo::GroundSpeed ) * 3.6 : std::numeric_limits<double>::quiet_NaN(); // convert from m/s to km/h
+                          localPosition.attribute( QGeoPositionInfo::GroundSpeed ) * 3.6 : -1; // convert from m/s to km/h
   if ( !qgsDoubleNear( newSpeed, mLastPosition.speed ) )
   {
     mLastPosition.speed = newSpeed;
@@ -182,7 +182,7 @@ void InternalPositionProvider::parsePositionUpdate( const QGeoPositionInfo &posi
   }
 
   const double newVerticalSpeed = localPosition.hasAttribute( QGeoPositionInfo::VerticalSpeed ) ?
-                                  localPosition.attribute( QGeoPositionInfo::VerticalSpeed ) * 3.6 : std::numeric_limits<double>::quiet_NaN(); // convert from m/s to km/h
+                                  localPosition.attribute( QGeoPositionInfo::VerticalSpeed ) * 3.6 : -1; // convert from m/s to km/h
   if ( !qgsDoubleNear( newVerticalSpeed, mLastPosition.verticalSpeed ) )
   {
     mLastPosition.verticalSpeed = newVerticalSpeed;

--- a/app/position/providers/trimblepositionprovider.cpp
+++ b/app/position/providers/trimblepositionprovider.cpp
@@ -216,7 +216,7 @@ GeoPosition TrimblePositionProvider::parseLocationMessage( const QString &json )
   }
 
   if ( obj.contains( QStringLiteral( "bearing" ) ) && !obj.value( QStringLiteral( "bearing" ) ).isNull() )
-    pos.direction = obj.value( QStringLiteral( "bearing" ) ).toDouble( -1 );
+    pos.direction = obj.value( QStringLiteral( "bearing" ) ).toDouble( std::numeric_limits<double>::quiet_NaN() );
 
   if ( obj.contains( QStringLiteral( "pdop" ) ) && !obj.value( QStringLiteral( "pdop" ) ).isNull() )
     pos.pdop = obj.value( QStringLiteral( "pdop" ) ).toDouble( -1 );
@@ -228,10 +228,10 @@ GeoPosition TrimblePositionProvider::parseLocationMessage( const QString &json )
     pos.vdop = obj.value( QStringLiteral( "vdop" ) ).toDouble( -1 );
 
   if ( obj.contains( QStringLiteral( "hrms" ) ) && !obj.value( QStringLiteral( "hrms" ) ).isNull() )
-    pos.hacc = obj.value( QStringLiteral( "hrms" ) ).toDouble( -1 );
+    pos.hacc = obj.value( QStringLiteral( "hrms" ) ).toDouble( std::numeric_limits<double>::quiet_NaN() );
 
   if ( obj.contains( QStringLiteral( "vrms" ) ) && !obj.value( QStringLiteral( "vrms" ) ).isNull() )
-    pos.vacc = obj.value( QStringLiteral( "vrms" ) ).toDouble( -1 );
+    pos.vacc = obj.value( QStringLiteral( "vrms" ) ).toDouble( std::numeric_limits<double>::quiet_NaN() );
 
   if ( obj.contains( QStringLiteral( "totalSatInUse" ) ) && !obj.value( QStringLiteral( "totalSatInUse" ) ).isNull() )
     pos.satellitesUsed = obj.value( QStringLiteral( "totalSatInUse" ) ).toInt( -1 );

--- a/app/qml/gps/MMGpsDataDrawer.qml
+++ b/app/qml/gps/MMGpsDataDrawer.qml
@@ -166,7 +166,7 @@ MMComponents.MMDrawer {
 
               title: qsTr( "Horizontal accuracy" )
               value: {
-                if ( !PositionKit.hasPosition || PositionKit.horizontalAccuracy < 0 ) {
+                if ( !PositionKit.hasPosition || Number.isNaN( PositionKit.horizontalAccuracy ) ) {
                   return qsTr( "N/A" )
                 }
 
@@ -181,7 +181,7 @@ MMComponents.MMDrawer {
 
               title: qsTr( "Vertical accuracy" )
               value: {
-                if ( !PositionKit.hasPosition || PositionKit.verticalAccuracy < 0 ) {
+                if ( !PositionKit.hasPosition || Number.isNaN( PositionKit.verticalAccuracy ) ) {
                   return qsTr( "N/A" )
                 }
 

--- a/app/test/testposition.cpp
+++ b/app/test/testposition.cpp
@@ -212,8 +212,8 @@ void TestPosition::testBluetoothProviderPosition()
   // test if position kit has correct information
   QVERIFY( qgsDoubleNear( positionKit->latitude(), 48.10305 ) );
   QVERIFY( qgsDoubleNear( positionKit->longitude(), 17.1064 ) );
-  QCOMPARE( positionKit->horizontalAccuracy(), -1 );
-  QCOMPARE( positionKit->verticalAccuracy(), -1 );
+  QVERIFY( std::isnan( positionKit->horizontalAccuracy() ) );
+  QVERIFY( std::isnan( positionKit->verticalAccuracy() ) );
   QCOMPARE( positionKit->altitude() + positionKit->antennaHeight(), 171.3 );
   QCOMPARE( positionKit->speed(), -1 );
   QCOMPARE( positionKit->hdop(), -1 );


### PR DESCRIPTION
This fixes issue where stale/untrue position data is shown to users if the data is missing from newer position update. We will clear the data now.