### PR TITLE
Fix app freeze when adding photos to non-spatial layer

### DIFF
--- a/app/qml/form/editors/MMFormRelationEditor.qml
+++ b/app/qml/form/editors/MMFormRelationEditor.qml
@@ -220,9 +220,15 @@ MMPrivateComponents.MMBaseInput {
       button.text: qsTr( "Add feature" )
 
       onClosed: listLoader.active = false
-      onFeatureClicked: ( featurePair ) => root.openLinkedFeature( featurePair )
+      onFeatureClicked: ( featurePair ) => {
+        root.forceActiveFocus()
+        root.openLinkedFeature( featurePair )
+      }
       onSearchTextChanged: ( searchText ) => rmodel.searchExpression = searchText
-      onButtonClicked: root.createLinkedFeature( root._fieldController.featureLayerPair, root._fieldAssociatedRelation )
+      onButtonClicked: {
+        root.forceActiveFocus()
+        root.createLinkedFeature( root._fieldController.featureLayerPair, root._fieldAssociatedRelation )
+      }
 
       Component.onCompleted: open()
     }


### PR DESCRIPTION
### Description
Adding a photo (or any linked feature) to a relation while its parent feature was still unsaved caused the app to freeze. This is the same root cause and fix pattern as the freeze fixed in #3483, which added `forceActiveFocus()` before creating/opening linked features elsewhere in this file that fix was never applied to the relation drawer's own "Add feature" button and list item clicks, leaving those two entry points still exposed.

Fixes: https://github.com/MerginMaps/mobile/issues/4636

### What Changed
`MMFormRelationEditor.qml`: call `root.forceActiveFocus()` before `createLinkedFeature`/`openLinkedFeature` in the relation drawer's `onButtonClicked` and `onFeatureClicked` handlers.

### Behaviour
- **Before:** adding a child feature to an unsaved parent while a text input (e.g. the drawer's search box) still had focus/keyboard open could freeze the app.
- **After:** focus is cleared first, so the keyboard commits/closes before the parent save is triggered, and the freeze no longer occurs.
