### PR TITLE
Disable predictive back on android 16+ devices

### DIFF
--- a/cmake_templates/AndroidManifest.xml.in
+++ b/cmake_templates/AndroidManifest.xml.in
@@ -48,6 +48,7 @@
             android:screenOrientation="unspecified"
             android:exported="true"
             android:theme="@style/Theme.App.Starting"
+            android:enableOnBackInvokedCallback="false"
             >
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />


### PR DESCRIPTION
Android 16 introduced new [_predictive back_ behaviour](https://developer.android.com/about/versions/16/behavior-changes-16#predictive-back), which instead of firing back button signal to the app instead switches apps/returns back to home screen. Let's disable it for now, so users will get the expected behaviour.