### PR TITLE
Updated vcpkg to support Geospatial PDFs

### DIFF
--- a/vcpkg.json
+++ b/vcpkg.json
@@ -57,6 +57,7 @@
         {
           "name": "gdal",
           "features": [
+            "poppler",
             {
               "name": "tools",
               "platform": "linux | osx"


### PR DESCRIPTION
## Issue
GeoPDF layers were marked as invalid when opening QGIS projects in the mobile app, even though the same projects worked fine in QGIS Desktop.

## Solution
Added the poppler feature to the GDAL dependency in vcpkg.json. 

## Acceptance criteria
- Geospatial PDF files can be opened in the mobile app